### PR TITLE
Workaround certissue

### DIFF
--- a/pkg/controller/securityonboarding/securityonboarding_controller.go
+++ b/pkg/controller/securityonboarding/securityonboarding_controller.go
@@ -469,7 +469,7 @@ func getIAMOnboardJob(instance *operatorv1alpha1.SecurityOnboarding, r *Reconcil
 		},
 		{
 			Name:            "init-identity-provider",
-			Command:         []string{"sh", "-c", "until curl --cacert /certs/ca.crt -i -fsS https://platform-identity-provider:4300 | grep '200 OK'; do sleep 3; done;"},
+			Command:         []string{"sh", "-c", "until curl -k -i -fsS https://platform-identity-provider:4300 | grep '200 OK'; do sleep 3; done;"},
 			Image:           instance.Spec.InitIdentityProvider.ImageRegistry + "/" + instance.Spec.InitIdentityProvider.ImageName + ":" + instance.Spec.InitIdentityProvider.ImageTag,
 			ImagePullPolicy: corev1.PullPolicy("Always"),
 			VolumeMounts: []corev1.VolumeMount{
@@ -499,7 +499,7 @@ func getIAMOnboardJob(instance *operatorv1alpha1.SecurityOnboarding, r *Reconcil
 		},
 		{
 			Name:            "init-pap",
-			Command:         []string{"sh", "-c", "until curl --cacert /certs/ca.crt -i -fsS https://iam-pap:39001/v1/health | grep '200 OK'; do sleep 3; done;"},
+			Command:         []string{"sh", "-c", "until curl -k -i -fsS https://iam-pap:39001/v1/health | grep '200 OK'; do sleep 3; done;"},
 			Image:           instance.Spec.InitPAP.ImageRegistry + "/" + instance.Spec.InitPAP.ImageName + ":" + instance.Spec.InitPAP.ImageTag,
 			ImagePullPolicy: corev1.PullPolicy("Always"),
 			VolumeMounts: []corev1.VolumeMount{

--- a/pkg/controller/securityonboarding/securityonboarding_controller.go
+++ b/pkg/controller/securityonboarding/securityonboarding_controller.go
@@ -481,7 +481,7 @@ func getIAMOnboardJob(instance *operatorv1alpha1.SecurityOnboarding, r *Reconcil
 		},
 		{
 			Name:            "init-identity-manager",
-			Command:         []string{"sh", "-c", "until curl --cacert /certs/ca.crt -i -fsS https://platform-identity-management:4500 | grep '200 OK'; do sleep 3; done;"},
+			Command:         []string{"sh", "-c", "until curl -k-i -fsS https://platform-identity-management:4500 | grep '200 OK'; do sleep 3; done;"},
 			Image:           instance.Spec.InitIdentityManager.ImageRegistry + "/" + instance.Spec.InitIdentityManager.ImageName + ":" + instance.Spec.InitIdentityManager.ImageTag,
 			ImagePullPolicy: corev1.PullPolicy("Always"),
 			VolumeMounts: []corev1.VolumeMount{


### PR DESCRIPTION
The pod stuck in initializing stage.
iam-onboarding-gnnft                               0/1     Init:1/5            0          82m

```
 init-identity-provider:
    Container ID:  
    Image:         quay.io/opencloudio/icp-platform-auth:3.3.1
    Image ID:      
    Port:          <none>
    Host Port:     <none>
    Command:
      sh
      -c
      until curl --cacert /certs/ca.crt -i -fsS https://platform-identity-provider:4300 | grep '200 OK'; do sleep 3; done;
    State:          Waiting
      Reason:       PodInitializing
    Ready:          False
    Restart Count:  0
    Environment:    <none>
```
exec into the init-identity-provider container, run the curl command and found the error locating the /certs/ca.crt. Verify that that ca.crt file exists. Use openssl to view the cert, it does not recognize the format.