### PR TITLE
Updated csv, crds and crs with new config parameter excludeOperand for secret-watcher and policy-controller.

### DIFF
--- a/deploy/crds/operator.ibm.com_v1alpha1_pap_cr.yaml
+++ b/deploy/crds/operator.ibm.com_v1alpha1_pap_cr.yaml
@@ -31,5 +31,5 @@ spec:
       requests:
         cpu: 50m
         memory: 200Mi
-  operatorVersion: "3.5.0"
+  operatorVersion: "0.14.1"
   replicas: 1

--- a/deploy/crds/operator.ibm.com_v1alpha1_policycontroller_cr.yaml
+++ b/deploy/crds/operator.ibm.com_v1alpha1_policycontroller_cr.yaml
@@ -7,9 +7,11 @@ metadata:
     app.kubernetes.io/managed-by: ibm-iam-operator
     app.kubernetes.io/name: ibm-iam-operator
 spec:
+  config:
+    excludeOperand: false
   operatorVersion: "0.14.1"
   imageRegistry: "quay.io/opencloudio/iam-policy-controller"
-  imageTagPostfix: "3.3.2"
+  imageTagPostfix: "3.5.0"
   replicas: 1
   resources:
     limits:

--- a/deploy/crds/operator.ibm.com_v1alpha1_secretwatcher_cr.yaml
+++ b/deploy/crds/operator.ibm.com_v1alpha1_secretwatcher_cr.yaml
@@ -7,9 +7,11 @@ metadata:
     app.kubernetes.io/managed-by: ibm-iam-operator
     app.kubernetes.io/name: ibm-iam-operator
 spec:
+  config:
+    excludeOperand: false
   operatorVersion: "0.14.1"
   imageRegistry: "quay.io/opencloudio/icp-secret-watcher"
-  imageTagPostfix: "3.3.3"
+  imageTagPostfix: "3.5.0"
   resources:
     limits:
       cpu: 200m

