### PR TITLE
add icp_port env variable.

### DIFF
--- a/pkg/controller/authentication/configmap.go
+++ b/pkg/controller/authentication/configmap.go
@@ -18,6 +18,7 @@ package authentication
 
 import (
 	"context"
+	"fmt"
 	operatorv1alpha1 "github.com/IBM/ibm-iam-operator/pkg/apis/operator/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -85,7 +86,7 @@ func authIdpConfigMap(instance *operatorv1alpha1.Authentication, scheme *runtime
 			"IDENTITY_PROVIDER_URL":       "https://127.0.0.1:4300",
 			"IDENTITY_MGMT_URL":           "https://127.0.0.1:4500",
 			"MASTER_HOST":                 instance.Spec.Config.ClusterCADomain,
-			"ICP_PORT":                    instance.Spec.Config.ICPPort,
+			"ICP_PORT":                    fmt.Sprint(instance.Spec.Config.ICPPort),
 			"NODE_ENV":                    "production",
 			"AUDIT_ENABLED_IDPROVIDER":    "false",
 			"AUDIT_ENABLED_IDMGMT":        "false",

--- a/pkg/controller/authentication/configmap.go
+++ b/pkg/controller/authentication/configmap.go
@@ -85,6 +85,7 @@ func authIdpConfigMap(instance *operatorv1alpha1.Authentication, scheme *runtime
 			"IDENTITY_PROVIDER_URL":       "https://127.0.0.1:4300",
 			"IDENTITY_MGMT_URL":           "https://127.0.0.1:4500",
 			"MASTER_HOST":                 instance.Spec.Config.ClusterCADomain,
+			"ICP_PORT":                    instance.Spec.Config.ICPPort,
 			"NODE_ENV":                    "production",
 			"AUDIT_ENABLED_IDPROVIDER":    "false",
 			"AUDIT_ENABLED_IDMGMT":        "false",

--- a/pkg/controller/authentication/containers.go
+++ b/pkg/controller/authentication/containers.go
@@ -369,7 +369,7 @@ func buildAuthServiceContainer(instance *operatorv1alpha1.Authentication, authSe
 }
 
 func buildIdentityProviderContainer(instance *operatorv1alpha1.Authentication, identityProviderImage string) corev1.Container {
-	
+
 	icpConsoleURL := os.Getenv("ICP_CONSOLE_URL")
 	envVars := []corev1.EnvVar{
 		{
@@ -593,6 +593,17 @@ func buildIdentityProviderContainer(instance *operatorv1alpha1.Authentication, i
 		{
 			Name:  "MASTER_HOST",
 			Value: icpConsoleURL,
+		},
+		{
+			Name: "ICP_PORT",
+			ValueFrom: &corev1.EnvVarSource{
+				ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: "platform-auth-idp",
+					},
+					Key: "ICP_PORT",
+				},
+			},
 		},
 	}
 


### PR DESCRIPTION
This PR tries to add env variable:
```
ICP_PORT
```
The env variable is useful for OIDC provider to expose public endpoints to external OIDC client.