### PR TITLE
Updated latest sha digest for identity-manager operand image for CS 3.5.5 release.

### DIFF
--- a/deploy/olm-catalog/ibm-iam-operator/3.7.4/ibm-iam-operator.v3.7.4.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-iam-operator/3.7.4/ibm-iam-operator.v3.7.4.clusterserviceversion.yaml
@@ -2050,7 +2050,7 @@ spec:
                 - name: IDENTITY_PROVIDER_TAG_OR_SHA
                   value: sha256:c236405be6cb45b396daa7ec8f480e08c6439d23d849e57dd60bd26a006a6296
                 - name: IDENTITY_MANAGER_TAG_OR_SHA
-                  value: sha256:2c29055654d4e9c043d69b3e1160cbfea40efaf278b34f503399bc47599b018e
+                  value: sha256:33bc0009828331a8c7245a62dbb7b7bb458571728b4e339b9165c484f752ab5a
                 - name: POLICY_ADMINISTRATION_TAG_OR_SHA
                   value: sha256:f61ac066951f215dc4afd922660af9b3e52071c2fcd321659fa10bb28de71b56
                 - name: POLICY_DECISION_TAG_OR_SHA

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -48,7 +48,7 @@ spec:
             - name: IDENTITY_PROVIDER_TAG_OR_SHA
               value: "sha256:c236405be6cb45b396daa7ec8f480e08c6439d23d849e57dd60bd26a006a6296"
             - name: IDENTITY_MANAGER_TAG_OR_SHA
-              value: "sha256:2c29055654d4e9c043d69b3e1160cbfea40efaf278b34f503399bc47599b018e"
+              value: "sha256:33bc0009828331a8c7245a62dbb7b7bb458571728b4e339b9165c484f752ab5a"
             - name: POLICY_ADMINISTRATION_TAG_OR_SHA
               value: "sha256:f61ac066951f215dc4afd922660af9b3e52071c2fcd321659fa10bb28de71b56"
             - name: POLICY_DECISION_TAG_OR_SHA


### PR DESCRIPTION
Updated latest sha digest for identity-manager operand image for CS 3.5.5 release.