### PR TITLE
Update operator.yaml to bump up operands and move to latest ubi

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:0ccb9988abbc72d383258d58a7f519a10b637d472f28fbca6eb5fab79ba82a6b
+FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:48a4bec3d1dec90b5dd5420bf7c41a5756b7fbe8b862546134fbe2caa607679f
 LABEL org.label-schema.vendor="IBM" \
     org.label-schema.name="ibm-iam-operator" \
     org.label-schema.description="IBM IAM Operator" \

--- a/build/Dockerfile.ppc64le
+++ b/build/Dockerfile.ppc64le
@@ -20,7 +20,7 @@ RUN wget -O /qemu-ppc64le-static https://github.com/multiarch/qemu-user-static/r
 
 RUN chmod +x /qemu-ppc64le-static
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:3410b9e870bd51bd71646a85beb9e7dd767275208ff33f52c3277c1877c9a3b9
+FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:82b6decae91cf9cc9c3d65e264920e351850b2b3f4711b07d58d815fd4cdab3d
 ARG VCS_REF
 ARG VCS_URL
 

--- a/build/Dockerfile.ppc64le
+++ b/build/Dockerfile.ppc64le
@@ -16,7 +16,7 @@
 
 FROM alpine as builder
 
-RUN wget -O /qemu-ppc64le-static https://github.com/multiarch/qemu-user-static/releases/v5.2.0-2/download/qemu-ppc64le-static
+RUN wget -O /qemu-ppc64le-static https://github.com/multiarch/qemu-user-static/releases/download/v5.2.0-2/qemu-ppc64le-static
 
 RUN chmod +x /qemu-ppc64le-static
 

--- a/build/Dockerfile.ppc64le
+++ b/build/Dockerfile.ppc64le
@@ -1,5 +1,5 @@
 #
-# Copyright 2020 IBM Corporation
+# Copyright 2020, 2021 IBM Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ RUN wget -O /qemu-ppc64le-static https://github.com/multiarch/qemu-user-static/r
 
 RUN chmod +x /qemu-ppc64le-static
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:82b6decae91cf9cc9c3d65e264920e351850b2b3f4711b07d58d815fd4cdab3d
+FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:3410b9e870bd51bd71646a85beb9e7dd767275208ff33f52c3277c1877c9a3b9
 ARG VCS_REF
 ARG VCS_URL
 

--- a/build/Dockerfile.ppc64le
+++ b/build/Dockerfile.ppc64le
@@ -16,7 +16,7 @@
 
 FROM alpine as builder
 
-RUN wget -O /qemu-ppc64le-static https://github.com/multiarch/qemu-user-static/releases/latest/download/qemu-ppc64le-static
+RUN wget -O /qemu-ppc64le-static https://github.com/multiarch/qemu-user-static/releases/v5.2.0-2/download/qemu-ppc64le-static
 
 RUN chmod +x /qemu-ppc64le-static
 

--- a/build/Dockerfile.ppc64le
+++ b/build/Dockerfile.ppc64le
@@ -20,7 +20,7 @@ RUN wget -O /qemu-ppc64le-static https://github.com/multiarch/qemu-user-static/r
 
 RUN chmod +x /qemu-ppc64le-static
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:5bae25288d7cea563733606751e1f5f9606e4332c7755f0e5974091f0e58dac5
+FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:82b6decae91cf9cc9c3d65e264920e351850b2b3f4711b07d58d815fd4cdab3d
 ARG VCS_REF
 ARG VCS_URL
 

--- a/build/Dockerfile.s390x
+++ b/build/Dockerfile.s390x
@@ -16,7 +16,7 @@
 
 FROM alpine as builder
 
-RUN wget -O /qemu-s390x-static https://github.com/multiarch/qemu-user-static/releases/latest/download/qemu-s390x-static
+RUN wget -O /qemu-s390x-static https://github.com/multiarch/qemu-user-static/releases/v5.2.0-2/download/qemu-s390x-static
 
 RUN chmod +x /qemu-s390x-static
 

--- a/build/Dockerfile.s390x
+++ b/build/Dockerfile.s390x
@@ -16,7 +16,7 @@
 
 FROM alpine as builder
 
