### PR TITLE
update ubi images

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:f19c5b5d417cad1452ced0d174bca363ac41554190406c9147488b58394e2c56
+FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:5f931273a2b9250318a45914228c25e8e3ea0feec846edd67c92f03af1596a8a
 
 LABEL org.label-schema.vendor="IBM" \
     org.label-schema.name="ibm-iam-operator" \

--- a/build/Dockerfile.ppc64le
+++ b/build/Dockerfile.ppc64le
@@ -20,7 +20,7 @@ RUN wget -O /qemu-ppc64le-static https://github.com/multiarch/qemu-user-static/r
 
 RUN chmod +x /qemu-ppc64le-static
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:2507309a69f786388f4aad70cfd27a4582f3bd2df19a4608166845a1ba4d6f36
+FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:d32fa019f53a718e47714b50d91a19431e40de0174c0d522e5bf703da4235608
 ARG VCS_REF
 ARG VCS_URL
 

--- a/build/Dockerfile.s390x
+++ b/build/Dockerfile.s390x
@@ -20,7 +20,7 @@ RUN wget -O /qemu-s390x-static https://github.com/multiarch/qemu-user-static/rel
 
 RUN chmod +x /qemu-s390x-static
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:8cdff755d0fa477f3b2c69cedcf78d89a9e2bf965f3d72ab804c2e39f3e58ab1
+FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:c16e3df0de887329613549ca94934353bc3d2212bb8e51eb7c0af94805d410ea
 ARG VCS_REF
 ARG VCS_URL
 


### PR DESCRIPTION
Issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/42505
https://github.ibm.com/IBMPrivateCloud/roadmap/issues/42565

```
docker manifest inspect registry.access.redhat.com/ubi8/ubi-minimal:8.3-201
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
   "manifests": [
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 737,
         "digest": "sha256:5f931273a2b9250318a45914228c25e8e3ea0feec846edd67c92f03af1596a8a",
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 737,
         "digest": "sha256:c6592eb9cdd7ea7fa43beddf507ca2a8c2127f13ef66d49baea2fd28e37f62ba",
         "platform": {
            "architecture": "arm64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 737,
         "digest": "sha256:d32fa019f53a718e47714b50d91a19431e40de0174c0d522e5bf703da4235608",
         "platform": {
            "architecture": "ppc64le",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 737,
         "digest": "sha256:c16e3df0de887329613549ca94934353bc3d2212bb8e51eb7c0af94805d410ea",
         "platform": {
            "architecture": "s390x",
            "os": "linux"
         }
      }
   ]
}
```