### PR TITLE
Changed default value of OS_TOKEN_LENGTH to support OCP 4.6 in 3.7.4 branch (Issue #42278)

### DIFF
--- a/deploy/olm-catalog/ibm-iam-operator/3.7.5/ibm-iam-operator.v3.7.5.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-iam-operator/3.7.5/ibm-iam-operator.v3.7.5.clusterserviceversion.yaml
@@ -2049,7 +2049,7 @@ spec:
                 - name: AUTH_SERVICE_TAG_OR_SHA
                   value: sha256:acdb61d4674b5f3ae276ef9f7208d5ac33a7bbcba8194a429a43273f143fb9b5
                 - name: IDENTITY_PROVIDER_TAG_OR_SHA
-                  value: sha256:c236405be6cb45b396daa7ec8f480e08c6439d23d849e57dd60bd26a006a6296
+                  value: sha256:ff423dd5ae0e7ef55d8fa346eb23f9d4b1401583f0c9308a1734fec88150f202
                 - name: IDENTITY_MANAGER_TAG_OR_SHA
                   value: sha256:33bc0009828331a8c7245a62dbb7b7bb458571728b4e339b9165c484f752ab5a
                 - name: POLICY_ADMINISTRATION_TAG_OR_SHA

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -46,7 +46,7 @@ spec:
             - name: AUTH_SERVICE_TAG_OR_SHA
               value: "sha256:acdb61d4674b5f3ae276ef9f7208d5ac33a7bbcba8194a429a43273f143fb9b5"
             - name: IDENTITY_PROVIDER_TAG_OR_SHA
-              value: "sha256:c236405be6cb45b396daa7ec8f480e08c6439d23d849e57dd60bd26a006a6296"
+              value: "sha256:ff423dd5ae0e7ef55d8fa346eb23f9d4b1401583f0c9308a1734fec88150f202"
             - name: IDENTITY_MANAGER_TAG_OR_SHA
               value: "sha256:33bc0009828331a8c7245a62dbb7b7bb458571728b4e339b9165c484f752ab5a"
             - name: POLICY_ADMINISTRATION_TAG_OR_SHA

--- a/pkg/controller/authentication/configmap.go
+++ b/pkg/controller/authentication/configmap.go
@@ -241,7 +241,7 @@ func authIdpConfigMap(instance *operatorv1alpha1.Authentication, scheme *runtime
 			"PROVIDER_ISSUER_URL":                instance.Spec.Config.ProviderIssuerURL,
 			"PREFERRED_LOGIN":                    instance.Spec.Config.PreferredLogin,
 			"LIBERTY_TOKEN_LENGTH":               "1024",
-			"OS_TOKEN_LENGTH":                    "45",
+			"OS_TOKEN_LENGTH":                    "51",
 			"LIBERTY_DEBUG_ENABLED":              "false",
 			"LOGJAM_DHKEYSIZE_2048_BITS_ENABLED": "true",
 			"LDAP_RECURSIVE_SEARCH":              "true",

--- a/pkg/controller/authentication/containers.go
+++ b/pkg/controller/authentication/containers.go
@@ -439,6 +439,17 @@ func buildIdentityProviderContainer(instance *operatorv1alpha1.Authentication, i
 			Value: "platform-identity-provider",
 		},
 		{
+			Name: "ROKS_USER_PREFIX",
+			ValueFrom: &corev1.EnvVarSource{
+				ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: "platform-auth-idp",
+					},
+					Key: "ROKS_USER_PREFIX",
+				},
+			},
+		},
+		{
 			Name: "AUDIT_ENABLED",
 			ValueFrom: &corev1.EnvVarSource{
 				ConfigMapKeyRef: &corev1.ConfigMapKeySelector{


### PR DESCRIPTION
Changed default value of OS_TOKEN_LENGTH to support OCP 4.6 in 3.7.4 branch (Issue #42278)