### PR TITLE
Update Dockerfile to move to latest ubi minimal and latest audit 1.0.8

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:48a4bec3d1dec90b5dd5420bf7c41a5756b7fbe8b862546134fbe2caa607679f
+FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:7735715721f161dea5603092c040b5eb89ab101044617f67288a866d0f9d0aaa
 LABEL org.label-schema.vendor="IBM" \
     org.label-schema.name="ibm-iam-operator" \
     org.label-schema.description="IBM IAM Operator" \

--- a/build/Dockerfile.ppc64le
+++ b/build/Dockerfile.ppc64le
@@ -20,7 +20,7 @@ RUN wget -O /qemu-ppc64le-static https://github.com/multiarch/qemu-user-static/r
 
 RUN chmod +x /qemu-ppc64le-static
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:82b6decae91cf9cc9c3d65e264920e351850b2b3f4711b07d58d815fd4cdab3d
+FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:1f525c72b1b0a0f67f0d00ca620fe35d25336e0392edd00512dc45ee41661beb
 ARG VCS_REF
 ARG VCS_URL
 

--- a/build/Dockerfile.s390x
+++ b/build/Dockerfile.s390x
@@ -20,7 +20,7 @@ RUN wget -O /qemu-s390x-static https://github.com/multiarch/qemu-user-static/rel
 
 RUN chmod +x /qemu-s390x-static
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:3410b9e870bd51bd71646a85beb9e7dd767275208ff33f52c3277c1877c9a3b9
+FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:5b935f49feacbda3f2fffbd091936ecd132266b10299a9b694eaa47bb814854b
 ARG VCS_REF
 ARG VCS_URL
 

--- a/deploy/olm-catalog/ibm-iam-operator/3.11.1/ibm-iam-operator.v3.11.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-iam-operator/3.11.1/ibm-iam-operator.v3.11.1.clusterserviceversion.yaml
@@ -1763,7 +1763,7 @@ spec:
                 - name: ICP_IAM_ONBOARDING_IMAGE
                   value: quay.io/opencloudio/icp-iam-onboarding:3.6.1
                 - name: AUDIT_SYSLOG_SERVICE_IMAGE
-                  value: quay.io/opencloudio/audit-syslog-service:1.0.7
+                  value: quay.io/opencloudio/audit-syslog-service:1.0.8
                 - name: WATCH_NAMESPACE
                   valueFrom:
                     fieldRef:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -62,7 +62,7 @@ spec:
             - name: ICP_IAM_ONBOARDING_IMAGE
               value: quay.io/opencloudio/icp-iam-onboarding:3.6.1
             - name: AUDIT_SYSLOG_SERVICE_IMAGE
-              value: quay.io/opencloudio/audit-syslog-service:1.0.7
+              value: quay.io/opencloudio/audit-syslog-service:1.0.8
             - name: WATCH_NAMESPACE
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
Move to latest ubi-minimal:8.4-205.1626828526
docker manifest inspect registry.access.redhat.com/ubi8/ubi-minimal:8.4-205.1626828526
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
   "manifests": [
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 737,
         "digest": "sha256:7735715721f161dea5603092c040b5eb89ab101044617f67288a866d0f9d0aaa",
         "platform": {
            "architecture": "amd64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 737,
         "digest": "sha256:3fd316744d34570518af714b729fc6d744a7860af5e25594f1b48f315d59419a",
         "platform": {
            "architecture": "arm64",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 737,
         "digest": "sha256:1f525c72b1b0a0f67f0d00ca620fe35d25336e0392edd00512dc45ee41661beb",
         "platform": {
            "architecture": "ppc64le",
            "os": "linux"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 737,
         "digest": "sha256:5b935f49feacbda3f2fffbd091936ecd132266b10299a9b694eaa47bb814854b",
         "platform": {
            "architecture": "s390x",
            "os": "linux"
         }
      }
   ]
}