### PR TITLE
update ubi images

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:73cf49188e632ca3828171e6950fceda8cda2bbdb8b9f471edff0ade190df0ff
+FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:4a02f98dd98f11f0ab2849a57dcf4d9e33e24568e9e4ce81b549b60191b6c7d7
 
 LABEL org.label-schema.vendor="IBM" \
     org.label-schema.name="ibm-iam-operator" \

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:5f931273a2b9250318a45914228c25e8e3ea0feec846edd67c92f03af1596a8a
+FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:73cf49188e632ca3828171e6950fceda8cda2bbdb8b9f471edff0ade190df0ff
 
 LABEL org.label-schema.vendor="IBM" \
     org.label-schema.name="ibm-iam-operator" \

--- a/build/Dockerfile.ppc64le
+++ b/build/Dockerfile.ppc64le
@@ -20,7 +20,7 @@ RUN wget -O /qemu-ppc64le-static https://github.com/multiarch/qemu-user-static/r
 
 RUN chmod +x /qemu-ppc64le-static
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:0db8382d228dd3c0e687a526a55d14a0b2e6d1293d87e328438efccfabc78b59
+FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:f5b185532ece6cc482c8424280e2cdccb1b95b735e464ea7aef29dd13c768937
 ARG VCS_REF
 ARG VCS_URL
 

--- a/build/Dockerfile.ppc64le
+++ b/build/Dockerfile.ppc64le
@@ -20,7 +20,7 @@ RUN wget -O /qemu-ppc64le-static https://github.com/multiarch/qemu-user-static/r
 
 RUN chmod +x /qemu-ppc64le-static
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:d32fa019f53a718e47714b50d91a19431e40de0174c0d522e5bf703da4235608
+FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:0db8382d228dd3c0e687a526a55d14a0b2e6d1293d87e328438efccfabc78b59
 ARG VCS_REF
 ARG VCS_URL
 

--- a/build/Dockerfile.s390x
+++ b/build/Dockerfile.s390x
@@ -20,7 +20,7 @@ RUN wget -O /qemu-s390x-static https://github.com/multiarch/qemu-user-static/rel
 
 RUN chmod +x /qemu-s390x-static
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:b0724d2733bb278a229b135e7432d47012b057cb8e8c2bde3a1f58a1bbd73078
+FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:768552c16ef80d4e7cf28e29266322dc5d6b68a431a41afd74757a3f0eff03e2
 ARG VCS_REF
 ARG VCS_URL
 

--- a/build/Dockerfile.s390x
+++ b/build/Dockerfile.s390x
@@ -20,7 +20,7 @@ RUN wget -O /qemu-s390x-static https://github.com/multiarch/qemu-user-static/rel
 
 RUN chmod +x /qemu-s390x-static
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:c16e3df0de887329613549ca94934353bc3d2212bb8e51eb7c0af94805d410ea
+FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:b0724d2733bb278a229b135e7432d47012b057cb8e8c2bde3a1f58a1bbd73078
 ARG VCS_REF
 ARG VCS_URL
 


### PR DESCRIPTION
Issues: https://github.ibm.com/ibmprivatecloud/roadmap/issues/43472 
https://github.ibm.com/ibmprivatecloud/roadmap/issues/43520

> docker manifest inspect registry.access.redhat.com/ubi8/ubi-minimal:8.3-230
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
   "manifests": [
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 737,
         "digest": "sha256:4a02f98dd98f11f0ab2849a57dcf4d9e33e24568e9e4ce81b549b60191b6c7d7",
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 737,
         "digest": "sha256:17a38d4ef304c5f2adeffa948b41c78723f97d0e59a0982feba6d3ef8d81a332",
         "platform": {
            "architecture": "arm64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 737,
         "digest": "sha256:f5b185532ece6cc482c8424280e2cdccb1b95b735e464ea7aef29dd13c768937",
         "platform": {
            "architecture": "ppc64le",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 737,
         "digest": "sha256:768552c16ef80d4e7cf28e29266322dc5d6b68a431a41afd74757a3f0eff03e2",
         "platform": {
            "architecture": "s390x",
            "os": "linux"
         }
      }
   ]
}