--- a/deploy/olm-catalog/ibm-iam-operator/3.10.0/ibm-iam-operator.v3.10.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-iam-operator/3.10.0/ibm-iam-operator.v3.10.0.clusterserviceversion.yaml
@@ -152,7 +152,7 @@ metadata:
             "auditService": {
               "imageName": "audit-syslog-service",
               "imageRegistry": "quay.io/opencloudio",
-              "imageTag": "1.0.5",
+              "imageTag": "1.0.7",
               "syslogTlsPath": "/etc/audit-tls",
               "resources": {
                 "limits": {
@@ -207,6 +207,7 @@ metadata:
               "defaultAdminUser": "admin",
               "enableImpersonation": false,
               "fipsEnabled": true,
+              "ibmCloudSaas": false,
               "icpPort": 8443,
               "installType": "fresh",
               "isOpenshiftEnv": true,
@@ -223,6 +224,7 @@ metadata:
               "roksEnabled": true,
               "roksURL": "https://roks.domain.name:443",
               "roksUserPrefix": "changeme",
+              "saasClientRedirectUrl": "",
               "wlpClientID": "4444be3a738841016ab76d71b650e836",
               "wlpClientRegistrationSecret": "f1362ca4d20b8389af2d1ea68042c9af",
               "wlpClientSecret": "aa73bf39752053bf723d1143fb4cf8a2"
@@ -292,7 +294,7 @@ metadata:
             "auditService": {
               "imageName": "audit-syslog-service",
               "imageRegistry": "quay.io/opencloudio",
-              "imageTag": "1.0.5",
+              "imageTag": "1.0.7",
               "syslogTlsPath": "/etc/audit-tls",
               "resources": {
                 "limits": {
@@ -305,7 +307,7 @@ metadata:
                 }
               }
             },
-            "operatorVersion": "3.9.1",
+            "operatorVersion": "0.14.1",
             "papService": {
               "imageName": "iam-policy-administration",
               "imageRegistry": "quay.io/opencloudio",
@@ -336,6 +338,9 @@ metadata:
             "name": "policycontroller-deployment"
           },
           "spec": {
+            "config": {
+              "excludeOperand": false
+            },
             "imageRegistry": "quay.io/opencloudio/iam-policy-controller",
             "imageTagPostfix": "3.5.0",
             "operatorVersion": "0.14.1",
@@ -364,6 +369,9 @@ metadata:
             "name": "secretwatcher-deployment"
           },
           "spec": {
+            "config": {
+              "excludeOperand": false
+            },
             "imageRegistry": "quay.io/opencloudio/icp-secret-watcher",
             "imageTagPostfix": "3.5.0",
             "operatorVersion": "0.14.1",
@@ -1628,7 +1636,7 @@ spec:
           - patch
           - update
           - watch
-          - delete      
+          - delete
         # this is used by iam poliy controller
         - apiGroups:
           - iam.policies.ibm.com
@@ -1641,7 +1649,7 @@ spec:
           - patch
           - update
           - watch
-          - delete                                           
+          - delete
         serviceAccountName: ibm-iam-operand-restricted
       - rules:
         - apiGroups:
@@ -1671,7 +1679,7 @@ spec:
           - update
           - watch
           - escalate
-          - bind  
+          - bind
         - apiGroups:
           - rbac.authorization.k8s.io
           resources:
@@ -1694,7 +1702,7 @@ spec:
           - get
           - list
           - patch
-          - update            
+          - update
           - watch
           - delete
         serviceAccountName: ibm-iam-operator

--- a/deploy/olm-catalog/ibm-iam-operator/3.10.0/ibm-iam-operator.v3.10.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-iam-operator/3.10.0/ibm-iam-operator.v3.10.0.clusterserviceversion.yaml
@@ -586,7 +586,7 @@ metadata:
     support: IBM
   labels:
     operatorframework.io/arch.s390x: supported
-    operatorframework.io/os.linux: supported 
+    operatorframework.io/os.linux: supported
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.ppc64le: supported
   name: ibm-iam-operator.v3.10.0
@@ -1527,7 +1527,7 @@ spec:
      - 3.6.5
      - 3.6.4
      - 3.6.3
-     - 3.6.2    
+     - 3.6.2
      - 3.6.0
         - With this version, support for OpenShift 4.3 is added.
      - 3.5.0
@@ -1656,7 +1656,7 @@ spec:
           - admissionregistration.k8s.io
           resources:
           - mutatingwebhookconfigurations
-          #iam.hooks.securityenforcement.admission.cloud.ibm.com used by oidcclient-watcher 
+          #iam.hooks.securityenforcement.admission.cloud.ibm.com used by oidcclient-watcher
           verbs:
           - get
           - list

--- a/deploy/olm-catalog/ibm-iam-operator/3.10.0/operator.ibm.com_policycontrollers_crd.yaml
+++ b/deploy/olm-catalog/ibm-iam-operator/3.10.0/operator.ibm.com_policycontrollers_crd.yaml
@@ -35,6 +35,11 @@ spec:
         spec:
           description: PolicyControllerSpec defines the desired state of PolicyController
           properties:
+            config:
+              properties:
+                excludeOperand:
+                  type: boolean
+              type: object
             imageRegistry:
               type: string
             imageTagPostfix:

--- a/deploy/olm-catalog/ibm-iam-operator/3.10.0/operator.ibm.com_secretwatchers_crd.yaml
+++ b/deploy/olm-catalog/ibm-iam-operator/3.10.0/operator.ibm.com_secretwatchers_crd.yaml
@@ -35,6 +35,11 @@ spec:
         spec:
           description: SecretWatcherSpec defines the desired state of SecretWatcher
           properties:
+            config:
+              properties:
+                excludeOperand:
+                  type: boolean
+              type: object
             imageRegistry:
               type: string
             imageTagPostfix:

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -263,8 +263,6 @@ rules:
   - patch
   - update
   - watch
-  - bind
-  - escalate
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:


### PR DESCRIPTION
- Updated csv, crds and crs with new config parameter `excludeOperand` for secret-watcher and policy-controller. (Related issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/47094)
- Updated csv with other missing config parameters.