### PR TITLE
Update operator.yaml to bump identity manager after build passes

### DIFF
--- a/deploy/olm-catalog/ibm-iam-operator/3.11.1/ibm-iam-operator.v3.11.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-iam-operator/3.11.1/ibm-iam-operator.v3.11.1.clusterserviceversion.yaml
@@ -1749,7 +1749,7 @@ spec:
                 - name: ICP_IDENTITY_PROVIDER_IMAGE
                   value: quay.io/opencloudio/icp-identity-provider:3.6.1
                 - name: ICP_IDENTITY_MANAGER_IMAGE
-                  value: quay.io/opencloudio/icp-identity-manager:3.6.0
+                  value: quay.io/opencloudio/icp-identity-manager:3.6.1
                 - name: IAM_POLICY_ADMINISTRATION_IMAGE
                   value: quay.io/opencloudio/iam-policy-administration:3.6.1
                 - name: IAM_POLICY_DECISION_IMAGE

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -48,7 +48,7 @@ spec:
             - name: ICP_IDENTITY_PROVIDER_IMAGE
               value: quay.io/opencloudio/icp-identity-provider:3.6.1
             - name: ICP_IDENTITY_MANAGER_IMAGE
-              value: quay.io/opencloudio/icp-identity-manager:3.6.0
+              value: quay.io/opencloudio/icp-identity-manager:3.6.1
             - name: IAM_POLICY_ADMINISTRATION_IMAGE
               value: quay.io/opencloudio/iam-policy-administration:3.6.1
             - name: IAM_POLICY_DECISION_IMAGE


### PR DESCRIPTION
Bump up identity manager version to 3.6.1 after build passes for August release.