### PR TITLE
Updated latest image digest sha for IAM operand images.

### DIFF
--- a/deploy/olm-catalog/ibm-iam-operator/3.9.0/ibm-iam-operator.v3.9.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-iam-operator/3.9.0/ibm-iam-operator.v3.9.0.clusterserviceversion.yaml
@@ -33,7 +33,7 @@ metadata:
             "oidcInitAuthService": {
               "imageName": "icp-platform-auth",
               "imageRegistry": "quay.io/opencloudio",
-              "imageTag": "3.3.12",
+              "imageTag": "3.3.13",
               "resources": {
                 "limits": {
                   "cpu": "200m",
@@ -48,7 +48,7 @@ metadata:
             "oidcInitIdentityProvider": {
               "imageName": "icp-platform-auth",
               "imageRegistry": "quay.io/opencloudio",
-              "imageTag": "3.3.12",
+              "imageTag": "3.3.13",
               "resources": {
                 "limits": {
                   "cpu": "200m",
@@ -63,7 +63,7 @@ metadata:
             "oidcInitIdentityManager": {
               "imageName": "icp-platform-auth",
               "imageRegistry": "quay.io/opencloudio",
-              "imageTag": "3.3.12",
+              "imageTag": "3.3.13",
               "resources": {
                 "limits": {
                   "cpu": "200m",
@@ -92,7 +92,7 @@ metadata:
             "auditService": {
               "imageName": "audit-syslog-service",
               "imageRegistry": "quay.io/opencloudio",
-              "imageTag": "1.0.3",
+              "imageTag": "1.0.4",
               "syslogTlsPath": "/etc/audit-tls",
               "resources": {
                 "limits": {
@@ -111,7 +111,7 @@ metadata:
             "initMongodb": {
               "imageName": "icp-platform-auth",
               "imageRegistry": "quay.io/opencloudio",
-              "imageTag": "3.3.12",
+              "imageTag": "3.3.13",
               "resources": {
                 "limits": {
                   "cpu": "100m",
@@ -152,7 +152,7 @@ metadata:
             "auditService": {
               "imageName": "audit-syslog-service",
               "imageRegistry": "quay.io/opencloudio",
-              "imageTag": "1.0.3",
+              "imageTag": "1.0.4",
               "syslogTlsPath": "/etc/audit-tls",
               "resources": {
                 "limits": {
@@ -168,7 +168,7 @@ metadata:
             "authService": {
               "imageName": "icp-platform-auth",
               "imageRegistry": "quay.io/opencloudio",
-              "imageTag": "3.3.12",
+              "imageTag": "3.3.13",
               "ldapsCACert": "platform-auth-ldaps-ca-cert",
               "resources": {
                 "limits": {
@@ -185,7 +185,7 @@ metadata:
             "clientRegistration": {
               "imageName": "icp-platform-auth",
               "imageRegistry": "quay.io/opencloudio",
-              "imageTag": "3.3.12",
+              "imageTag": "3.3.13",
               "resources": {
                 "limits": {
                   "cpu": "1000m",
@@ -261,7 +261,7 @@ metadata:
             "initMongodb": {
               "imageName": "icp-platform-auth",
               "imageRegistry": "quay.io/opencloudio",
-              "imageTag": "3.3.12",
+              "imageTag": "3.3.13",
               "resources": {
                 "limits": {
                   "cpu": "100m",
@@ -292,7 +292,7 @@ metadata:
             "auditService": {
               "imageName": "audit-syslog-service",
               "imageRegistry": "quay.io/opencloudio",
-              "imageTag": "1.0.3",
+              "imageTag": "1.0.4",
               "syslogTlsPath": "/etc/audit-tls",
               "resources": {
                 "limits": {
@@ -309,7 +309,7 @@ metadata:
             "papService": {
               "imageName": "iam-policy-administration",
               "imageRegistry": "quay.io/opencloudio",
-              "imageTag": "3.3.9",
+              "imageTag": "3.3.10",
               "resources": {
                 "limits": {
                   "cpu": "1000m",
@@ -395,7 +395,7 @@ metadata:
             "iamOnboarding": {
               "imageName": "icp-iam-onboarding",
               "imageRegistry": "quay.io/opencloudio",
-              "imageTag": "3.3.3",
+              "imageTag": "3.3.9",
               "resources": {
                 "limits": {
                   "cpu": "200m",
@@ -409,14 +409,14 @@ metadata:
             },
             "imageName": "icp-iam-onboarding",
             "imageRegistry": "quay.io/opencloudio",
-            "imageTag": "3.3.3",
+            "imageTag": "3.3.9",
             "impersonation": {
               "enableImpersonation": false
             },
             "initAuthService": {
               "imageName": "icp-platform-auth",
               "imageRegistry": "quay.io/opencloudio",
-              "imageTag": "3.3.12",
+              "imageTag": "3.3.13",
               "resources": {
                 "limits": {
                   "cpu": "200m",
@@ -431,7 +431,7 @@ metadata:
             "initIdentityManager": {
               "imageName": "icp-platform-auth",
               "imageRegistry": "quay.io/opencloudio",
-              "imageTag": "3.3.12",
+              "imageTag": "3.3.13",
               "resources": {
                 "limits": {
                   "cpu": "200m",
@@ -446,7 +446,7 @@ metadata:
             "initIdentityProvider": {
               "imageName": "icp-platform-auth",
               "imageRegistry": "quay.io/opencloudio",
-              "imageTag": "3.3.12",
+              "imageTag": "3.3.13",
               "resources": {
                 "limits": {
                   "cpu": "200m",
@@ -461,7 +461,7 @@ metadata:
             "initPAPSpec": {
               "imageName": "icp-platform-auth",
               "imageRegistry": "quay.io/opencloudio",
-              "imageTag": "3.3.12",
+              "imageTag": "3.3.13",
               "resources": {
                 "limits": {
                   "cpu": "200m",
@@ -476,7 +476,7 @@ metadata:
             "initTokenService": {
               "imageName": "icp-platform-auth",
               "imageRegistry": "quay.io/opencloudio",
-              "imageTag": "3.3.12",
+              "imageTag": "3.3.13",
               "resources": {
                 "limits": {
                   "cpu": "200m",
@@ -1692,13 +1692,13 @@ spec:
                 - ibm-iam-operator
                 env:
                 - name: AUTH_SERVICE_TAG_OR_SHA
-                  value: sha256:959f0fa63c15a5407b81935df0c26988da2af68d1668f56f7270ddec77fe4fe0
+                  value: sha256:acff27adac74cc058c72e735317502d5ef1f54f8b9b8bb46e921d779740ecb2c
                 - name: IDENTITY_PROVIDER_TAG_OR_SHA
-                  value: sha256:78a3f482e58e48866bdad82c81f771ef52da6cbf9614fe62fc84889d69d995d8
+                  value: sha256:3c730d8aadc2490e8af87e9d65b18887f486059666a5ec92c45815471f6baba2
                 - name: IDENTITY_MANAGER_TAG_OR_SHA
                   value: sha256:5d8eb877e50bc71ba779faaf98159c9b1755a3f6c38fcad64f938a0280c250c6
                 - name: POLICY_ADMINISTRATION_TAG_OR_SHA
-                  value: sha256:bcd8f1297a72e484fb4f0cc113c8dfaa678bd2ee7418786a90ce44f850c286a8
+                  value: sha256:67e37da717419c7ee0834d185f280c302db43737fb9b315ffd729e2ec2571b42
                 - name: POLICY_DECISION_TAG_OR_SHA
                   value: sha256:a696d99a9baf53fc3b1048a79993b30acb8cf563115e2aa3220fe8bd285e2ff9
                 - name: SECRET_WATCHER_TAG_OR_SHA
@@ -1708,7 +1708,7 @@ spec:
                 - name: POLICY_CONTROLLER_TAG_OR_SHA
                   value: sha256:d080f925186f92348892d63799d1cdb0e18cc82c710b162992d3229aac89f454
                 - name: IAM_ONBOARDING_TAG_OR_SHA
-                  value: sha256:85cb9c78ec897fdd9eca89c77150986241c9ed23e73dd59d4add8d60c7efddf4
+                  value: sha256:bb3efc1064f642bd86ddfc2268dcfe164399a77a23f28d376b7a2163d59a614a
                 - name: AUDIT_TAG_OR_SHA
                   value: sha256:4d68ee3e14b74e117b54e1c49686de847008d5e453b267168f6e52af9c9e9d4d
                 - name: WATCH_NAMESPACE

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -44,13 +44,13 @@ spec:
           imagePullPolicy: Always
           env:
             - name: AUTH_SERVICE_TAG_OR_SHA
-              value: "sha256:959f0fa63c15a5407b81935df0c26988da2af68d1668f56f7270ddec77fe4fe0"
+              value: "sha256:acff27adac74cc058c72e735317502d5ef1f54f8b9b8bb46e921d779740ecb2c"
             - name: IDENTITY_PROVIDER_TAG_OR_SHA
-              value: "sha256:78a3f482e58e48866bdad82c81f771ef52da6cbf9614fe62fc84889d69d995d8"
+              value: "sha256:3c730d8aadc2490e8af87e9d65b18887f486059666a5ec92c45815471f6baba2"
             - name: IDENTITY_MANAGER_TAG_OR_SHA
               value: "sha256:5d8eb877e50bc71ba779faaf98159c9b1755a3f6c38fcad64f938a0280c250c6"
             - name: POLICY_ADMINISTRATION_TAG_OR_SHA
-              value: "sha256:bcd8f1297a72e484fb4f0cc113c8dfaa678bd2ee7418786a90ce44f850c286a8"
+              value: "sha256:67e37da717419c7ee0834d185f280c302db43737fb9b315ffd729e2ec2571b42"
             - name: POLICY_DECISION_TAG_OR_SHA
               value: "sha256:a696d99a9baf53fc3b1048a79993b30acb8cf563115e2aa3220fe8bd285e2ff9"
             - name: SECRET_WATCHER_TAG_OR_SHA
@@ -60,7 +60,7 @@ spec:
             - name: POLICY_CONTROLLER_TAG_OR_SHA
               value: "sha256:d080f925186f92348892d63799d1cdb0e18cc82c710b162992d3229aac89f454"
             - name: IAM_ONBOARDING_TAG_OR_SHA
-              value: "sha256:85cb9c78ec897fdd9eca89c77150986241c9ed23e73dd59d4add8d60c7efddf4"
+              value: "sha256:bb3efc1064f642bd86ddfc2268dcfe164399a77a23f28d376b7a2163d59a614a"
             - name: AUDIT_TAG_OR_SHA
               value: "sha256:4d68ee3e14b74e117b54e1c49686de847008d5e453b267168f6e52af9c9e9d4d"
             - name: WATCH_NAMESPACE


### PR DESCRIPTION
Updated latest image digest sha for IAM operand images.

Travis multi-arch build links for image digest sha:
https://travis.ibm.com/IBMPrivateCloud/platform-identity-provider/jobs/43777242#L387
https://travis.ibm.com/IBMPrivateCloud/pap/jobs/43763998#L372	(Branch: release-3.3.9)
https://travis.ibm.com/IBMPrivateCloud/icp-iam-onboarding/jobs/43763701#L291	(Branch: release-3.3.8)
https://travis.ibm.com/IBMPrivateCloud/platform-auth-service/jobs/43764274#L297	  (Branch: release-3.3.12)
