### PR TITLE
Update Dockerfile - to latest ubi 8

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:a62d408337bb50546019e2334fdd43ec1ecc150d60f5f195fd324c578c25ab3a
+FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:0ccb9988abbc72d383258d58a7f519a10b637d472f28fbca6eb5fab79ba82a6b
 LABEL org.label-schema.vendor="IBM" \
     org.label-schema.name="ibm-iam-operator" \
     org.label-schema.description="IBM IAM Operator" \

--- a/build/Dockerfile.ppc64le
+++ b/build/Dockerfile.ppc64le
@@ -20,7 +20,7 @@ RUN wget -O /qemu-ppc64le-static https://github.com/multiarch/qemu-user-static/r
 
 RUN chmod +x /qemu-ppc64le-static
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:0d42603bf9f539f28c133e9a13e74cec8d3baaa0165c6f873ff931d50c708d8c
+FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:5bae25288d7cea563733606751e1f5f9606e4332c7755f0e5974091f0e58dac5
 ARG VCS_REF
 ARG VCS_URL
 

--- a/build/Dockerfile.s390x
+++ b/build/Dockerfile.s390x
@@ -20,7 +20,7 @@ RUN wget -O /qemu-s390x-static https://github.com/multiarch/qemu-user-static/rel
 
 RUN chmod +x /qemu-s390x-static
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:4b3905174e708d2656df72b4800a7abf87284a20ab44b3ef4d7136193caccf9f
+FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:f1c6d887cda1d9dc7f40bcb237e7eef3c5db1674fd156290061cd3cecba290cc
 ARG VCS_REF
 ARG VCS_URL
 


### PR DESCRIPTION
Update to latest to remediate CVE-2021-27219 package glib2