### PR TITLE
Code changes handle namespace-admission-config webhook resource on upgrade (Issue #46959)

### DIFF
--- a/pkg/controller/authentication/authentication_controller.go
+++ b/pkg/controller/authentication/authentication_controller.go
@@ -330,7 +330,15 @@ func (r *ReconcileAuthentication) deleteExternalResources(instance *operatorv1al
 	crMap := generateCRData()
 	crbMap := generateCRBData("dummy", "dummy")
 	userName := instance.Spec.Config.DefaultAdminUser
-	webhook := "namespace-admission-config" + "-" + instance.Namespace
+	// These code changes handles all use cases:
+	// - fresh install in saas or on-prem mode and
+	// - upgrade on older releases in on-prem mode
+	webhook := "namespace-admission-config"
+	if instance.Spec.Config.IBMCloudSaas {
+		// in saas mode
+		webhook = webhook + "-" + instance.Namespace
+	}
+
 
 	// Remove Cluster Role
 	for crName := range crMap {

--- a/pkg/controller/securityonboarding/securityonboarding_controller.go
+++ b/pkg/controller/securityonboarding/securityonboarding_controller.go
@@ -918,6 +918,15 @@ func getIAMOnboardJob(instance *operatorv1alpha1.SecurityOnboarding, r *Reconcil
 			},
 		},
 		{
+			Name: "IBM_CLOUD_SAAS",
+			ValueFrom: &corev1.EnvVarSource{
+				ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+					Key:                  "IBM_CLOUD_SAAS",
+					LocalObjectReference: corev1.LocalObjectReference{Name: "platform-auth-idp"},
+				},
+			},
+		},
+		{
 			Name:  "MONGO_DB",
 			Value: "platform-db",
 		},


### PR DESCRIPTION
Code changes handle namespace-admission-config webhook resource on upgrade (Issue https://github.ibm.com/IBMPrivateCloud/roadmap/issues/46960)
Added IBM_CLOUD_SAAS env varaible to iam-onboarding job. (Issue https://github.ibm.com/IBMPrivateCloud/roadmap/issues/46959)