### PR TITLE
Issue44140 - update audit syslog image to version 1.0.5

### DIFF
--- a/deploy/crds/operator.ibm.com_v1alpha1_authentication_cr.yaml
+++ b/deploy/crds/operator.ibm.com_v1alpha1_authentication_cr.yaml
@@ -12,7 +12,7 @@ spec:
   auditService: 
     imageRegistry: "quay.io/opencloudio"
     imageName: "audit-syslog-service"
-    imageTag: "1.0.3"
+    imageTag: "1.0.5"
     syslogTlsPath: "/etc/audit-tls"
     resources:
       limits:

--- a/deploy/crds/operator.ibm.com_v1alpha1_pap_cr.yaml
+++ b/deploy/crds/operator.ibm.com_v1alpha1_pap_cr.yaml
@@ -11,7 +11,7 @@ spec:
   auditService:
     imageRegistry: "quay.io/opencloudio"
     imageName: "audit-syslog-service"
-    imageTag: "1.0.3"
+    imageTag: "1.0.5"
     syslogTlsPath: "/etc/audit-tls"
     resources:
       limits:

--- a/deploy/crds/operator.ibm.com_v1alpha1_policydecision_cr.yaml
+++ b/deploy/crds/operator.ibm.com_v1alpha1_policydecision_cr.yaml
@@ -11,7 +11,7 @@ spec:
   auditService:
     imageRegistry: "quay.io/opencloudio"
     imageName: "audit-syslog-service"
-    imageTag: "1.0.3"
+    imageTag: "1.0.5"
     syslogTlsPath: "/etc/audit-tls"
     resources:
       limits:

--- a/deploy/olm-catalog/ibm-iam-operator/3.9.0/ibm-iam-operator.v3.9.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-iam-operator/3.9.0/ibm-iam-operator.v3.9.0.clusterserviceversion.yaml
@@ -92,7 +92,7 @@ metadata:
             "auditService": {
               "imageName": "audit-syslog-service",
               "imageRegistry": "quay.io/opencloudio",
-              "imageTag": "1.0.4",
+              "imageTag": "1.0.5",
               "syslogTlsPath": "/etc/audit-tls",
               "resources": {
                 "limits": {
@@ -152,7 +152,7 @@ metadata:
             "auditService": {
               "imageName": "audit-syslog-service",
               "imageRegistry": "quay.io/opencloudio",
-              "imageTag": "1.0.4",
+              "imageTag": "1.0.5",
               "syslogTlsPath": "/etc/audit-tls",
               "resources": {
                 "limits": {
@@ -292,7 +292,7 @@ metadata:
             "auditService": {
               "imageName": "audit-syslog-service",
               "imageRegistry": "quay.io/opencloudio",
-              "imageTag": "1.0.4",
+              "imageTag": "1.0.5",
               "syslogTlsPath": "/etc/audit-tls",
               "resources": {
                 "limits": {
@@ -1727,7 +1727,7 @@ spec:
                 - name: ICP_IAM_ONBOARDING_IMAGE
                   value: quay.io/opencloudio/icp-iam-onboarding:3.4.0
                 - name: AUDIT_SYSLOG_SERVICE_IMAGE
-                  value: quay.io/opencloudio/audit-syslog-service:1.0.4
+                  value: quay.io/opencloudio/audit-syslog-service:1.0.5
                 - name: WATCH_NAMESPACE
                   valueFrom:
                     fieldRef:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -62,7 +62,7 @@ spec:
             - name: ICP_IAM_ONBOARDING_IMAGE
               value: quay.io/opencloudio/icp-iam-onboarding:3.4.0
             - name: AUDIT_SYSLOG_SERVICE_IMAGE
-              value: quay.io/opencloudio/audit-syslog-service:1.0.4
+              value: quay.io/opencloudio/audit-syslog-service:1.0.5
             - name: WATCH_NAMESPACE
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
Related issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/44140