### PR TITLE
Support changing only roks prefix

### DIFF
--- a/deploy/crds/operator.ibm.com_v1alpha1_authentication_cr.yaml
+++ b/deploy/crds/operator.ibm.com_v1alpha1_authentication_cr.yaml
@@ -103,7 +103,7 @@ spec:
     bootstrapUserId: "kubeadmin"
     providerIssuerURL: ""
     roksURL: "https://roks.domain.name:443"
-    roksUserPrefix: "IAM#"
+    roksUserPrefix: "changeme"
     wlpClientID: "4444be3a738841016ab76d71b650e836"
     wlpClientRegistrationSecret: "f1362ca4d20b8389af2d1ea68042c9af"
     wlpClientSecret: "aa73bf39752053bf723d1143fb4cf8a2"

--- a/deploy/olm-catalog/ibm-iam-operator/3.7.1/ibm-iam-operator.v3.7.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-iam-operator/3.7.1/ibm-iam-operator.v3.7.1.clusterserviceversion.yaml
@@ -190,7 +190,7 @@ metadata:
               "openshiftPort": 443,
               "roksEnabled": true,
               "roksURL": "https://roks.domain.name:443",
-              "roksUserPrefix": "IAM#",
+              "roksUserPrefix": "changeme",
               "wlpClientID": "4444be3a738841016ab76d71b650e836",
               "wlpClientRegistrationSecret": "f1362ca4d20b8389af2d1ea68042c9af",
               "wlpClientSecret": "aa73bf39752053bf723d1143fb4cf8a2"


### PR DESCRIPTION
This allows the user to only specify the prefix in new install
Here are the scenarios we handle-

**New install
1. user specifies none - we programatically enable roks with prefix set to empty string
2. user specifies roksPrefix - we programatically enable roks with prefix set to the one specified
3. user specifies roksURL, roksEnabled, and roksPrefix - we honor all
4. user specifies roksURL, roksEnabled - we set prefix to be IAM#, (to be consistent with previous release)

**Upgrade
we preserve existing settings on the cluster