-RUN wget -O /qemu-s390x-static https://github.com/multiarch/qemu-user-static/releases/v5.2.0-2/download/qemu-s390x-static
+RUN wget -O /qemu-s390x-static https://github.com/multiarch/qemu-user-static/releases/download/v5.2.0-2/qemu-s390x-static
 
 RUN chmod +x /qemu-s390x-static
 

--- a/build/Dockerfile.s390x
+++ b/build/Dockerfile.s390x
@@ -20,7 +20,7 @@ RUN wget -O /qemu-s390x-static https://github.com/multiarch/qemu-user-static/rel
 
 RUN chmod +x /qemu-s390x-static
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:f1c6d887cda1d9dc7f40bcb237e7eef3c5db1674fd156290061cd3cecba290cc
+FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:3410b9e870bd51bd71646a85beb9e7dd767275208ff33f52c3277c1877c9a3b9
 ARG VCS_REF
 ARG VCS_URL
 

--- a/build/Dockerfile.s390x
+++ b/build/Dockerfile.s390x
@@ -1,5 +1,5 @@
 #
-# Copyright 2020 IBM Corporation
+# Copyright 2020, 2021 IBM Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/deploy/olm-catalog/ibm-iam-operator/3.11.1/ibm-iam-operator.v3.11.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-iam-operator/3.11.1/ibm-iam-operator.v3.11.1.clusterserviceversion.yaml
@@ -1749,7 +1749,7 @@ spec:
                 - name: ICP_IDENTITY_PROVIDER_IMAGE
                   value: quay.io/opencloudio/icp-identity-provider:3.6.1
                 - name: ICP_IDENTITY_MANAGER_IMAGE
-                  value: quay.io/opencloudio/icp-identity-manager:3.6.1
+                  value: quay.io/opencloudio/icp-identity-manager:3.6.0
                 - name: IAM_POLICY_ADMINISTRATION_IMAGE
                   value: quay.io/opencloudio/iam-policy-administration:3.6.1
                 - name: IAM_POLICY_DECISION_IMAGE
@@ -1761,7 +1761,7 @@ spec:
                 - name: IAM_POLICY_CONTROLLER_IMAGE
                   value: quay.io/opencloudio/iam-policy-controller:3.6.1
                 - name: ICP_IAM_ONBOARDING_IMAGE
-                  value: quay.io/opencloudio/icp-iam-onboarding:3.6.0
+                  value: quay.io/opencloudio/icp-iam-onboarding:3.6.1
                 - name: AUDIT_SYSLOG_SERVICE_IMAGE
                   value: quay.io/opencloudio/audit-syslog-service:1.0.7
                 - name: WATCH_NAMESPACE

--- a/deploy/olm-catalog/ibm-iam-operator/3.11.1/ibm-iam-operator.v3.11.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-iam-operator/3.11.1/ibm-iam-operator.v3.11.1.clusterserviceversion.yaml
@@ -1749,17 +1749,17 @@ spec:
                 - name: ICP_IDENTITY_PROVIDER_IMAGE
                   value: quay.io/opencloudio/icp-identity-provider:3.6.1
                 - name: ICP_IDENTITY_MANAGER_IMAGE
-                  value: quay.io/opencloudio/icp-identity-manager:3.6.0
+                  value: quay.io/opencloudio/icp-identity-manager:3.6.1
                 - name: IAM_POLICY_ADMINISTRATION_IMAGE
-                  value: quay.io/opencloudio/iam-policy-administration:3.6.0
+                  value: quay.io/opencloudio/iam-policy-administration:3.6.1
                 - name: IAM_POLICY_DECISION_IMAGE
-                  value: quay.io/opencloudio/iam-policy-decision:3.6.0
+                  value: quay.io/opencloudio/iam-policy-decision:3.6.1
                 - name: ICP_SECRET_WATCHER_IMAGE
-                  value: quay.io/opencloudio/icp-secret-watcher:3.6.0
+                  value: quay.io/opencloudio/icp-secret-watcher:3.6.1
                 - name: ICP_OIDCCLIENT_WATCHER_IMAGE
