### PR TITLE
Added IDENTITY_MGMT_URL to auth-pdp container. (Issue #44579)

### DIFF
--- a/pkg/controller/policydecision/containers.go
+++ b/pkg/controller/policydecision/containers.go
@@ -316,6 +316,10 @@ func buildPdpContainer(pdpImage string, resources *corev1.ResourceRequirements) 
 				Name:  "IDENTITY_PROVIDER_URL",
 				Value: "https://platform-identity-provider:4300",
 			},
+			{
+				Name:  "IDENTITY_MGMT_URL",
+				Value: "https://platform-identity-management:4500",
+			},
 		},
 	}
 


### PR DESCRIPTION
Added IDENTITY_MGMT_URL to auth-pdp container. (Issue https://github.ibm.com/IBMPrivateCloud/roadmap/issues/44579)