### PR TITLE
Add csv

### DIFF
--- a/deploy/olm-catalog/ibm-iam-operator/3.5.0/ibm-iam-operator.v3.5.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-iam-operator/3.5.0/ibm-iam-operator.v3.5.0.clusterserviceversion.yaml
@@ -1,0 +1,427 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "operator.ibm.com/v1alpha1",
+          "kind": "OIDCClientWatcher",
+          "metadata": {
+            "name": "example-oidcclientwatcher"
+          },
+          "spec": {
+            "imageRegistry": "hyc-cloud-private-edge-docker-local.artifactory.swg-devops.com/ibmcom-amd64/icp-oidcclient-watcher",
+            "imageTagPostfix": "3.3.0",
+            "operatorVersion": "0.14.1",
+            "replicas": 1
+          }
+        },
+        {
+          "apiVersion": "operator.ibm.com/v1alpha1",
+          "kind": "PolicyDecision",
+          "metadata": {
+            "name": "example-policydecision"
+          },
+          "spec": {
+            "auditService": {
+              "imageName": "icp-audit-service",
+              "imageRegistry": "hyc-cloud-private-edge-docker-local.artifactory.swg-devops.com/ibmcom-amd64",
+              "imageTag": "3.3.1",
+              "journalPath": "/run/systemd/journal"
+            },
+            "imageName": "icp-secret-watcher",
+            "imageRegistry": "hyc-cloud-private-edge-docker-local.artifactory.swg-devops.com/ibmcom-amd64",
+            "imageTag": "3.3.0",
+            "initMongodb": {
+              "imageName": "icp-platform-auth",
+              "imageRegistry": "hyc-cloud-private-edge-docker-local.artifactory.swg-devops.com/ibmcom-amd64",
+              "imageTag": "3.3.0"
+            },
+            "operatorVersion": "0.14.1",
+            "replicas": 1
+          }
+        },
+        {
+          "apiVersion": "operator.ibm.com/v1alpha1",
+          "kind": "Authentication",
+          "metadata": {
+            "name": "example-authentication"
+          },
+          "spec": {
+            "auditService": {
+              "imageName": "icp-audit-service",
+              "imageRegistry": "hyc-cloud-private-edge-docker-local.artifactory.swg-devops.com/ibmcom-amd64",
+              "imageTag": "3.3.1",
+              "journalPath": "/run/systemd/journal"
+            },
+            "authService": {
+              "imageName": "icp-platform-auth",
+              "imageRegistry": "hyc-cloud-private-edge-docker-local.artifactory.swg-devops.com/ibmcom-amd64",
+              "imageTag": "3.3.0",
+              "ldapsCACert": "platform-auth-ldaps-ca-cert",
+              "routerCertSecret": "icp-management-ingress-tls-secret"
+            },
+            "clientRegistration": {
+              "imageName": "icp-platform-auth",
+              "imageRegistry": "hyc-cloud-private-edge-docker-local.artifactory.swg-devops.com/ibmcom-amd64",
+              "imageTag": "3.3.0"
+            },
+            "config": {
+              "authUniqueHosts": "internal-ip1 internal-ip2 mycluster.icp",
+              "clusterCADomain": "mycluster.icp",
+              "clusterExternalAddress": "10.0.0.1",
+              "clusterInternalAddress": "10.0.0.1",
+              "clusterName": "mycluster",
+              "defaultAdminPassword": "password",
+              "defaultAdminUser": "admin",
+              "enableImpersonation": true,
+              "fipsEnabled": true,
+              "icpPort": 8443,
+              "installType": "fresh",
+              "isOpenshiftEnv": true,
+              "oidcIssuerURL": "https://127.0.0.1:8443/idauth/oidc/endpoint/OP",
+              "openshiftPort": 443,
+              "roksEnabled": true,
+              "roksURL": "https://roks.domain.name:443",
+              "roksUserPrefix": "IAM#",
+              "wlpClientID": "Awdfagsadf",
+              "wlpClientRegistrationSecret": "Awdfagsadf",
+              "wlpClientSecret": "Awdfagsadf"
+            },
+            "identityManager": {
+              "imageName": "icp-identity-manager",
+              "imageRegistry": "hyc-cloud-private-edge-docker-local.artifactory.swg-devops.com/ibmcom-amd64",
+              "imageTag": "3.3.1",
+              "masterNodesList": "10.0.0.1 10.0.0.2 10.0.0.3"
+            },
+            "identityProvider": {
+              "imageName": "icp-identity-provider",
+              "imageRegistry": "hyc-cloud-private-edge-docker-local.artifactory.swg-devops.com/ibmcom-amd64",
+              "imageTag": "3.3.1"
+            },
+            "initMongodb": {
+              "imageName": "icp-platform-auth",
+              "imageRegistry": "hyc-cloud-private-edge-docker-local.artifactory.swg-devops.com/ibmcom-amd64",
+              "imageTag": "3.3.0"
+            },
+            "operatorVersion": "0.14.1",
+            "replicas": 1
+          }
+        },
+        {
+          "apiVersion": "operator.ibm.com/v1alpha1",
+          "kind": "Pap",
+          "metadata": {
+            "name": "example-pap"
+          },
+          "spec": {
+            "auditService": {
+              "imageName": "icp-audit-service",
+              "imageRegistry": "hyc-cloud-private-release-docker-local.artifactory.swg-devops.com/ibmcom-amd64",
+              "imageTag": "3.3.0",
+              "journalPath": "/run/systemd/journal"
+            },
+            "operatorVersion": "3.5.0",
+            "papService": {
+              "imageName": "iam-policy-administration",
+              "imageRegistry": "hyc-cloud-private-release-docker-local.artifactory.swg-devops.com/ibmcom-amd64",
+              "imageTag": "3.3.0"
+            },
+            "replicas": 1
+          }
+        },
+        {
+          "apiVersion": "operator.ibm.com/v1alpha1",
+          "kind": "PolicyController",
+          "metadata": {
+            "name": "policycontroller-deployment"
+          },
+          "spec": {
+            "imageRegistry": "hyc-cloud-private-edge-docker-local.artifactory.swg-devops.com/ibmcom-amd64/iam-policy-controller",
+            "imageTagPostfix": "3.3.0",
+            "operatorVersion": "0.14.1",
+            "replicas": 1
+          }
+        },
+        {
+          "apiVersion": "operator.ibm.com/v1alpha1",
+          "kind": "SecretWatcher",
+          "metadata": {
+            "name": "secretwatcher-deployment"
+          },
+          "spec": {
+            "imageRegistry": "hyc-cloud-private-edge-docker-local.artifactory.swg-devops.com/ibmcom-amd64/icp-secret-watcher",
+            "imageTagPostfix": "3.3.0",
+            "operatorVersion": "0.14.1",
+            "replicas": 1
+          }
+        },
+        {
+          "apiVersion": "operator.ibm.com/v1alpha1",
+          "kind": "SecurityOnboarding",
+          "metadata": {
+            "name": "example-securityonboarding"
+          },
+          "spec": {
+            "iamOnboarding": {
+              "imageName": "icp-iam-onboarding",
+              "imageRegistry": "hyc-cloud-private-edge-docker-local.artifactory.swg-devops.com/ibmcom-amd64",
+              "imageTag": "3.3.1"
+            },
+            "imageName": "icp-iam-onboarding",
+            "imageRegistry": "hyc-cloud-private-edge-docker-local.artifactory.swg-devops.com/ibmcom-amd64",
+            "imageTag": "3.3.1",
+            "impersonation": {
+              "enableImpersonation": false
+            },
+            "initAuthService": {
+              "imageName": "icp-platform-auth",
+              "imageRegistry": "hyc-cloud-private-edge-docker-local.artifactory.swg-devops.com/ibmcom-amd64",
+              "imageTag": "3.3.1"
+            },
+            "initIdentityManager": {
+              "imageName": "icp-platform-auth",
+              "imageRegistry": "hyc-cloud-private-edge-docker-local.artifactory.swg-devops.com/ibmcom-amd64",
+              "imageTag": "3.3.1"
+            },
+            "initIdentityProvider": {
+              "imageName": "icp-platform-auth",
+              "imageRegistry": "hyc-cloud-private-edge-docker-local.artifactory.swg-devops.com/ibmcom-amd64",
+              "imageTag": "3.3.1"
+            },
+            "initPAPSpec": {
+              "imageName": "icp-platform-auth",
+              "imageRegistry": "hyc-cloud-private-edge-docker-local.artifactory.swg-devops.com/ibmcom-amd64",
+              "imageTag": "3.3.1"
+            },
+            "initTokenService": {
+              "imageName": "icp-platform-auth",
+              "imageRegistry": "hyc-cloud-private-edge-docker-local.artifactory.swg-devops.com/ibmcom-amd64",
+              "imageTag": "3.3.1"
+            },
+            "operatorVersion": "0.14.1",
+            "replicas": 1
+          }
+        }
+      ]
+    capabilities: Basic Install
+  name: ibm-iam-operator.v3.5.0
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: Authentication is the Schema for the authentications API
+      kind: Authentication
+      name: authentications.operator.ibm.com
+      version: v1alpha1
+      displayName: IAM authentication service
+    - description: OIDCClientWatcher is the Schema for the oidcclientwatchers API
+      kind: OIDCClientWatcher
+      name: oidcclientwatchers.operator.ibm.com
+      version: v1alpha1
+      displayName: IAM OIDC client watcher
+    - description: Pap is the Schema for the paps API
+      kind: Pap
+      name: paps.operator.ibm.com
+      version: v1alpha1
+      displayName: IAM policy administration point
+    - description: PolicyController is the Schema for the policycontrollers API
+      kind: PolicyController
+      name: policycontrollers.operator.ibm.com
+      version: v1alpha1
+      displayName: IAM policy controller
+    - description: PolicyDecision is the Schema for the policydecisions API
+      kind: PolicyDecision
+      name: policydecisions.operator.ibm.com
+      version: v1alpha1
+      displayName: IAM policy decision
+    - description: SecretWatcher is the Schema for the secretwatchers API
+      kind: SecretWatcher
+      name: secretwatchers.operator.ibm.com
+      version: v1alpha1
+      displayName: IAM secret watcher
+    - description: SecurityOnboarding is the Schema for the securityonboardings API
+      kind: SecurityOnboarding
+      name: securityonboardings.operator.ibm.com
+      version: v1alpha1
+      displayName: IAM security onboarding
+  description: The IAM Operator provides a Kubernetes CRD-Based API to deploy and upgrade IAM services.
+  displayName: Ibm IAM Operator
+  icon:
+  - base64data: ""
+    mediatype: ""
+  install:
+    spec:
+      deployments:
+      - name: ibm-iam-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: ibm-iam-operator
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                name: ibm-iam-operator
+            spec:
+              containers:
+              - command:
+                - ibm-iam-operator
+                env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: ibm-iam-operator
+                image: quay.io/opencloudio/ibm-iam-operator:latest
+                imagePullPolicy: Always
+                name: ibm-iam-operator
+                resources: {}
+              serviceAccountName: ibm-iam-operator
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          - services/finalizers
+          - endpoints
+          - persistentvolumeclaims
+          - events
+          - configmaps
+          - secrets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          - replicasets
+          - statefulsets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - get
+          - create
+        - apiGroups:
+          - apps
+          resourceNames:
+          - ibm-iam-operator
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - get
+        - apiGroups:
+          - apps
+          resources:
+          - replicasets
+          - deployments
+          verbs:
+          - get
+        - apiGroups:
+          - operator.ibm.com
+          resources:
+          - '*'
+          - policydecisions
+          - oidcclientwatchers
+          - authentications
+          - policycontrollers
+          - paps
+          - securityonboardings
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - certmanager.k8s.io
+          resources:
+          - '*'
+          - certificates
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - networking.k8s.io
+          resources:
+          - '*'
+          - ingresses
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - batch
+          resources:
+          - jobs
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        serviceAccountName: ibm-iam-operator
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - ""
+  maintainers:
+  - {}
+  maturity: alpha
+  provider: {}
+  replaces: ibm-iam-operator.v0.0.0
+  version: 3.5.0

