### PR TITLE
Changed name of namespace-admission-config webhook to support SAAS

### DIFF
--- a/pkg/controller/authentication/authentication_controller.go
+++ b/pkg/controller/authentication/authentication_controller.go
@@ -330,7 +330,7 @@ func (r *ReconcileAuthentication) deleteExternalResources(instance *operatorv1al
 	crMap := generateCRData()
 	crbMap := generateCRBData("dummy", "dummy")
 	userName := instance.Spec.Config.DefaultAdminUser
-	webhook := "namespace-admission-config"
+	webhook := "namespace-admission-config" + "-" + instance.Namespace
 
 	// Remove Cluster Role
 	for crName := range crMap {

--- a/pkg/controller/authentication/webhook.go
+++ b/pkg/controller/authentication/webhook.go
@@ -32,7 +32,7 @@ func (r *ReconcileAuthentication) handleWebhook(instance *operatorv1alpha1.Authe
 
 	reqLogger := log.WithValues("Instance.Namespace", instance.Namespace, "Instance.Name", instance.Name)
 	var err error
-	webhook := "namespace-admission-config"
+	webhook := "namespace-admission-config" + "-" + instance.Namespace
 
 	err = r.client.Get(context.TODO(), types.NamespacedName{Name: webhook, Namespace: ""}, currentWebhook)
 	if err != nil {
@@ -49,6 +49,7 @@ func (r *ReconcileAuthentication) handleWebhook(instance *operatorv1alpha1.Authe
 			// User created successfully - return and requeue
 			*requeueResult = true
 		} else {
+			reqLogger.Error(err, "Failed to get an existing webhook", "Webhook.Namespace", instance.Namespace, "Webhook.Name", webhook)
 			return err
 		}
 	} else {
@@ -82,7 +83,7 @@ func generateWebhookObject(instance *operatorv1alpha1.Authentication, scheme *ru
 		},
 		Webhooks: []reg.MutatingWebhook{
 			{
-				Name:          "iam.hooks.securityenforcement.admission.cloud.ibm.com",
+				Name:          instance.Namespace + "." + "iam.hooks.securityenforcement.admission.cloud.ibm.com",
 				FailurePolicy: &failurePolicy,
 				ClientConfig: reg.WebhookClientConfig{
 					Service: &reg.ServiceReference{

--- a/pkg/controller/oidcclientwatcher/oidcclientwatcher_controller.go
+++ b/pkg/controller/oidcclientwatcher/oidcclientwatcher_controller.go
@@ -655,6 +655,17 @@ func (r *ReconcileOIDCClientWatcher) deploymentForOIDCClientWatcher(instance *op
 									},
 								},
 								{
+									Name: "IBM_CLOUD_SAAS",
+									ValueFrom: &corev1.EnvVarSource{
+										ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: "platform-auth-idp",
+											},
+											Key: "IBM_CLOUD_SAAS",
+										},
+									},
+								},
+								{
 									Name: "ROKS_ENABLED",
 									ValueFrom: &corev1.EnvVarSource{
 										ConfigMapKeyRef: &corev1.ConfigMapKeySelector{

--- a/pkg/controller/pap/containers.go
+++ b/pkg/controller/pap/containers.go
@@ -316,6 +316,17 @@ func buildPapContainer(papImage string, resources *corev1.ResourceRequirements) 
 				},
 			},
 			{
+				Name: "IBM_CLOUD_SAAS",
+				ValueFrom: &corev1.EnvVarSource{
+					ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "platform-auth-idp",
+						},
+						Key: "IBM_CLOUD_SAAS",
+					},
+				},
+			},
+			{
 				Name:  "IDENTITY_PROVIDER_URL",
 				Value: "https://platform-identity-provider:4300",
 			},

--- a/pkg/controller/policydecision/containers.go
+++ b/pkg/controller/policydecision/containers.go
@@ -280,6 +280,17 @@ func buildPdpContainer(pdpImage string, resources *corev1.ResourceRequirements) 
 				},
 			},
 			{
+				Name: "IBM_CLOUD_SAAS",
+				ValueFrom: &corev1.EnvVarSource{
+					ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "platform-auth-idp",
+						},
+						Key: "IBM_CLOUD_SAAS",
+					},
+				},
+			},
+			{
 				Name: "ROKS_ENABLED",
 				ValueFrom: &corev1.EnvVarSource{
 					ConfigMapKeyRef: &corev1.ConfigMapKeySelector{


### PR DESCRIPTION
- Changed name of `namespace-admission-config` webhook to include namespace to differentiate across multiple instances of IAM. (Related issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/45715)
- Added `IBM_CLOUD_SAAS` env variable to pdp, pap and oidcclient-watcher containers. (Related issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/45717)