### PR TITLE
Revert "Update webhook.go" to use v1beta1

### DIFF
--- a/pkg/controller/authentication/webhook.go
+++ b/pkg/controller/authentication/webhook.go
@@ -148,7 +148,7 @@ func generateWebhookObject(instance *operatorv1alpha1.Authentication, scheme *ru
 					},
 				},
 				SideEffects:             &sideEffectClass,
-				AdmissionReviewVersions: []string{"v1"},
+				AdmissionReviewVersions: []string{"v1beta1","v1"},
 				Rules: []reg.RuleWithOperations{
 					{
 						Rule: reg.Rule{


### PR DESCRIPTION
Reverts IBM/ibm-iam-operator#407