-                  value: quay.io/opencloudio/icp-oidcclient-watcher:3.6.0
+                  value: quay.io/opencloudio/icp-oidcclient-watcher:3.6.1
                 - name: IAM_POLICY_CONTROLLER_IMAGE
-                  value: quay.io/opencloudio/iam-policy-controller:3.6.0
+                  value: quay.io/opencloudio/iam-policy-controller:3.6.1
                 - name: ICP_IAM_ONBOARDING_IMAGE
                   value: quay.io/opencloudio/icp-iam-onboarding:3.6.0
                 - name: AUDIT_SYSLOG_SERVICE_IMAGE

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -48,19 +48,19 @@ spec:
             - name: ICP_IDENTITY_PROVIDER_IMAGE
               value: quay.io/opencloudio/icp-identity-provider:3.6.1
             - name: ICP_IDENTITY_MANAGER_IMAGE
-              value: quay.io/opencloudio/icp-identity-manager:3.6.0
+              value: quay.io/opencloudio/icp-identity-manager:3.6.1
             - name: IAM_POLICY_ADMINISTRATION_IMAGE
-              value: quay.io/opencloudio/iam-policy-administration:3.6.0
+              value: quay.io/opencloudio/iam-policy-administration:3.6.1
             - name: IAM_POLICY_DECISION_IMAGE
-              value: quay.io/opencloudio/iam-policy-decision:3.6.0
+              value: quay.io/opencloudio/iam-policy-decision:3.6.1
             - name: ICP_SECRET_WATCHER_IMAGE
-              value: quay.io/opencloudio/icp-secret-watcher:3.6.0
+              value: quay.io/opencloudio/icp-secret-watcher:3.6.1
             - name: ICP_OIDCCLIENT_WATCHER_IMAGE
-              value: quay.io/opencloudio/icp-oidcclient-watcher:3.6.0
+              value: quay.io/opencloudio/icp-oidcclient-watcher:3.6.1
             - name: IAM_POLICY_CONTROLLER_IMAGE
-              value: quay.io/opencloudio/iam-policy-controller:3.6.0
+              value: quay.io/opencloudio/iam-policy-controller:3.6.1
             - name: ICP_IAM_ONBOARDING_IMAGE
-              value: quay.io/opencloudio/icp-iam-onboarding:3.6.0
+              value: quay.io/opencloudio/icp-iam-onboarding:3.6.1
             - name: AUDIT_SYSLOG_SERVICE_IMAGE
               value: quay.io/opencloudio/audit-syslog-service:1.0.7
             - name: WATCH_NAMESPACE

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -48,7 +48,7 @@ spec:
             - name: ICP_IDENTITY_PROVIDER_IMAGE
               value: quay.io/opencloudio/icp-identity-provider:3.6.1
             - name: ICP_IDENTITY_MANAGER_IMAGE
-              value: quay.io/opencloudio/icp-identity-manager:3.6.1
+              value: quay.io/opencloudio/icp-identity-manager:3.6.0
             - name: IAM_POLICY_ADMINISTRATION_IMAGE
               value: quay.io/opencloudio/iam-policy-administration:3.6.1
             - name: IAM_POLICY_DECISION_IMAGE


### PR DESCRIPTION
Fixes: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/48416

updated images from:
```
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
   "manifests": [
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 737,
         "digest": "sha256:48a4bec3d1dec90b5dd5420bf7c41a5756b7fbe8b862546134fbe2caa607679f",
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 737,
         "digest": "sha256:ad1de47449386ae0f6009c38d714cbcc218d6f8087ea2d45272b671baa5072af",
         "platform": {
            "architecture": "arm64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 737,
         "digest": "sha256:82b6decae91cf9cc9c3d65e264920e351850b2b3f4711b07d58d815fd4cdab3d",
         "platform": {
            "architecture": "ppc64le",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 737,
         "digest": "sha256:3410b9e870bd51bd71646a85beb9e7dd767275208ff33f52c3277c1877c9a3b9",
         "platform": {
            "architecture": "s390x",
            "os": "linux"
         }
      }
   ]
}