### PR TITLE
Update Dockerfile - update Ubi images for 3.6.5

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:f42e065cf3bf0a377c14a4afd21454cf0b9cbbf7eded886a82a75d9e433e8d02
+FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:a62d408337bb50546019e2334fdd43ec1ecc150d60f5f195fd324c578c25ab3a
 
 LABEL org.label-schema.vendor="IBM" \
     org.label-schema.name="ibm-iam-operator" \

--- a/build/Dockerfile.ppc64le
+++ b/build/Dockerfile.ppc64le
@@ -20,7 +20,7 @@ RUN wget -O /qemu-ppc64le-static https://github.com/multiarch/qemu-user-static/r
 
 RUN chmod +x /qemu-ppc64le-static
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:7c3f8a353a25b4a3265526b22fb1eca61f1be4fae6b18be9f4263f4a8d5fbebd
+FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:0d42603bf9f539f28c133e9a13e74cec8d3baaa0165c6f873ff931d50c708d8c
 ARG VCS_REF
 ARG VCS_URL
 

--- a/build/Dockerfile.ppc64le
+++ b/build/Dockerfile.ppc64le
@@ -1,5 +1,5 @@
 #
-# Copyright 2020 IBM Corporation
+# Copyright 2020,2021 IBM Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/build/Dockerfile.s390x
+++ b/build/Dockerfile.s390x
@@ -1,5 +1,5 @@
 #
-# Copyright 2020 IBM Corporation
+# Copyright 2020,2021 IBM Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ RUN wget -O /qemu-s390x-static https://github.com/multiarch/qemu-user-static/rel
 
 RUN chmod +x /qemu-s390x-static
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:7e7e3802f4f4bc1082eb859ad08bafed535e5777e3c265319de35caee6ce5176
+FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:4b3905174e708d2656df72b4800a7abf87284a20ab44b3ef4d7136193caccf9f
 ARG VCS_REF
 ARG VCS_URL
 


### PR DESCRIPTION
https://github.ibm.com/IBMPrivateCloud/roadmap/issues/46750


 docker manifest inspect registry.access.redhat.com/ubi8/ubi-minimal:8.3-298.1618432845
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
   "manifests": [
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 737,
         "digest": "sha256:a62d408337bb50546019e2334fdd43ec1ecc150d60f5f195fd324c578c25ab3a",
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 737,
         "digest": "sha256:231d86e11434aeace9f879006fbba111ce4cf03db6441fd43e172e4c7212606c",
         "platform": {
            "architecture": "arm64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 737,
         "digest": "sha256:0d42603bf9f539f28c133e9a13e74cec8d3baaa0165c6f873ff931d50c708d8c",
         "platform": {
            "architecture": "ppc64le",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 737,
         "digest": "sha256:4b3905174e708d2656df72b4800a7abf87284a20ab44b3ef4d7136193caccf9f",
         "platform": {
            "architecture": "s390x",
            "os": "linux"
         }
      }
   ]
}