--- a/deploy/olm-catalog/ibm-iam-operator/3.5.0/operator.ibm.com_authentications_crd.yaml
+++ b/deploy/olm-catalog/ibm-iam-operator/3.5.0/operator.ibm.com_authentications_crd.yaml
@@ -1,0 +1,229 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: authentications.operator.ibm.com
+spec:
+  group: operator.ibm.com
+  names:
+    kind: Authentication
+    listKind: AuthenticationList
+    plural: authentications
+    singular: authentication
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: Authentication is the Schema for the authentications API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: AuthenticationSpec defines the desired state of Authentication
+          properties:
+            auditService:
+              properties:
+                imageName:
+                  type: string
+                imageRegistry:
+                  type: string
+                imageTag:
+                  type: string
+                journalPath:
+                  type: string
+              required:
+              - imageName
+              - imageRegistry
+              - imageTag
+              - journalPath
+              type: object
+            authService:
+              properties:
+                imageName:
+                  type: string
+                imageRegistry:
+                  type: string
+                imageTag:
+                  type: string
+                ldapsCACert:
+                  type: string
+                routerCertSecret:
+                  type: string
+              required:
+              - imageName
+              - imageRegistry
+              - imageTag
+              - ldapsCACert
+              - routerCertSecret
+              type: object
+            clientRegistration:
+              properties:
+                imageName:
+                  type: string
+                imageRegistry:
+                  type: string
+                imageTag:
+                  type: string
+              required:
+              - imageName
+              - imageRegistry
+              - imageTag
+              type: object
+            config:
+              properties:
+                authUniqueHosts:
+                  type: string
+                clusterCADomain:
+                  type: string
+                clusterExternalAddress:
+                  type: string
+                clusterInternalAddress:
+                  type: string
+                clusterName:
+                  type: string
+                defaultAdminPassword:
+                  type: string
+                defaultAdminUser:
+                  type: string
+                enableImpersonation:
+                  type: boolean
+                fipsEnabled:
+                  type: boolean
+                icpPort:
+                  format: int32
+                  type: integer
+                installType:
+                  type: string
+                isOpenshiftEnv:
+                  type: boolean
+                oidcIssuerURL:
+                  type: string
+                openshiftPort:
+                  format: int32
+                  type: integer
+                roksEnabled:
+                  type: boolean
+                roksURL:
+                  type: string
+                roksUserPrefix:
+                  type: string
+                wlpClientID:
+                  type: string
+                wlpClientRegistrationSecret:
+                  type: string
+                wlpClientSecret:
+                  type: string
+              required:
+              - authUniqueHosts
+              - clusterCADomain
+              - clusterExternalAddress
+              - clusterInternalAddress
+              - clusterName
+              - defaultAdminPassword
+              - defaultAdminUser
+              - enableImpersonation
+              - fipsEnabled
+              - icpPort
+              - installType
+              - isOpenshiftEnv
+              - oidcIssuerURL
+              - openshiftPort
+              - roksEnabled
+              - roksURL
+              - roksUserPrefix
+              - wlpClientID
+              - wlpClientRegistrationSecret
+              - wlpClientSecret
+              type: object
+            identityManager:
+              properties:
+                imageName:
+                  type: string
+                imageRegistry:
+                  type: string
+                imageTag:
+                  type: string
+                masterNodesList:
+                  type: string
+              required:
+              - imageName
+              - imageRegistry
+              - imageTag
+              - masterNodesList
+              type: object
+            identityProvider:
+              properties:
+                imageName:
+                  type: string
+                imageRegistry:
+                  type: string
+                imageTag:
+                  type: string
+              required:
+              - imageName
+              - imageRegistry
+              - imageTag
+              type: object
+            initMongodb:
+              properties:
+                imageName:
+                  type: string
+                imageRegistry:
+                  type: string
+                imageTag:
+                  type: string
+              required:
+              - imageName
+              - imageRegistry
+              - imageTag
+              type: object
+            operatorVersion:
+              description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
+                Important: Run "operator-sdk generate k8s" to regenerate code after
+                modifying this file Add custom validation using kubebuilder tags:
+                https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
+              type: string
+            replicas:
+              format: int32
+              type: integer
+          required:
+          - auditService
+          - authService
+          - clientRegistration
+          - config
+          - identityManager
+          - identityProvider
+          - initMongodb
+          - operatorVersion
+          - replicas
+          type: object
+        status:
+          description: AuthenticationStatus defines the observed state of Authentication
+          properties:
+            nodes:
+              description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
+                of cluster Important: Run "operator-sdk generate k8s" to regenerate
+                code after modifying this file Add custom validation using kubebuilder
+                tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
+              items:
+                type: string
+              type: array
+          required:
+          - nodes
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/deploy/olm-catalog/ibm-iam-operator/3.5.0/operator.ibm.com_oidcclientwatchers_crd.yaml
+++ b/deploy/olm-catalog/ibm-iam-operator/3.5.0/operator.ibm.com_oidcclientwatchers_crd.yaml
@@ -1,0 +1,69 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: oidcclientwatchers.operator.ibm.com
+spec:
+  group: operator.ibm.com
+  names:
+    kind: OIDCClientWatcher
+    listKind: OIDCClientWatcherList
+    plural: oidcclientwatchers
+    singular: oidcclientwatcher
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: OIDCClientWatcher is the Schema for the oidcclientwatchers API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: OIDCClientWatcherSpec defines the desired state of OIDCClientWatcher
+          properties:
+            imageRegistry:
+              type: string
+            imageTagPostfix:
+              type: string
+            operatorVersion:
+              description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
+                Important: Run "operator-sdk generate k8s" to regenerate code after
+                modifying this file Add custom validation using kubebuilder tags:
+                https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
+              type: string
+            replicas:
+              format: int32
+              type: integer
+          required:
+          - replicas
+          type: object
+        status:
+          description: OIDCClientWatcherStatus defines the observed state of OIDCClientWatcher
+          properties:
+            nodes:
+              description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
+                of cluster Important: Run "operator-sdk generate k8s" to regenerate
+                code after modifying this file Add custom validation using kubebuilder
+                tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
+              items:
+                type: string
+              type: array
+          required:
+          - nodes
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/deploy/olm-catalog/ibm-iam-operator/3.5.0/operator.ibm.com_paps_crd.yaml
+++ b/deploy/olm-catalog/ibm-iam-operator/3.5.0/operator.ibm.com_paps_crd.yaml
@@ -1,0 +1,99 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: paps.operator.ibm.com
+spec:
+  group: operator.ibm.com
+  names:
+    kind: Pap
+    listKind: PapList
+    plural: paps
+    singular: pap
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: Pap is the Schema for the paps API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: PapSpec defines the desired state of Pap
+          properties:
+            auditService:
+              properties:
+                imageName:
+                  type: string
+                imageRegistry:
+                  type: string
+                imageTag:
+                  type: string
+                journalPath:
+                  type: string
+              required:
+              - imageName
+              - imageRegistry
+              - imageTag
+              - journalPath
+              type: object
+            operatorVersion:
+              description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
+                Important: Run "operator-sdk generate k8s" to regenerate code after
+                modifying this file Add custom validation using kubebuilder tags:
+                https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
+              type: string
+            papService:
+              description: PapServiceSpec defined the desired state of PapService
+                Container
+              properties:
+                imageName:
+                  type: string
+                imageRegistry:
+                  type: string
+                imageTag:
+                  type: string
+              required:
+              - imageName
+              - imageRegistry
+              - imageTag
+              type: object
+            replicas:
+              format: int32
+              type: integer
+          required:
+          - auditService
+          - operatorVersion
+          - papService
+          - replicas
+          type: object
+        status:
+          description: PapStatus defines the observed state of Pap
+          properties:
+            nodes:
+              description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
+                of cluster Important: Run "operator-sdk generate k8s" to regenerate
+                code after modifying this file Add custom validation using kubebuilder
+                tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
+              items:
+                type: string
+              type: array
+          required:
+          - nodes
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/deploy/olm-catalog/ibm-iam-operator/3.5.0/operator.ibm.com_policycontrollers_crd.yaml
+++ b/deploy/olm-catalog/ibm-iam-operator/3.5.0/operator.ibm.com_policycontrollers_crd.yaml
@@ -1,0 +1,69 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: policycontrollers.operator.ibm.com
+spec:
+  group: operator.ibm.com
+  names:
+    kind: PolicyController
+    listKind: PolicyControllerList
+    plural: policycontrollers
+    singular: policycontroller
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: PolicyController is the Schema for the policycontrollers API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: PolicyControllerSpec defines the desired state of PolicyController
+          properties:
+            imageRegistry:
+              type: string
+            imageTagPostfix:
+              type: string
+            operatorVersion:
+              description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
+                Important: Run "operator-sdk generate k8s" to regenerate code after
+                modifying this file Add custom validation using kubebuilder tags:
+                https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
+              type: string
+            replicas:
+              format: int32
+              type: integer
+          required:
+          - replicas
+          type: object
+        status:
+          description: PolicyControllerStatus defines the observed state of PolicyController
+          properties:
+            nodes:
+              description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
+                of cluster Important: Run "operator-sdk generate k8s" to regenerate
+                code after modifying this file Add custom validation using kubebuilder
+                tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
+              items:
+                type: string
+              type: array
+          required:
+          - nodes
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/deploy/olm-catalog/ibm-iam-operator/3.5.0/operator.ibm.com_policydecisions_crd.yaml
+++ b/deploy/olm-catalog/ibm-iam-operator/3.5.0/operator.ibm.com_policydecisions_crd.yaml
@@ -1,0 +1,106 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: policydecisions.operator.ibm.com
+spec:
+  group: operator.ibm.com
+  names:
+    kind: PolicyDecision
+    listKind: PolicyDecisionList
+    plural: policydecisions
+    singular: policydecision
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: PolicyDecision is the Schema for the policydecisions API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: PolicyDecisionSpec defines the desired state of PolicyDecision
+          properties:
+            auditService:
+              properties:
+                imageName:
+                  type: string
+                imageRegistry:
+                  type: string
+                imageTag:
+                  type: string
+                journalPath:
+                  type: string
+              required:
+              - imageName
+              - imageRegistry
+              - imageTag
+              - journalPath
+              type: object
+            imageName:
+              type: string
+            imageRegistry:
+              type: string
+            imageTag:
+              type: string
+            initMongodb:
+              properties:
+                imageName:
+                  type: string
+                imageRegistry:
+                  type: string
+                imageTag:
+                  type: string
+              required:
+              - imageName
+              - imageRegistry
+              - imageTag
+              type: object
+            operatorVersion:
+              description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
+                Important: Run "operator-sdk generate k8s" to regenerate code after
+                modifying this file Add custom validation using kubebuilder tags:
+                https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
+              type: string
+            replicas:
+              format: int32
+              type: integer
+          required:
+          - auditService
+          - imageName
+          - imageRegistry
+          - imageTag
+          - initMongodb
+          - operatorVersion
+          - replicas
+          type: object
+        status:
+          description: PolicyDecisionStatus defines the observed state of PolicyDecision
+          properties:
+            nodes:
+              description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
+                of cluster Important: Run "operator-sdk generate k8s" to regenerate
+                code after modifying this file Add custom validation using kubebuilder
+                tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
+              items:
+                type: string
+              type: array
+          required:
+          - nodes
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/deploy/olm-catalog/ibm-iam-operator/3.5.0/operator.ibm.com_secretwatchers_crd.yaml
+++ b/deploy/olm-catalog/ibm-iam-operator/3.5.0/operator.ibm.com_secretwatchers_crd.yaml
@@ -1,0 +1,69 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: secretwatchers.operator.ibm.com
+spec:
+  group: operator.ibm.com
+  names:
+    kind: SecretWatcher
+    listKind: SecretWatcherList
+    plural: secretwatchers
+    singular: secretwatcher
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: SecretWatcher is the Schema for the secretwatchers API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: SecretWatcherSpec defines the desired state of SecretWatcher
+          properties:
+            imageRegistry:
+              type: string
+            imageTagPostfix:
+              type: string
+            operatorVersion:
+              description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
+                Important: Run "operator-sdk generate k8s" to regenerate code after
+                modifying this file Add custom validation using kubebuilder tags:
+                https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
+              type: string
+            replicas:
+              format: int32
+              type: integer
+          required:
+          - replicas
+          type: object
+        status:
+          description: SecretWatcherStatus defines the observed state of SecretWatcher
+          properties:
+            nodes:
+              description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
+                of cluster Important: Run "operator-sdk generate k8s" to regenerate
+                code after modifying this file Add custom validation using kubebuilder
+                tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
+              items:
+                type: string
+              type: array
+          required:
+          - nodes
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/deploy/olm-catalog/ibm-iam-operator/3.5.0/operator.ibm.com_securityonboardings_crd.yaml
+++ b/deploy/olm-catalog/ibm-iam-operator/3.5.0/operator.ibm.com_securityonboardings_crd.yaml
@@ -1,0 +1,167 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: securityonboardings.operator.ibm.com
+spec:
+  group: operator.ibm.com
+  names:
+    kind: SecurityOnboarding
+    listKind: SecurityOnboardingList
+    plural: securityonboardings
+    singular: securityonboarding
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: SecurityOnboarding is the Schema for the securityonboardings API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: SecurityOnboardingSpec defines the desired state of SecurityOnboarding
+          properties:
+            iamOnboarding:
+              properties:
+                imageName:
+                  type: string
+                imageRegistry:
+                  type: string
+                imageTag:
+                  type: string
+              required:
+              - imageName
+              - imageRegistry
+              - imageTag
+              type: object
+            imageName:
+              type: string
+            imageRegistry:
+              type: string
+            imageTag:
+              type: string
+            impersonation:
+              properties:
+                enableImpersonation:
+                  type: boolean
+              required:
+              - enableImpersonation
+              type: object
+            initAuthService:
+              properties:
+                imageName:
+                  type: string
+                imageRegistry:
+                  type: string
+                imageTag:
+                  type: string
+              required:
+              - imageName
+              - imageRegistry
+              - imageTag
+              type: object
+            initIdentityManager:
+              properties:
+                imageName:
+                  type: string
+                imageRegistry:
+                  type: string
+                imageTag:
+                  type: string
+              required:
+              - imageName
+              - imageRegistry
+              - imageTag
+              type: object
+            initIdentityProvider:
+              properties:
+                imageName:
+                  type: string
+                imageRegistry:
+                  type: string
+                imageTag:
+                  type: string
+              required:
+              - imageName
+              - imageRegistry
+              - imageTag
+              type: object
+            initPAPSpec:
+              properties:
+                imageName:
+                  type: string
+                imageRegistry:
+                  type: string
+                imageTag:
+                  type: string
+              required:
+              - imageName
+              - imageRegistry
+              - imageTag
+              type: object
+            initTokenService:
+              properties:
+                imageName:
+                  type: string
+                imageRegistry:
+                  type: string
+                imageTag:
+                  type: string
+              required:
+              - imageName
+              - imageRegistry
+              - imageTag
+              type: object
+            operatorVersion:
+              description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
+                Important: Run "operator-sdk generate k8s" to regenerate code after
+                modifying this file Add custom validation using kubebuilder tags:
+                https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
+              type: string
+            replicas:
+              format: int32
+              type: integer
+          required:
+          - iamOnboarding
+          - imageName
+          - imageRegistry
+          - imageTag
+          - impersonation
+          - initAuthService
+          - initIdentityManager
+          - initIdentityProvider
+          - initPAPSpec
+          - initTokenService
+          - operatorVersion
+          - replicas
+          type: object
+        status:
+          description: SecurityOnboardingStatus defines the observed state of SecurityOnboarding
+          properties:
+            podNames:
+              description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
+                of cluster Important: Run "operator-sdk generate k8s" to regenerate
+                code after modifying this file Add custom validation using kubebuilder
+                tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
+              items:
+                type: string
+              type: array
+          required:
+          - podNames
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/deploy/olm-catalog/ibm-iam-operator/ibm-iam-operator.package.yaml
+++ b/deploy/olm-catalog/ibm-iam-operator/ibm-iam-operator.package.yaml
@@ -1,0 +1,5 @@
+channels:
+- currentCSV: ibm-iam-operator.v3.5.0
+  name: alpha
+defaultChannel: alpha
+packageName: ibm-iam-operator


### PR DESCRIPTION
I followed this link https://github.ibm.com/IBMPrivateCloud/roadmap/blob/master/feature-specs/installer/certify-operator.md#check-operator-bundle-locally to create csv, and manually added displayName to each element under `owned` in the generated file deploy/olm-catalog/ibm-iam-operator/3.5.0/ibm-iam-operator.v3.5.0.clusterserviceversion.yaml. 