### PR TITLE
update next-csv.sh bump up version to 3.12.0 for CS 3.12

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ IMAGE_BUILD_OPTS=--build-arg "VCS_REF=$(GIT_COMMIT_ID)" --build-arg "VCS_URL=$(G
 # Use your own docker registry and image name for dev/test by overridding the IMG and REGISTRY environment variable.
 IMG ?= ibm-iam-operator
 REGISTRY ?= "hyc-cloud-private-integration-docker-local.artifactory.swg-devops.com/ibmcom"
-CSV_VERSION ?= 3.11.2
+CSV_VERSION ?= 3.12.0
 
 QUAY_USERNAME ?=
 QUAY_PASSWORD ?=

--- a/common/scripts/lint-csv.sh
+++ b/common/scripts/lint-csv.sh
@@ -18,7 +18,7 @@
 STATUS=0
 ARCH=$(uname -m)
 OS=$(uname -s)
-VERSION=${CSV_VERSION:-3.11.2}
+VERSION=${CSV_VERSION:-3.12.0}
 
 if [[ $ARCH == "x86_64" && $OS == "Linux" ]]; then
     curl -L -o /tmp/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64

--- a/common/scripts/next-csv.sh
+++ b/common/scripts/next-csv.sh
@@ -20,13 +20,20 @@
 # The CSV version that is currently in dev
 
 CURRENT_DEV_CSV=$1
-let NEW_DEV_CSV_Z=$(echo $CURRENT_DEV_CSV | cut -d '.' -f3)+1
-NEW_DEV_CSV=$(echo $CURRENT_DEV_CSV | gsed "s/\.[0-9][0-9]*$/\.$NEW_DEV_CSV_Z/")
-let PREVIOUS_DEV_CSV_Z=$(echo $CURRENT_DEV_CSV | cut -d '.' -f3)-1
-PREVIOUS_DEV_CSV=$(echo $CURRENT_DEV_CSV | gsed "s/\.[0-9][0-9]*$/\.$PREVIOUS_DEV_CSV_Z/")
+NEW_DEV_CSV=$2
+PREVIOUS_DEV_CSV=$3
 
-CSV_PATH=deploy/olm-catalog/ibm-iam-operator/
-echo "$NEW_DEV_CSV:
+if [ -z "$NEW_DEV_CSV" ]; then
+	let NEW_DEV_CSV_Z=$(echo $CURRENT_DEV_CSV | cut -d '.' -f3)+1
+	NEW_DEV_CSV=$(echo $CURRENT_DEV_CSV | gsed "s/\.[0-9][0-9]*$/\.$NEW_DEV_CSV_Z/")
+fi
+if [ -z "$PREVIOUS_DEV_CSV" ]; then
+	let PREVIOUS_DEV_CSV_Z=$(echo $CURRENT_DEV_CSV | cut -d '.' -f3)-1
+	PREVIOUS_DEV_CSV=$(echo $CURRENT_DEV_CSV | gsed "s/\.[0-9][0-9]*$/\.$PREVIOUS_DEV_CSV_Z/")
+fi
+
+CSV_PATH=deploy/olm-catalog/ibm-iam-operator
+echo "$NEW_DEV_CSV":
 # Make new z level release directory
 mkdir $CSV_PATH/$NEW_DEV_CSV
 echo "Made new directory"
@@ -45,7 +52,7 @@ read
 # Update New CSV
 # replace old CSV value with new one
 gsed -i "s/$CURRENT_DEV_CSV/$NEW_DEV_CSV/g" $CSV_PATH/$NEW_DEV_CSV/ibm-iam-operator.v$NEW_DEV_CSV.clusterserviceversion.yaml
-TIME_STAMP="$(date '+%Y-%m-%dT%H:%M:%S'Z)
+TIME_STAMP="$(date '+%Y-%m-%dT%H:%M:%S'Z)"
 gsed -i "s/2[0-9]*-[0-9]*-[0-9]*T[0-9]*:[0-9]*:[0-9]*Z/$TIME_STAMP/g" $CSV_PATH/$NEW_DEV_CSV/ibm-iam-operator.v$NEW_DEV_CSV.clusterserviceversion.yaml
 echo "Updated New file with new CSV version"
 gsed -i "s/$PREVIOUS_DEV_CSV/$CURRENT_DEV_CSV/g" $CSV_PATH/$NEW_DEV_CSV/ibm-iam-operator.v$NEW_DEV_CSV.clusterserviceversion.yaml

--- a/deploy/olm-catalog/ibm-iam-operator/3.12.0/iam.policies_v1alpha1_iampolicy.yaml
+++ b/deploy/olm-catalog/ibm-iam-operator/3.12.0/iam.policies_v1alpha1_iampolicy.yaml
@@ -1,0 +1,82 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    app.kubernetes.io/instance: ibm-iam-operator
+    app.kubernetes.io/managed-by: ibm-iam-operator
+    app.kubernetes.io/name: ibm-iam-operator
+  name: iampolicies.iam.policies.ibm.com
+spec:
+  group: iam.policies.ibm.com
+  names:
+    kind: IamPolicy
+    listKind: IamPolicyList
+    plural: iampolicies
+    singular: iampolicy
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              labelSelector:
+                description: selecting a list of namespaces where the policy applies
+                type: object
+              maxClusterRoleBindingUsers:
+                description: Maximum number of cluster role binding users still valid before it is considered non-compliant
+                format: int64
+                type: integer
+              maxRoleBindingViolationsPerNamespace:
+                description: Maximum number of iam rolebindings violations still valid before it is considered non-compliant
+                format: int64
+                type: integer
+              namespaceSelector:
+                description: Selecting a list of namespaces where the policy applies
+                properties:
+                  exclude:
+                    items:
+                      type: string
+                    type: array
+                  include:
+                    items:
+                      type: string
+                    type: array
+                type: object
+              remediationAction:
+                description: enforce, inform
+                type: string
+              severity:
+                description: low, medium, or high
+                type: string
+            type: object
+          status:
+            properties:
+              compliancyDetails:
+                description: Compliant, NonCompliant, UnkownCompliancy
+                type: object
+              compliant:
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: IamPolicy
+    listKind: IamPolicyList
+    plural: iampolicies
+    singular: iampolicy
+  conditions: []
+  storedVersions:
+  - v1alpha1

--- a/deploy/olm-catalog/ibm-iam-operator/3.12.0/ibm-iam-operator.v3.12.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-iam-operator/3.12.0/ibm-iam-operator.v3.12.0.clusterserviceversion.yaml
@@ -1745,23 +1745,23 @@ spec:
                 - ibm-iam-operator
                 env:
                 - name: ICP_PLATFORM_AUTH_IMAGE
-                  value: quay.io/opencloudio/icp-platform-auth:3.6.2
+                  value: quay.io/opencloudio/icp-platform-auth:3.7.0
                 - name: ICP_IDENTITY_PROVIDER_IMAGE
-                  value: quay.io/opencloudio/icp-identity-provider:3.6.2
+                  value: quay.io/opencloudio/icp-identity-provider:3.7.0
                 - name: ICP_IDENTITY_MANAGER_IMAGE
-                  value: quay.io/opencloudio/icp-identity-manager:3.6.2
+                  value: quay.io/opencloudio/icp-identity-manager:3.7.0
                 - name: IAM_POLICY_ADMINISTRATION_IMAGE
-                  value: quay.io/opencloudio/iam-policy-administration:3.6.2
+                  value: quay.io/opencloudio/iam-policy-administration:3.7.0
                 - name: IAM_POLICY_DECISION_IMAGE
-                  value: quay.io/opencloudio/iam-policy-decision:3.6.2
+                  value: quay.io/opencloudio/iam-policy-decision:3.7.0
                 - name: ICP_SECRET_WATCHER_IMAGE
-                  value: quay.io/opencloudio/icp-secret-watcher:3.6.2
+                  value: quay.io/opencloudio/icp-secret-watcher:3.7.0
                 - name: ICP_OIDCCLIENT_WATCHER_IMAGE
-                  value: quay.io/opencloudio/icp-oidcclient-watcher:3.6.2
+                  value: quay.io/opencloudio/icp-oidcclient-watcher:3.7.0
                 - name: IAM_POLICY_CONTROLLER_IMAGE
-                  value: quay.io/opencloudio/iam-policy-controller:3.6.2
+                  value: quay.io/opencloudio/iam-policy-controller:3.7.0
                 - name: ICP_IAM_ONBOARDING_IMAGE
-                  value: quay.io/opencloudio/icp-iam-onboarding:3.6.2
+                  value: quay.io/opencloudio/icp-iam-onboarding:3.7.0
                 - name: AUDIT_SYSLOG_SERVICE_IMAGE
                   value: quay.io/opencloudio/audit-syslog-service:1.0.8
                 - name: WATCH_NAMESPACE

--- a/deploy/olm-catalog/ibm-iam-operator/3.12.0/ibm-iam-operator.v3.12.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-iam-operator/3.12.0/ibm-iam-operator.v3.12.0.clusterserviceversion.yaml
@@ -1,0 +1,2040 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "operator.ibm.com/v1alpha1",
+          "kind": "OIDCClientWatcher",
+          "metadata": {
+            "labels": {
+              "app.kubernetes.io/instance": "ibm-iam-operator",
+              "app.kubernetes.io/managed-by": "ibm-iam-operator",
+              "app.kubernetes.io/name": "ibm-iam-operator"
+            },
+            "name": "example-oidcclientwatcher"
+          },
+          "spec": {
+            "imageRegistry": "quay.io/opencloudio/icp-oidcclient-watcher",
+            "imageTagPostfix": "3.6.0",
+            "operatorVersion": "0.14.1",
+            "replicas": 1,
+            "resources": {
+              "limits": {
+                "cpu": "200m",
+                "memory": "256Mi"
+              },
+              "requests": {
+                "cpu": "10m",
+                "memory": "16Mi"
+              }
+            },
+            "oidcInitAuthService": {
+              "imageName": "icp-platform-auth",
+              "imageRegistry": "quay.io/opencloudio",
+              "imageTag": "3.6.0",
+              "resources": {
+                "limits": {
+                  "cpu": "200m",
+                  "memory": "256Mi"
+                },
+                "requests": {
+                  "cpu": "100m",
+                  "memory": "128M"
+                }
+              }
+            },
+            "oidcInitIdentityProvider": {
+              "imageName": "icp-platform-auth",
+              "imageRegistry": "quay.io/opencloudio",
+              "imageTag": "3.6.0",
+              "resources": {
+                "limits": {
+                  "cpu": "200m",
+                  "memory": "256Mi"
+                },
+                "requests": {
+                  "cpu": "100m",
+                  "memory": "128M"
+                }
+              }
+            },
+            "oidcInitIdentityManager": {
+              "imageName": "icp-platform-auth",
+              "imageRegistry": "quay.io/opencloudio",
+              "imageTag": "3.6.0",
+              "resources": {
+                "limits": {
+                  "cpu": "200m",
+                  "memory": "256Mi"
+                },
+                "requests": {
+                  "cpu": "100m",
+                  "memory": "128M"
+                }
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "operator.ibm.com/v1alpha1",
+          "kind": "PolicyDecision",
+          "metadata": {
+            "labels": {
+              "app.kubernetes.io/instance": "ibm-iam-operator",
+              "app.kubernetes.io/managed-by": "ibm-iam-operator",
+              "app.kubernetes.io/name": "ibm-iam-operator"
+            },
+            "name": "example-policydecision"
+          },
+          "spec": {
+            "auditService": {
+              "imageName": "audit-syslog-service",
+              "imageRegistry": "quay.io/opencloudio",
+              "imageTag": "1.0.7",
+              "syslogTlsPath": "/etc/audit-tls",
+              "resources": {
+                "limits": {
+                  "cpu": "200m",
+                  "memory": "256Mi"
+                },
+                "requests": {
+                  "cpu": "10m",
+                  "memory": "100Mi"
+                }
+              }
+            },
+            "imageName": "iam-policy-decision",
+            "imageRegistry": "quay.io/opencloudio",
+            "imageTag": "3.6.0",
+            "initMongodb": {
+              "imageName": "icp-platform-auth",
+              "imageRegistry": "quay.io/opencloudio",
+              "imageTag": "3.6.0",
+              "resources": {
+                "limits": {
+                  "cpu": "100m",
+                  "memory": "128Mi"
+                },
+                "requests": {
+                  "cpu": "100m",
+                  "memory": "128Mi"
+                }
+              }
+            },
+            "operatorVersion": "0.14.1",
+            "replicas": 1,
+            "resources": {
+              "limits": {
+                "cpu": "200m",
+                "memory": "256Mi"
+              },
+              "requests": {
+                "cpu": "20m",
+                "memory": "100Mi"
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "operator.ibm.com/v1alpha1",
+          "kind": "Authentication",
+          "metadata": {
+            "labels": {
+              "app.kubernetes.io/instance": "ibm-iam-operator",
+              "app.kubernetes.io/managed-by": "ibm-iam-operator",
+              "app.kubernetes.io/name": "ibm-iam-operator"
+            },
+            "name": "example-authentication"
+          },
+          "spec": {
+            "auditService": {
+              "imageName": "audit-syslog-service",
+              "imageRegistry": "quay.io/opencloudio",
+              "imageTag": "1.0.7",
+              "syslogTlsPath": "/etc/audit-tls",
+              "resources": {
+                "limits": {
+                  "cpu": "100m",
+                  "memory": "128Mi"
+                },
+                "requests": {
+                  "cpu": "10m",
+                  "memory": "100Mi"
+                }
+              }
+            },
+            "authService": {
+              "imageName": "icp-platform-auth",
+              "imageRegistry": "quay.io/opencloudio",
+              "imageTag": "3.6.1",
+              "ldapsCACert": "platform-auth-ldaps-ca-cert",
+              "resources": {
+                "limits": {
+                  "cpu": "1000m",
+                  "memory": "1Gi"
+                },
+                "requests": {
+                  "cpu": "100m",
+                  "memory": "350Mi"
+                }
+              },
+              "routerCertSecret": "route-tls-secret"
+            },
+            "clientRegistration": {
+              "imageName": "icp-platform-auth",
+              "imageRegistry": "quay.io/opencloudio",
+              "imageTag": "3.6.0",
+              "resources": {
+                "limits": {
+                  "cpu": "1000m",
+                  "memory": "1Gi"
+                },
+                "requests": {
+                  "cpu": "100m",
+                  "memory": "128Mi"
+                }
+              }
+            },
+            "config": {
+              "authUniqueHosts": "internal-ip1 internal-ip2 mycluster.icp",
+              "clusterCADomain": "mycluster.icp",
+              "clusterExternalAddress": "10.0.0.1",
+              "clusterInternalAddress": "10.0.0.1",
+              "clusterName": "mycluster",
+              "defaultAdminPassword": "password",
+              "defaultAdminUser": "admin",
+              "enableImpersonation": false,
+              "fipsEnabled": true,
+              "ibmCloudSaas": false,
+              "onPremMultipleDeploy": false,
+              "icpPort": 8443,
+              "installType": "fresh",
+              "isOpenshiftEnv": true,
+              "nonceEnabled": true,
+              "xframeDomain": "",
+              "preferredLogin": "",
+              "bootstrapUserId": "kubeadmin",
+              "providerIssuerURL": "",
+              "claimsSupported": "name,family_name,display_name,given_name,preferred_username",
+              "claimsMap": "name=\"givenName\" family_name=\"givenName\" given_name=\"givenName\" preferred_username=\"displayName\" display_name=\"displayName\"",
+              "scopeClaim": "profile=\"name,family_name,display_name,given_name,preferred_username\"",
+              "oidcIssuerURL": "https://127.0.0.1:443/idauth/oidc/endpoint/OP",
+              "openshiftPort": 443,
+              "roksEnabled": true,
+              "roksURL": "https://roks.domain.name:443",
+              "roksUserPrefix": "changeme",
+              "saasClientRedirectUrl": "",
+              "wlpClientID": "4444be3a738841016ab76d71b650e836",
+              "wlpClientRegistrationSecret": "f1362ca4d20b8389af2d1ea68042c9af",
+              "wlpClientSecret": "aa73bf39752053bf723d1143fb4cf8a2"
+            },
+            "identityManager": {
+              "imageName": "icp-identity-manager",
+              "imageRegistry": "quay.io/opencloudio",
+              "imageTag": "3.6.0",
+              "masterNodesList": "10.0.0.1",
+              "resources": {
+                "limits": {
+                  "cpu": "1000m",
+                  "memory": "1Gi"
+                },
+                "requests": {
+                  "cpu": "50m",
+                  "memory": "150Mi"
+                }
+              }
+            },
+            "identityProvider": {
+              "imageName": "icp-identity-provider",
+              "imageRegistry": "quay.io/opencloudio",
+              "imageTag": "3.6.1",
+              "resources": {
+                "limits": {
+                  "cpu": "1000m",
+                  "memory": "1Gi"
+                },
+                "requests": {
+                  "cpu": "50m",
+                  "memory": "150Mi"
+                }
+              }
+            },
+            "initMongodb": {
+              "imageName": "icp-platform-auth",
+              "imageRegistry": "quay.io/opencloudio",
+              "imageTag": "3.6.0",
+              "resources": {
+                "limits": {
+                  "cpu": "100m",
+                  "memory": "128Mi"
+                },
+                "requests": {
+                  "cpu": "100m",
+                  "memory": "128Mi"
+                }
+              }
+            },
+            "operatorVersion": "0.14.1",
+            "replicas": 1
+          }
+        },
+        {
+          "apiVersion": "operator.ibm.com/v1alpha1",
+          "kind": "Pap",
+          "metadata": {
+            "labels": {
+              "app.kubernetes.io/instance": "ibm-iam-operator",
+              "app.kubernetes.io/managed-by": "ibm-iam-operator",
+              "app.kubernetes.io/name": "ibm-iam-operator"
+            },
+            "name": "example-pap"
+          },
+          "spec": {
+            "auditService": {
+              "imageName": "audit-syslog-service",
+              "imageRegistry": "quay.io/opencloudio",
+              "imageTag": "1.0.7",
+              "syslogTlsPath": "/etc/audit-tls",
+              "resources": {
+                "limits": {
+                  "cpu": "200m",
+                  "memory": "200Mi"
+                },
+                "requests": {
+                  "cpu": "20m",
+                  "memory": "20Mi"
+                }
+              }
+            },
+            "operatorVersion": "0.14.1",
+            "papService": {
+              "imageName": "iam-policy-administration",
+              "imageRegistry": "quay.io/opencloudio",
+              "imageTag": "3.6.0",
+              "resources": {
+                "limits": {
+                  "cpu": "1000m",
+                  "memory": "1Gi"
+                },
+                "requests": {
+                  "cpu": "50m",
+                  "memory": "200Mi"
+                }
+              }
+            },
+            "replicas": 1
+          }
+        },
+        {
+          "apiVersion": "operator.ibm.com/v1alpha1",
+          "kind": "PolicyController",
+          "metadata": {
+            "labels": {
+              "app.kubernetes.io/instance": "ibm-iam-operator",
+              "app.kubernetes.io/managed-by": "ibm-iam-operator",
+              "app.kubernetes.io/name": "ibm-iam-operator"
+            },
+            "name": "policycontroller-deployment"
+          },
+          "spec": {
+            "config": {
+              "excludeOperand": false
+            },
+            "imageRegistry": "quay.io/opencloudio/iam-policy-controller",
+            "imageTagPostfix": "3.6.0",
+            "operatorVersion": "0.14.1",
+            "replicas": 1,
+            "resources": {
+              "limits": {
+                "cpu": "200m",
+                "memory": "384Mi"
+              },
+              "requests": {
+                "cpu": "100m",
+                "memory": "128Mi"
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "operator.ibm.com/v1alpha1",
+          "kind": "SecretWatcher",
+          "metadata": {
+            "labels": {
+              "app.kubernetes.io/instance": "ibm-iam-operator",
+              "app.kubernetes.io/managed-by": "ibm-iam-operator",
+              "app.kubernetes.io/name": "ibm-iam-operator"
+            },
+            "name": "secretwatcher-deployment"
+          },
+          "spec": {
+            "config": {
+              "excludeOperand": false
+            },
+            "imageRegistry": "quay.io/opencloudio/icp-secret-watcher",
+            "imageTagPostfix": "3.6.0",
+            "operatorVersion": "0.14.1",
+            "replicas": 1,
+            "resources": {
+              "limits": {
+                "cpu": "200m",
+                "memory": "512Mi"
+              },
+              "requests": {
+                "cpu": "50m",
+                "memory": "64Mi"
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "operator.ibm.com/v1alpha1",
+          "kind": "SecurityOnboarding",
+          "metadata": {
+            "labels": {
+              "app.kubernetes.io/instance": "ibm-iam-operator",
+              "app.kubernetes.io/managed-by": "ibm-iam-operator",
+              "app.kubernetes.io/name": "ibm-iam-operator"
+            },
+            "name": "example-securityonboarding"
+          },
+          "spec": {
+            "iamOnboarding": {
+              "imageName": "icp-iam-onboarding",
+              "imageRegistry": "quay.io/opencloudio",
+              "imageTag": "3.6.0",
+              "resources": {
+                "limits": {
+                  "cpu": "200m",
+                  "memory": "1024Mi"
+                },
+                "requests": {
+                  "cpu": "20m",
+                  "memory": "64M"
+                }
+              }
+            },
+            "imageName": "icp-iam-onboarding",
+            "imageRegistry": "quay.io/opencloudio",
+            "imageTag": "3.6.0",
+            "impersonation": {
+              "enableImpersonation": false
+            },
+            "initAuthService": {
+              "imageName": "icp-platform-auth",
+              "imageRegistry": "quay.io/opencloudio",
+              "imageTag": "3.6.0",
+              "resources": {
+                "limits": {
+                  "cpu": "200m",
+                  "memory": "256Mi"
+                },
+                "requests": {
+                  "cpu": "100m",
+                  "memory": "128M"
+                }
+              }
+            },
+            "initIdentityManager": {
+              "imageName": "icp-platform-auth",
+              "imageRegistry": "quay.io/opencloudio",
+              "imageTag": "3.6.0",
+              "resources": {
+                "limits": {
+                  "cpu": "200m",
+                  "memory": "256Mi"
+                },
+                "requests": {
+                  "cpu": "100m",
+                  "memory": "128M"
+                }
+              }
+            },
+            "initIdentityProvider": {
+              "imageName": "icp-platform-auth",
+              "imageRegistry": "quay.io/opencloudio",
+              "imageTag": "3.6.0",
+              "resources": {
+                "limits": {
+                  "cpu": "200m",
+                  "memory": "256Mi"
+                },
+                "requests": {
+                  "cpu": "100m",
+                  "memory": "128M"
+                }
+              }
+            },
+            "initPAPSpec": {
+              "imageName": "icp-platform-auth",
+              "imageRegistry": "quay.io/opencloudio",
+              "imageTag": "3.6.0",
+              "resources": {
+                "limits": {
+                  "cpu": "200m",
+                  "memory": "256Mi"
+                },
+                "requests": {
+                  "cpu": "100m",
+                  "memory": "128M"
+                }
+              }
+            },
+            "initTokenService": {
+              "imageName": "icp-platform-auth",
+              "imageRegistry": "quay.io/opencloudio",
+              "imageTag": "3.6.0",
+              "resources": {
+                "limits": {
+                  "cpu": "200m",
+                  "memory": "256Mi"
+                },
+                "requests": {
+                  "cpu": "100m",
+                  "memory": "128M"
+                }
+              }
+            },
+            "operatorVersion": "0.14.1",
+            "replicas": 1,
+            "resources": {
+              "limits": {
+                "cpu": "200m",
+                "memory": "512Mi"
+              },
+              "requests": {
+                "cpu": "20m",
+                "memory": "64Mi"
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "operator.ibm.com/v1alpha1",
+          "kind": "OperandRequest",
+          "metadata": {
+            "name": "ibm-iam-request"
+          },
+          "spec": {
+            "requests": [
+              {
+                "operands": [
+                  {
+                    "name": "ibm-mongodb-operator"
+                  },
+                  {
+                    "name": "ibm-cert-manager-operator"
+                  },
+                  {
+                    "name": "ibm-management-ingress-operator"
+                  },
+                  {
+                    "name": "ibm-ingress-nginx-operator"
+                  }
+                ],
+                "registry": "common-service"
+              }
+            ]
+          }
+        },
+        {
+          "apiVersion": "operator.ibm.com/v1alpha1",
+          "kind": "OperandBindInfo",
+          "metadata": {
+            "name": "ibm-iam-bindinfo"
+          },
+          "spec": {
+            "operand": "ibm-iam-operator",
+            "registry": "common-service",
+            "description": "Binding information that should be accessible to iam adopters",
+            "bindings": {
+              "public-oidc-creds": {
+                "secret": "platform-oidc-credentials"
+              },
+              "public-auth-creds": {
+                "secret" : "platform-auth-idp-credentials"
+              },
+              "public-auth-cert": {
+                "secret" : "platform-auth-secret"
+              },
+              "public-cam-secret": {
+                "secret" : "oauth-client-secret"
+              },
+              "protected-zen-serviceid": {
+                "secret" : "zen-serviceid-apikey-secret"
+              },
+              "public-cam-map": {
+                "configmap" : "oauth-client-map"
+              },
+              "public-auth-config": {
+                "configmap" : "platform-auth-idp"
+              }
+            }
+          }
+        }
+      ]
+    capabilities: Basic Install
+    categories: Security
+    certified: "false"
+    containerImage: quay.io/opencloudio/ibm-iam-operator:latest
+    description: The IAM operator provides a simple Kubernetes CRD-Based API to manage
+      the lifecycle of IAM services. With this operator, you can simply deploy and
+      upgrade the IAM services
+    olm.skipRange: '<3.12.0'
+    repository: https://github.com/IBM/ibm-iam-operator
+    support: IBM
+  labels:
+    operatorframework.io/arch.s390x: supported
+    operatorframework.io/os.linux: supported
+    operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.ppc64le: supported
+  name: ibm-iam-operator.v3.12.0
+  namespace: placeholder
+spec:
+  relatedImages:
+    - name: ibm-iam-operator
+      image: quay.io/opencloudio/ibm-iam-operator:3.12.0
+    - name: icp-platform-auth
+      image: quay.io/opencloudio/icp-platform-auth:3.6.2
+    - name: icp-identity-provider
+      image: quay.io/opencloudio/icp-identity-provider:3.6.2
+    - name: icp-identity-manager
+      image: quay.io/opencloudio/icp-identity-manager:3.6.2
+    - name: iam-policy-administration
+      image: quay.io/opencloudio/iam-policy-administration:3.6.2
+    - name: iam-policy-decision
+      image: quay.io/opencloudio/iam-policy-decision:3.6.2
+    - name: icp-secret-watcher
+      image: quay.io/opencloudio/icp-secret-watcher:3.6.2
+    - name: icp-oidcclient-watcher
+      image: quay.io/opencloudio/icp-oidcclient-watcher:3.6.2
+    - name: iam-policy-controller
+      image: quay.io/opencloudio/iam-policy-controller:3.6.2
+    - name: icp-iam-onboarding
+      image: quay.io/opencloudio/icp-iam-onboarding:3.6.2
+    - name: audit-syslog-service
+      image: quay.io/opencloudio/audit-syslog-service:1.0.8
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: Authentication is the schema for the authentications API. Documentation For additional details regarding install parameters check https://ibm.biz/icpfs39install. License By installing this product you accept the license terms https://ibm.biz/icpfs39license 
+      kind: Authentication
+      name: authentications.operator.ibm.com
+      displayName: Authentication
+      resources:
+        - kind: secrets
+          name: ''
+          version: v1
+        - kind: mutatingwebhookconfigurations
+          name: ''
+          version: v1beta1
+        - kind: paps
+          name: ''
+          version: v1alpha1
+        - kind: clusterroles
+          name: ''
+          version: v1
+        - kind: clusterrolebindings
+          name: ''
+          version: v1
+        - kind: policycontrollers
+          name: ''
+          version: v1alpha1
+        - kind: ingresses
+          name: ''
+          version: v1beta1
+        - kind: securityonboardings
+          name: ''
+          version: v1alpha1
+        - kind: customresourcedefinitions
+          name: ''
+          version: v1beta1
+        - kind: policydecisions
+          name: ''
+          version: v1alpha1
+        - kind: secretwatchers
+          name: ''
+          version: v1alpha1
+        - kind: servicemonitors
+          name: ''
+          version: v1
+        - kind: authentications
+          name: ''
+          version: v1alpha1
+        - kind: Pods
+          name: ''
+          version: v1
+        - kind: statefulsets
+          name: ''
+          version: v1
+        - kind: services
+          name: ''
+          version: v1
+        - kind: persistentvolumeclaims
+          name: ''
+          version: v1
+        - kind: Jobs
+          name: ''
+          version: v1
+        - kind: configmaps
+          name: ''
+          version: v1
+        - kind: certificates
+          name: ''
+          version: v1alpha1
+        - kind: deployments
+          name: ''
+          version: v1
+        - kind: oidcclientwatchers
+          name: ''
+          version: v1alpha1
+        - kind: users
+          name: ''
+          version: v1
+        - kind: replicasets
+          name: ''
+          version: v1
+      specDescriptors:
+      - description: A list defines the catalog information for operators.
+        displayName: Operators
+        path: operators
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: A list defines the catalog information for identity manager.
+        displayName: identityManager
+        path: identityManager
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: A list defines the catalog information for operator version.
+        displayName: OperatorVersion
+        path: operatorVersion
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: A list defines the catalog information for audit service.
+        displayName: AuditService
+        path: auditService
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: A list defines the catalog information for auth service.
+        displayName: authService
+        path: authService
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: A list defines the catalog information for identity provider.
+        displayName: identityProvider
+        path: identityProvider
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: A list defines the catalog information for init mongodb.
+        displayName: initMongodb
+        path: initMongodb
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: A list defines the catalog information for replicas.
+        displayName: Replicas
+        path: replicas
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: A list defines the catalog information for client registration.
+        displayName: ClientRegistration
+        path: clientRegistration
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: A list defines the catalog information for config.
+        displayName: Config
+        path: config
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      statusDescriptors:
+      - description: The status of operators.
+        displayName: Operator Status
+        path: OperatorsStatus
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:podStatuses
+      - description: The status of nodes.
+        displayName: Node Status
+        path: nodes
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:podStatuses
+      version: v1alpha1
+    - description: OIDCClientWatcher is the schema for the oidcclientwatchers API. Documentation For additional details regarding install parameters check https://ibm.biz/icpfs39install. License By installing this product you accept the license terms https://ibm.biz/icpfs39license
+      kind: OIDCClientWatcher
+      name: oidcclientwatchers.operator.ibm.com
+      displayName: OIDCClientWatcher
+      resources:
+        - kind: secrets
+          name: ''
+          version: v1
+        - kind: mutatingwebhookconfigurations
+          name: ''
+          version: v1beta1
+        - kind: clusterroles
+          name: ''
+          version: v1
+        - kind: clusterrolebindings
+          name: ''
+          version: v1
+        - kind: paps
+          name: ''
+          version: v1alpha1
+        - kind: policycontrollers
+          name: ''
+          version: v1alpha1
+        - kind: ingresses
+          name: ''
+          version: v1beta1
+        - kind: securityonboardings
+          name: ''
+          version: v1alpha1
+        - kind: customresourcedefinitions
+          name: ''
+          version: v1beta1
+        - kind: policydecisions
+          name: ''
+          version: v1alpha1
+        - kind: secretwatchers
+          name: ''
+          version: v1alpha1
+        - kind: authentications
+          name: ''
+          version: v1alpha1
+        - kind: Pods
+          name: ''
+          version: v1
+        - kind: statefulsets
+          name: ''
+          version: v1
+        - kind: services
+          name: ''
+          version: v1
+        - kind: persistentvolumeclaims
+          name: ''
+          version: v1
+        - kind: Jobs
+          name: ''
+          version: v1
+        - kind: configmaps
+          name: ''
+          version: v1
+        - kind: certificates
+          name: ''
+          version: v1alpha1
+        - kind: deployments
+          name: ''
+          version: v1
+        - kind: oidcclientwatchers
+          name: ''
+          version: v1alpha1
+        - kind: users
+          name: ''
+          version: v1
+        - kind: replicasets
+          name: ''
+          version: v1
+        - kind: securityonboardings
+          name: ''
+          version: v1alpha1
+        - kind: servicemonitors
+          name: ''
+          version: v1
+      specDescriptors:
+      - description: A list defines the catalog information for operators.
+        displayName: Operators
+        path: operators
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: A list defines the catalog information for image registry.
+        displayName: imageRegistry
+        path: imageRegistry
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: A list defines the catalog information for image tag postfix.
+        displayName: imageTagPostfix
+        path: imageTagPostfix
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: A list defines the catalog information for operator version.
+        displayName: operatorVersion
+        path: operatorVersion
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: A list defines the catalog information for replicas.
+        displayName: Replicas
+        path: replicas
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: A list defines the catalog information for resources.
+        displayName: Resources
+        path: resources
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      statusDescriptors:
+      - description: The status of operators.
+        displayName: Operator Status
+        path: OperatorsStatus
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:podStatuses
+      - description: The status of nodes.
+        displayName: Node Status
+        path: nodes
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:podStatuses
+      version: v1alpha1
+    - description: Pap is the schema for the paps API. Documentation For additional details regarding install parameters check https://ibm.biz/icpfs39install. License By installing this product you accept the license terms https://ibm.biz/icpfs39license
+      kind: Pap
+      name: paps.operator.ibm.com
+      displayName: Pap
+      resources:
+        - kind: secrets
+          name: ''
+          version: v1
+        - kind: paps
+          name: ''
+          version: v1alpha1
+        - kind: policycontrollers
+          name: ''
+          version: v1alpha1
+        - kind: ingresses
+          name: ''
+          version: v1beta1
+        - kind: securityonboardings
+          name: ''
+          version: v1alpha1
+        - kind: customresourcedefinitions
+          name: ''
+          version: v1beta1
+        - kind: policydecisions
+          name: ''
+          version: v1alpha1
+        - kind: secretwatchers
+          name: ''
+          version: v1alpha1
+        - kind: servicemonitors
+          name: ''
+          version: v1
+        - kind: authentications
+          name: ''
+          version: v1alpha1
+        - kind: Pods
+          name: ''
+          version: v1
+        - kind: statefulsets
+          name: ''
+          version: v1
+        - kind: services
+          name: ''
+          version: v1
+        - kind: persistentvolumeclaims
+          name: ''
+          version: v1
+        - kind: Jobs
+          name: ''
+          version: v1
+        - kind: configmaps
+          name: ''
+          version: v1
+        - kind: certificates
+          name: ''
+          version: v1alpha1
+        - kind: deployments
+          name: ''
+          version: v1
+        - kind: oidcclientwatchers
+          name: ''
+          version: v1alpha1
+        - kind: users
+          name: ''
+          version: v1
+        - kind: replicasets
+          name: ''
+          version: v1
+      specDescriptors:
+      - description: A list defines the catalog information for operators.
+        displayName: Operators
+        path: operators
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: A list defines the catalog information for replicas.
+        displayName: Replicas
+        path: replicas
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: A list defines the catalog information for audit service.
+        displayName: AuditService
+        path: auditService
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: A list defines the catalog information for operator version.
+        displayName: OperatorVersion
+        path: operatorVersion
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: A list defines the catalog information for pap service.
+        displayName: PapService
+        path: papService
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      statusDescriptors:
+      - description: The status of operators.
+        displayName: Operator Status
+        path: OperatorsStatus
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:podStatuses
+      - description: The status of nodes.
+        displayName: Node Status
+        path: nodes
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:podStatuses
+      version: v1alpha1
+    - description: PolicyController is the schema for the policycontrollers API. Documentation For additional details regarding install parameters check https://ibm.biz/icpfs39install. License By installing this product you accept the license terms https://ibm.biz/icpfs39license
+      kind: PolicyController
+      name: policycontrollers.operator.ibm.com
+      displayName: PolicyController
+      resources:
+        - kind: secrets
+          name: ''
+          version: v1
+        - kind: clusterroles
+          name: ''
+          version: v1
+        - kind: clusterrolebindings
+          name: ''
+          version: v1
+        - kind: paps
+          name: ''
+          version: v1alpha1
+        - kind: policycontrollers
+          name: ''
+          version: v1alpha1
+        - kind: ingresses
+          name: ''
+          version: v1beta1
+        - kind: securityonboardings
+          name: ''
+          version: v1alpha1
+        - kind: customresourcedefinitions
+          name: ''
+          version: v1beta1
+        - kind: policydecisions
+          name: ''
+          version: v1alpha1
+        - kind: secretwatchers
+          name: ''
+          version: v1alpha1
+        - kind: servicemonitors
+          name: ''
+          version: v1
+        - kind: authentications
+          name: ''
+          version: v1alpha1
+        - kind: Pods
+          name: ''
+          version: v1
+        - kind: statefulsets
+          name: ''
+          version: v1
+        - kind: services
+          name: ''
+          version: v1
+        - kind: persistentvolumeclaims
+          name: ''
+          version: v1
+        - kind: Jobs
+          name: ''
+          version: v1
+        - kind: configmaps
+          name: ''
+          version: v1
+        - kind: certificates
+          name: ''
+          version: v1alpha1
+        - kind: deployments
+          name: ''
+          version: v1
+        - kind: oidcclientwatchers
+          name: ''
+          version: v1alpha1
+        - kind: users
+          name: ''
+          version: v1
+        - kind: replicasets
+          name: ''
+          version: v1
+      specDescriptors:
+      - description: A list defines the catalog information for operators.
+        displayName: Operators
+        path: operators
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: A list defines the catalog information for image registry.
+        displayName: imageRegistry
+        path: imageRegistry
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: A list defines the catalog information for image tag postfix.
+        displayName: imageTagPostfix
+        path: imageTagPostfix
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: A list defines the catalog information for operator version.
+        displayName: operatorVersion
+        path: operatorVersion
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: A list defines the catalog information for replicas.
+        displayName: Replicas
+        path: replicas
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: A list defines the catalog information for resources.
+        displayName: Resources
+        path: resources
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      statusDescriptors:
+      - description: The status of operators.
+        displayName: Operator Status
+        path: OperatorsStatus
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:podStatuses
+      - description: The status of nodes.
+        displayName: Node Status
+        path: nodes
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:podStatuses
+      version: v1alpha1
+    - description: PolicyDecision is the schema for the policydecisions API. Documentation For additional details regarding install parameters check https://ibm.biz/icpfs39install. License By installing this product you accept the license terms https://ibm.biz/icpfs39license
+      kind: PolicyDecision
+      name: policydecisions.operator.ibm.com
+      displayName: PolicyDecision
+      resources:
+        - kind: secrets
+          name: ''
+          version: v1
+        - kind: paps
+          name: ''
+          version: v1alpha1
+        - kind: policycontrollers
+          name: ''
+          version: v1alpha1
+        - kind: ingresses
+          name: ''
+          version: v1beta1
+        - kind: securityonboardings
+          name: ''
+          version: v1alpha1
+        - kind: customresourcedefinitions
+          name: ''
+          version: v1beta1
+        - kind: policydecisions
+          name: ''
+          version: v1alpha1
+        - kind: secretwatchers
+          name: ''
+          version: v1alpha1
+        - kind: servicemonitors
+          name: ''
+          version: v1
+        - kind: authentications
+          name: ''
+          version: v1alpha1
+        - kind: Pods
+          name: ''
+          version: v1
+        - kind: statefulsets
+          name: ''
+          version: v1
+        - kind: services
+          name: ''
+          version: v1
+        - kind: persistentvolumeclaims
+          name: ''
+          version: v1
+        - kind: Jobs
+          name: ''
+          version: v1
+        - kind: configmaps
+          name: ''
+          version: v1
+        - kind: certificates
+          name: ''
+          version: v1alpha1
+        - kind: deployments
+          name: ''
+          version: v1
+        - kind: oidcclientwatchers
+          name: ''
+          version: v1alpha1
+        - kind: users
+          name: ''
+          version: v1
+        - kind: replicasets
+          name: ''
+          version: v1
+      specDescriptors:
+      - description: A list defines the catalog information for operators.
+        displayName: Operators
+        path: operators
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: A list defines the catalog information for image registry.
+        displayName: imageRegistry
+        path: imageRegistry
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: A list defines the catalog information for image tag.
+        displayName: imageTag
+        path: imageTag
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: A list defines the catalog information for resources.
+        displayName: Resources
+        path: resources
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: A list defines the catalog information for init mongodb.
+        displayName: initMongodb
+        path: initMongodb
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: A list defines the catalog information for operator version.
+        displayName: operatorVersion
+        path: operatorVersion
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: A list defines the catalog information for replicas.
+        displayName: replicas
+        path: replicas
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: A list defines the catalog information for audit service.
+        displayName: auditService
+        path: auditService
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: A list defines the catalog information for image name.
+        displayName: imageName
+        path: imageName
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      statusDescriptors:
+      - description: The status of operators.
+        displayName: Operator Status
+        path: OperatorsStatus
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:podStatuses
+      - description: The status of nodes.
+        displayName: Node Status
+        path: nodes
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:podStatuses
+      version: v1alpha1
+    - description: SecretWatcher is the schema for the secretwatchers API. Documentation For additional details regarding install parameters check https://ibm.biz/icpfs39install. License By installing this product you accept the license terms https://ibm.biz/icpfs39license
+      kind: SecretWatcher
+      name: secretwatchers.operator.ibm.com
+      displayName: SecretWatcher
+      resources:
+        - kind: secrets
+          name: ''
+          version: v1
+        - kind: paps
+          name: ''
+          version: v1alpha1
+        - kind: policycontrollers
+          name: ''
+          version: v1alpha1
+        - kind: ingresses
+          name: ''
+          version: v1beta1
+        - kind: securityonboardings
+          name: ''
+          version: v1alpha1
+        - kind: customresourcedefinitions
+          name: ''
+          version: v1beta1
+        - kind: policydecisions
+          name: ''
+          version: v1alpha1
+        - kind: secretwatchers
+          name: ''
+          version: v1alpha1
+        - kind: servicemonitors
+          name: ''
+          version: v1
+        - kind: authentications
+          name: ''
+          version: v1alpha1
+        - kind: Pods
+          name: ''
+          version: v1
+        - kind: statefulsets
+          name: ''
+          version: v1
+        - kind: services
+          name: ''
+          version: v1
+        - kind: persistentvolumeclaims
+          name: ''
+          version: v1
+        - kind: Jobs
+          name: ''
+          version: v1
+        - kind: configmaps
+          name: ''
+          version: v1
+        - kind: certificates
+          name: ''
+          version: v1alpha1
+        - kind: deployments
+          name: ''
+          version: v1
+        - kind: oidcclientwatchers
+          name: ''
+          version: v1alpha1
+        - kind: users
+          name: ''
+          version: v1
+        - kind: replicasets
+          name: ''
+          version: v1
+      specDescriptors:
+      - description: A list defines the catalog information for operators.
+        displayName: Operators
+        path: operators
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: A list defines the catalog information for image registry.
+        displayName: imageRegistry
+        path: imageRegistry
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: A list defines the catalog information for image tag postfix.
+        displayName: imageTagPostfix
+        path: imageTagPostfix
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: A list defines the catalog information for operator version.
+        displayName: operatorVersion
+        path: operatorVersion
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: A list defines the catalog information for replicas.
+        displayName: Replicas
+        path: replicas
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: A list defines the catalog information for resources.
+        displayName: Resources
+        path: resources
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      statusDescriptors:
+      - description: The status of operators.
+        displayName: Operator Status
+        path: OperatorsStatus
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:podStatuses
+      - description: The status of nodes.
+        displayName: Node Status
+        path: nodes
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:podStatuses
+      version: v1alpha1
+    - description: SecurityOnboarding is the schema for the securityonboardings API. Documentation For additional details regarding install parameters check https://ibm.biz/icpfs39install. License By installing this product you accept the license terms https://ibm.biz/icpfs39license
+      kind: SecurityOnboarding
+      name: securityonboardings.operator.ibm.com
+      displayName: SecurityOnboarding
+      resources:
+        - kind: secrets
+          name: ''
+          version: v1
+        - kind: paps
+          name: ''
+          version: v1alpha1
+        - kind: policycontrollers
+          name: ''
+          version: v1alpha1
+        - kind: ingresses
+          name: ''
+          version: v1beta1
+        - kind: securityonboardings
+          name: ''
+          version: v1alpha1
+        - kind: customresourcedefinitions
+          name: ''
+          version: v1beta1
+        - kind: policydecisions
+          name: ''
+          version: v1alpha1
+        - kind: secretwatchers
+          name: ''
+          version: v1alpha1
+        - kind: servicemonitors
+          name: ''
+          version: v1
+        - kind: authentications
+          name: ''
+          version: v1alpha1
+        - kind: Pods
+          name: ''
+          version: v1
+        - kind: statefulsets
+          name: ''
+          version: v1
+        - kind: services
+          name: ''
+          version: v1
+        - kind: persistentvolumeclaims
+          name: ''
+          version: v1
+        - kind: Jobs
+          name: ''
+          version: v1
+        - kind: configmaps
+          name: ''
+          version: v1
+        - kind: certificates
+          name: ''
+          version: v1alpha1
+        - kind: deployments
+          name: ''
+          version: v1
+        - kind: oidcclientwatchers
+          name: ''
+          version: v1alpha1
+        - kind: users
+          name: ''
+          version: v1
+        - kind: replicasets
+          name: ''
+          version: v1
+      specDescriptors:
+      - description: A list defines the catalog information for operators.
+        displayName: Operators
+        path: operators
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: A list defines the catalog information for image name.
+        displayName: imageName
+        path: imageName
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: A list defines the catalog information for impersonation.
+        displayName: impersonation
+        path: impersonation
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: A list defines the catalog information for init identity manager.
+        displayName: initIdentityManager
+        path: initIdentityManager
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: A list defines the catalog information for replicas.
+        displayName: Replicas
+        path: replicas
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: A list defines the catalog information for iam onboarding.
+        displayName: iamOnboarding
+        path: iamOnboarding
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: A list defines the catalog information for image registry.
+        displayName: imageRegistry
+        path: imageRegistry
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: A list defines the catalog information for image tag.
+        displayName: imageTag
+        path: imageTag
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: A list defines the catalog information for resources.
+        displayName: Resources
+        path: resources
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: A list defines the catalog information for init auth service.
+        displayName: initAuthService
+        path: initAuthService
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: A list defines the catalog information for init identity provider.
+        displayName: initIdentityProvider
+        path: initIdentityProvider
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: A list defines the catalog information for init pap spec.
+        displayName: initPAPSpec
+        path: initPAPSpec
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: A list defines the catalog information for init token service.
+        displayName: initTokenService
+        path: initTokenService
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: A list defines the catalog information for operator version.
+        displayName: operatorVersion
+        path: operatorVersion
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      statusDescriptors:
+      - description: The status of operators.
+        displayName: Operator Status
+        path: OperatorsStatus
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:podStatuses'
+      - description: The status of pod names.
+        displayName: PodNames Status
+        path: podNames
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:podStatuses'
+      version: v1alpha1
+  description: |-
+    The `ibm-iam-operator` installs the IBM Cloud Platform Common Services Identity and access management (IAM) service.
+
+    **Important:** Do not install this operator directly. Install this operator only by using the IBM Common Service Operator. For more information about installing this operator and other Common Services operators, see [Installer documentation](http://ibm.biz/cpcs_opinstall). Additionally, you can exit this panel and navigate to the IBM Common Services tile in OperatorHub to learn more about the operator. If you are using the operator as part of an IBM Cloud Pak, see the documentation for that IBM Cloud Pak to learn more about how to install and use the operator service. For more information about IBM Cloud Paks, see [IBM Cloud Paks that use Common Services](http://ibm.biz/cpcs_cloudpaks).
+
+    You can use the `ibm-iam-operator` to install the authentication and authorization services for the IBM Cloud Platform Common Services.
+
+    With these services, you can configure security for IBM Cloud Platform Common Services, IBM Certified Containers (IBM products), or IBM Cloud Paks that are installed.
+
+    For more information about the available IBM Cloud Platform Common Services, see the [IBM Knowledge Center](http://ibm.biz/cpcsdocs).
+
+    ## Supported platforms
+
+     - Red Hat OpenShift Container Platform 4.3 or newer installed on one of the following platforms:
+
+        - Linux x86_64
+        - Linux on Power (ppc64le)
+        - Linux on IBM Z and LinuxONE
+
+    ## Operator versions
+     - 3.12.0
+     - 3.11.2
+     - 3.10.0
+     - 3.9.1
+     - 3.9.0
+     - 3.8.2
+     - 3.8.1
+     - 3.8.0
+     - 3.7.5
+     - 3.7.4
+     - 3.7.3
+     - 3.7.2
+     - 3.7.1
+     - 3.7.0
+     - 3.6.5
+     - 3.6.4
+     - 3.6.3
+     - 3.6.2
+     - 3.6.0
+        - With this version, support for OpenShift 4.3 is added.
+     - 3.5.0
+
+    ## Prerequisites
+
+    Before you install this operator, you need to first install the operator dependencies and prerequisites:
+
+    - For the list of operator dependencies, see the IBM Knowledge Center [Common Services dependencies documentation](http://ibm.biz/cpcs_opdependencies).
+
+    - For the list of prerequisites for installing the operator, see the IBM Knowledge Center [Preparing to install services documentation](http://ibm.biz/cpcs_opinstprereq).
+
+    ## Documentation
+
+    To install the operator by using the IBM Common Services Operator, follow the installation and configuration instructions that are in the IBM Knowledge Center.
+
+    - If you are using the operator as part of an IBM Cloud Pak, see the documentation for that IBM Cloud Pak [IBM Cloud Paks that use Common Services](http://ibm.biz/cpcs_cloudpaks).
+    - If you are using the operator with an IBM Containerized Software, see the IBM Cloud Platform Common Services Knowledge Center [Installer documentation](http://ibm.biz/cpcs_opinstall).
+  displayName: IBM IAM Operator
+  icon:
+  - base64data: "iVBORw0KGgoAAAANSUhEUgAAAK8AAACvCAMAAAC8TH5HAAAABGdBTUEAALGPC/xhBQAAAAFzUkdCAK7OHOkAAAB1UExURQAAAJGS77CC4pCS75yM64uV8pSQ7puA85OV87OB4auF5Hyd+H2c936b9n6b94Ca9n+b9n+b9n+b9qOJ56SI55yM6qSI536b96aH5q2D45mN64OZ9ZWQ7oyU8XWg+6uG5oqg/p6L6m+k/ZuY+3mr/6qQ9LqM80D8C0oAAAAbdFJOUwA67R4KKxMBBP6ak6vZgVtJxG5ot+hQ7YDVkwC2C58AAAuSSURBVHja7ZyJerK8EoCDCSTKjoiIS13of/+XeGYm4NLKrvj1OYxt7aa8TiazJZGxSSaZZJJJJvmcSCn/Eq7Cz79DLJk0rb+kXdM9nz0m/4p2mZufz3lAZvEn1HsGye2J9128h7/Gezj8Nd7D3+I9/xu8SjWHrS76bfN8A+NsYxjowCvbPN+QSGB6kWi6QHteyQLPfx+wYsH2eHSthgu05lXMy/PceRcwxtnjdnts4mjLq5hBceVdcVsya71FMeov0JIXMuQwR+DoXX5EMgf0uz2GrDYbb8mrmE+4Z/NdvDCApN+jX3uFdrySqfW70wzFbFLwWtVNkXa8ONlIvfx9Dk0xSyvYq0NpxasYJ9o8emcUVCw6EjGvuUpLXgfVm9cP1fAZp1yyCKeGBf8pB96g9jUZ57c6s1vIIAUfjXqY9eFg1yiuKJnOECzeW+TJm0+rxRGGWfcP7/dld8bZwqcp/dJqIs9hrJIJ/JD2abV5j1StfJn1/pofo/Kx0ae1KfAO7/Vld7anfVpf28M5kKPDc9kYLRW4RDhIwYV/PozVUAF39Qre3BmrvsM04nisjHHyJlUjZEOefuBj8UIA81zHfGJ84BYeHAP9LKseP1r5LNnvOlHeXJgqRZbUPzT97PHvBVb48VCX09W54du2u3ZJwjD0It/gqmCue/yoolm4b7tQjmohh7cGAWzHC8x/qOFOZmBG4bbERDkQrVYyiGP7iPwPLGrgsAofYbePonEJ2CHxAuvjxEjLvfUj7J1BaP0irY3i888SA63l3alWgwKjbXueZztOSBoucOE33huIZdsWHChXRds72O069PyHhSEBDiOynbAEBiGreCGJKoa5zT8GVBzt4QNgXc+wbq4YvW+hSMkDYNa4EYihWqlYtmouSsYTo4XvgWezHKDcI+7xuPbMMp7JH0GEfhZGRMDIG5FRtLG1IGCNvTp/d9nFZhMx/DXYH/cgSBv6SscM+Tyf0P450Lw+iCmbOGAMonOeO/XlMyTjgAsfmWAN9Y53RFy0hDAovXBDSBFBVAIHDdUJ2lre3J6AVG9Hcln5NQyKCUcrd390g5/BtjpNR2KNGwTVpRDSmk6et6jwCv0ScVhpxopxl3DBIjzVjrYk5gVuEPAaw7UP+aFV+0ex5Aq8y/hTYhiE/UXjhibrlBUisUm8hmHwqujuH3IqQLA/0dT+Af8Q34hT8du3QXlR4nrdkxhJ0554nwAXhpvj+hLUo2u/zWoJM1aXy70ZP8e97APWJ+WGbN1AXNP8tedAasM96PLu4Ik2jhpHZLkqgdGM5TNjuKzNnhkiUmneH8CSCe9wpXV429HDlCu7GcV9JwemWoEbWr3rGZx2iMs5F4+T3S1p89DoYGvkUeLCKC67m+uBsVwVuGpI+QVohGtZ6rHrU+Cu/UaP/ps4KY3iWhlipwNwd4Arh1WLCIy4lpA/2yiF4XZ9ehgMuaRgt7r6FMWiC9DuL64YWtyCrQKuEOLe1iJsG+eO2W8eo+POdrvVtdULrgG0Dbg76xW1uCDcm5GCguzDAeNlz0qPqgfzGunJeAl4aOug6KYQ7l2WhI7DZEMqZ7L5a1uBZWTQF3/QVHvmUosOBX0ZVkbfkgNtDYCbDcDVsIKbQYCJBCY/gak7FHQh+bqiX7LwsnuYfr1gqUTCUsPWgsWdF1H2I1/ZoYBMSLs3o3/blyke+FRiEPE9c1Huq9dpV60GWQNmvybSIrCnee0SGIlDJzJfVzwrttTq7bfkUNCSzV71a19pScNOGHrmi9pWV/Uue6lXYpEcBFfgslSOPG0MBTASc/YK3455PEqvyYY5r0G4AeH6gWHqSCyVxQ2s9ksJw9B/ATBYVUy8fdRL6ZhhlPo1HpIyHelM38OmCuA6oWvzwTah69DTbiW6qxdMCdPdAIGLbrC8lyIimxHRgrhQcA+cdoqluxXc0u7qhcTGNBAYeKkB9CTASfJjVuTo7mvoRsO676Ci+LRanVbd91YgLggp2GI1/kpRq7MAXnuDjBhC8Qpkl3UepwIXgblseDQq2XBcUK8bru0hGgbni7ynzrMNs1xOuJDmNQMAsfAI2B0CjOaAvKuuK2aES8C8XU8Sn98H9SKw12/SwfwVzNyArOLOL1lxEpO37/lKFujlpW3UfTSZwpxaQCkXb+JVd3OAAg1xrQ4vFGzC0MDrbuvLSGtRiSVYuonjeNU5MxMWAVudZzct1azdLmUXzGZLV7BCySxG6Zrq4MsFXqv79A7WiLu1OwwLFgElr7VA3LQjLtZnCCx7+KNo7a4BuG3lhRmKWXQ0LME40Gbxsqt6BQH3arExZ+viCl67Ib1rGHFLQPIQL7JFnHTjRfUCb68whR1mXM3dttpjcWvIAS6uNCRxlmVxxypeCVJw3wjl0/LzmrfaVG4kBgFT6ge57wJ4M7OTfmlNS4j+McpB4G2rTfBGkhAwp2UcWfB2cw/FFogBKQvxrhtTLMnMZYJiFG4eeLM0zVLRg3dIzmJvAbfRgiXjS81rXfeBLIE3TTuVQneZeH8Fb4HXFQ0rcGKJcsNFXsRdduYdViSQBQNy0LCilaSIu+R3TeqP8KKLQAXXzjgw3hR5l3erFvoldOOVr9Cv5eK6v1tzXch0UZfLNGEPvGQi3fU7tMi1m45PgCtb4Nin974Lftmd9yUtJZ94q/NgUG9KvA9rWOjgwKATMTqv3mpcbcDgQxaLRbpYyp+89/5tLMF98GTAVZsP4LfpAuXRYnALBwof+0AxejR0EVVpO4ARbvpz96D1GV7FvNoJB4lNDLiQOKofIQSTicQcnzeq5ZUsxTpi8ctQJeVrJmNj8wbEWxHhYNxjXff8UiT1vww1Oq9R59Dgz1gGb5Kff5a62jA/4tD222Ml75J4zd+8uglmfcQB76s2nktsM2w2z8p2yamWG90eTNrd9ly/ALnAtlP8LO5a1FdSo9sv7h3cVvGqGHkXT9Sr+3ZcjO4faNNYUMErkHf2tIeuqBNhjc0bHXEDoVHBa20qeRm1liw1Mq9H29z68Ard+hs7f0BzWD/3S8g7q+TV3RohR8VVLqq34pgR2G8NL9O8alx3Rrvy7Cr3q2LkXTyPClrBY55JgPqCthFGVbxsgbxxRd2jxKCGTS/zpelW0beD8pB4NxVhVw7t2HSvj0m9lfUx5A/zzWw2q0yPHzYHjWEOuDXvWLnhAtL1Gah3XrWsImkL/WjAkoX7au+r00bQ7my+qFr4ekETpFvyUGsOKOAgZrNNZaE2InCx9XF/qVmFQwNGBVevs42n31K9+5oqFxw0GURc22UayXjBenHrY1Z7UJ/FpOCkRsFjWe+SNsLuef2xCm0QMfvwe60pxnGf5v7iNTR/xWZWb8GjWcOFgBtK3FLBM+uTCpatd5aigue1Pngs4yVcp8VphmT+YYuQGIhxm/Fu37w+j0mPBk4+BIy4ett8q52lGJTneJsbHwHGwx/FQYp2Q6wtogCWH8DNLtdt0S1Pi6RICx8JG1nFCluOV9yWLgrrjAI4HfVQNtYu5emw9ri0EyZGWpCNORYxvVuAGZeHgLIuEVZB5UnAqGLryfsLvDx31Gfa6czSSW+D7XRFVZgEyizlRfEm3yJFSaiM+HQ5Ee5ll3SNVgCczkvi+SJ5c+PMMtIV0BLu6RL32P8Lry8pcVHJcZoYlniDcCNJ49Xp+/uk5QK20PP0kLWYP8qsg2zuvl/VyAlQS1bQ7SnjfQ814O7WeF4jX/P/5l//fT2V77svePeNd/gFNam/FN/eZPd9io0B/ojOwMWVsA8/wO1RZvc/nOgTbqfi7okAfDbUe+KDjcVsPq9X81eJPK/g/So476kfWUG1S6vjmcIqYpGkGwT7r4t8FfffdIP7ajmdNlnC2Qto2fWNtixjudRr4a+VLF0uTa4vJF8XKuXbg/Hr33TjffKn3gp/kkkmmWSSSSaZZJJJJplkkkkmmWSS/yf5H6HANgUotAMHAAAAAElFTkSuQmCC"
+    mediatype: "image/png"
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          #the namespaces are being watched by the oidcclientwatcher
+          - namespaces
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        # used in identity manager
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterroles
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+          - escalate
+          - bind
+        - apiGroups:
+          - authorization.openshift.io
+          resources:
+          - clusterrolebindings
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        # Used by oidcclient-watcher
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterrolebindings
+          - clusterrolebindings/finalizers
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        # fetch users call is used in identity manager
+        - apiGroups:
+          - user.openshift.io
+          resources:
+          - users
+          - groups
+          - identities
+          verbs:
+          - create
+          - get
+          - list
+          - patch
+          - update
+          - watch
+          - delete
+        # token allocation is used in identity provider
+        - apiGroups:
+          - oauth.openshift.io
+          resources:
+          - oauthaccesstokens
+          - oauthclients
+          verbs:
+          - create
+          - get
+          - list
+          - patch
+          - update
+          - watch
+          - delete
+        # this is used by iam poliy controller
+        - apiGroups:
+          - iam.policies.ibm.com
+          resources:
+          - iampolicies
+          verbs:
+          - create
+          - get
+          - list
+          - patch
+          - update
+          - watch
+          - delete
+        serviceAccountName: ibm-iam-operand-restricted
+      - rules:
+        - apiGroups:
+          - admissionregistration.k8s.io
+          resources:
+          - mutatingwebhookconfigurations
+          #iam.hooks.securityenforcement.admission.cloud.ibm.com used by oidcclient-watcher
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+          # Investigate further whether we can avoid the creation of clusteroles and clusterrolbeindings
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterroles
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+          - escalate
+          - bind
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterrolebindings
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - user.openshift.io
+          resources:
+          - users
+          # The default admin user has to be created
+          verbs:
+          - create
+          - get
+          - list
+          - patch
+          - update
+          - watch
+          - delete
+        serviceAccountName: ibm-iam-operator
+      deployments:
+      - name: ibm-iam-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: ibm-iam-operator
+          strategy: {}
+          template:
+            metadata:
+              annotations:
+                productID: 068a62892a1e4db39641342e592daa25
+                productMetric: FREE
+                productName: IBM Cloud Platform Common Services
+              labels:
+                app.kubernetes.io/instance: ibm-iam-operator
+                app.kubernetes.io/managed-by: ibm-iam-operator
+                app.kubernetes.io/name: ibm-iam-operator
+                name: ibm-iam-operator
+            spec:
+              affinity:
+                nodeAffinity:
+                  requiredDuringSchedulingIgnoredDuringExecution:
+                    nodeSelectorTerms:
+                    - matchExpressions:
+                      - key: kubernetes.io/arch
+                        operator: In
+                        values:
+                        - amd64
+                        - ppc64le
+                        - s390x
+              containers:
+              - command:
+                - ibm-iam-operator
+                env:
+                - name: ICP_PLATFORM_AUTH_IMAGE
+                  value: quay.io/opencloudio/icp-platform-auth:3.6.2
+                - name: ICP_IDENTITY_PROVIDER_IMAGE
+                  value: quay.io/opencloudio/icp-identity-provider:3.6.2
+                - name: ICP_IDENTITY_MANAGER_IMAGE
+                  value: quay.io/opencloudio/icp-identity-manager:3.6.2
+                - name: IAM_POLICY_ADMINISTRATION_IMAGE
+                  value: quay.io/opencloudio/iam-policy-administration:3.6.2
+                - name: IAM_POLICY_DECISION_IMAGE
+                  value: quay.io/opencloudio/iam-policy-decision:3.6.2
+                - name: ICP_SECRET_WATCHER_IMAGE
+                  value: quay.io/opencloudio/icp-secret-watcher:3.6.2
+                - name: ICP_OIDCCLIENT_WATCHER_IMAGE
+                  value: quay.io/opencloudio/icp-oidcclient-watcher:3.6.2
+                - name: IAM_POLICY_CONTROLLER_IMAGE
+                  value: quay.io/opencloudio/iam-policy-controller:3.6.2
+                - name: ICP_IAM_ONBOARDING_IMAGE
+                  value: quay.io/opencloudio/icp-iam-onboarding:3.6.2
+                - name: AUDIT_SYSLOG_SERVICE_IMAGE
+                  value: quay.io/opencloudio/audit-syslog-service:1.0.8
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: ibm-iam-operator
+                image: quay.io/opencloudio/ibm-iam-operator:latest
+                imagePullPolicy: Always
+                name: ibm-iam-operator
+                resources:
+                  limits:
+                    cpu: 25m
+                    memory: 320Mi
+                  requests:
+                    cpu: 10m
+                    memory: 80Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
+                  privileged: false
+                  readOnlyRootFilesystem: true
+              serviceAccountName: ibm-iam-operator
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          - services/finalizers
+          - endpoints
+          - persistentvolumeclaims
+          - events
+          - configmaps
+          - secrets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          - replicasets
+          - statefulsets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        # used by oidcclient watcher
+        - apiGroups:
+          - oidc.security.ibm.com
+          resources:
+          - clients
+          - clients/finalizers
+          - clients/status
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - roles
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - rolebindings
+          - rolebindings/finalizers
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        # this is used by iam poliy controller
+        - apiGroups:
+          - iam.policies.ibm.com
+          resources:
+          - iampolicies
+          verbs:
+          - create
+          - get
+          - list
+          - patch
+          - update
+          - watch
+          - delete
+        # this is used by identity provider to create/delete rolebinding for zen user
+        - apiGroups:
+          - authorization.openshift.io
+          resources:
+          - rolebindings
+          - rolebindings/finalizers
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        serviceAccountName: ibm-iam-operand-restricted
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          - services/finalizers
+          - endpoints
+          - persistentvolumeclaims
+          - events
+          - configmaps
+          - secrets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          - replicasets
+          - statefulsets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - get
+          - create
+        - apiGroups:
+          - apps
+          resourceNames:
+          - ibm-iam-operator
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - get
+        - apiGroups:
+          - apps
+          resources:
+          - replicasets
+          - deployments
+          verbs:
+          - get
+        - apiGroups:
+          - operator.ibm.com
+          resources:
+          - '*'
+          - policydecisions
+          - oidcclientwatchers
+          - authentications
+          - policycontrollers
+          - paps
+          - securityonboardings
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - certmanager.k8s.io
+          resources:
+          - '*'
+          - certificates
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - networking.k8s.io
+          resources:
+          - '*'
+          - ingresses
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - batch
+          resources:
+          - jobs
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        serviceAccountName: ibm-iam-operator
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - IBM
+  - Cloud
+  maintainers:
+  - email: support@ibm.com
+    name: IBM Support
+  maturity: stable
+  minKubeVersion: 1.19.0
+  provider:
+    name: IBM
+  replaces: ibm-iam-operator.v3.11.2
+  version: 3.12.0

--- a/deploy/olm-catalog/ibm-iam-operator/3.12.0/ibm-iam-operator.v3.12.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-iam-operator/3.12.0/ibm-iam-operator.v3.12.0.clusterserviceversion.yaml
@@ -17,7 +17,7 @@ metadata:
           },
           "spec": {
             "imageRegistry": "quay.io/opencloudio/icp-oidcclient-watcher",
-            "imageTagPostfix": "3.6.0",
+            "imageTagPostfix": "3.7.0",
             "operatorVersion": "0.14.1",
             "replicas": 1,
             "resources": {
@@ -33,7 +33,7 @@ metadata:
             "oidcInitAuthService": {
               "imageName": "icp-platform-auth",
               "imageRegistry": "quay.io/opencloudio",
-              "imageTag": "3.6.0",
+              "imageTag": "3.7.0",
               "resources": {
                 "limits": {
                   "cpu": "200m",
@@ -48,7 +48,7 @@ metadata:
             "oidcInitIdentityProvider": {
               "imageName": "icp-platform-auth",
               "imageRegistry": "quay.io/opencloudio",
-              "imageTag": "3.6.0",
+              "imageTag": "3.7.0",
               "resources": {
                 "limits": {
                   "cpu": "200m",
@@ -63,7 +63,7 @@ metadata:
             "oidcInitIdentityManager": {
               "imageName": "icp-platform-auth",
               "imageRegistry": "quay.io/opencloudio",
-              "imageTag": "3.6.0",
+              "imageTag": "3.7.0",
               "resources": {
                 "limits": {
                   "cpu": "200m",
@@ -92,7 +92,7 @@ metadata:
             "auditService": {
               "imageName": "audit-syslog-service",
               "imageRegistry": "quay.io/opencloudio",
-              "imageTag": "1.0.7",
+              "imageTag": "1.0.8",
               "syslogTlsPath": "/etc/audit-tls",
               "resources": {
                 "limits": {
@@ -107,11 +107,11 @@ metadata:
             },
             "imageName": "iam-policy-decision",
             "imageRegistry": "quay.io/opencloudio",
-            "imageTag": "3.6.0",
+            "imageTag": "3.7.0",
             "initMongodb": {
               "imageName": "icp-platform-auth",
               "imageRegistry": "quay.io/opencloudio",
-              "imageTag": "3.6.0",
+              "imageTag": "3.7.0",
               "resources": {
                 "limits": {
                   "cpu": "100m",
@@ -152,7 +152,7 @@ metadata:
             "auditService": {
               "imageName": "audit-syslog-service",
               "imageRegistry": "quay.io/opencloudio",
-              "imageTag": "1.0.7",
+              "imageTag": "1.0.8",
               "syslogTlsPath": "/etc/audit-tls",
               "resources": {
                 "limits": {
@@ -168,7 +168,7 @@ metadata:
             "authService": {
               "imageName": "icp-platform-auth",
               "imageRegistry": "quay.io/opencloudio",
-              "imageTag": "3.6.1",
+              "imageTag": "3.7.0",
               "ldapsCACert": "platform-auth-ldaps-ca-cert",
               "resources": {
                 "limits": {
@@ -185,7 +185,7 @@ metadata:
             "clientRegistration": {
               "imageName": "icp-platform-auth",
               "imageRegistry": "quay.io/opencloudio",
-              "imageTag": "3.6.0",
+              "imageTag": "3.7.0",
               "resources": {
                 "limits": {
                   "cpu": "1000m",
@@ -233,7 +233,7 @@ metadata:
             "identityManager": {
               "imageName": "icp-identity-manager",
               "imageRegistry": "quay.io/opencloudio",
-              "imageTag": "3.6.0",
+              "imageTag": "3.7.0",
               "masterNodesList": "10.0.0.1",
               "resources": {
                 "limits": {
@@ -249,7 +249,7 @@ metadata:
             "identityProvider": {
               "imageName": "icp-identity-provider",
               "imageRegistry": "quay.io/opencloudio",
-              "imageTag": "3.6.1",
+              "imageTag": "3.7.0",
               "resources": {
                 "limits": {
                   "cpu": "1000m",
@@ -264,7 +264,7 @@ metadata:
             "initMongodb": {
               "imageName": "icp-platform-auth",
               "imageRegistry": "quay.io/opencloudio",
-              "imageTag": "3.6.0",
+              "imageTag": "3.7.0",
               "resources": {
                 "limits": {
                   "cpu": "100m",
@@ -295,7 +295,7 @@ metadata:
             "auditService": {
               "imageName": "audit-syslog-service",
               "imageRegistry": "quay.io/opencloudio",
-              "imageTag": "1.0.7",
+              "imageTag": "1.0.8",
               "syslogTlsPath": "/etc/audit-tls",
               "resources": {
                 "limits": {
@@ -312,7 +312,7 @@ metadata:
             "papService": {
               "imageName": "iam-policy-administration",
               "imageRegistry": "quay.io/opencloudio",
-              "imageTag": "3.6.0",
+              "imageTag": "3.7.0",
               "resources": {
                 "limits": {
                   "cpu": "1000m",
@@ -343,7 +343,7 @@ metadata:
               "excludeOperand": false
             },
             "imageRegistry": "quay.io/opencloudio/iam-policy-controller",
-            "imageTagPostfix": "3.6.0",
+            "imageTagPostfix": "3.7.0",
             "operatorVersion": "0.14.1",
             "replicas": 1,
             "resources": {
@@ -374,7 +374,7 @@ metadata:
               "excludeOperand": false
             },
             "imageRegistry": "quay.io/opencloudio/icp-secret-watcher",
-            "imageTagPostfix": "3.6.0",
+            "imageTagPostfix": "3.7.0",
             "operatorVersion": "0.14.1",
             "replicas": 1,
             "resources": {
@@ -404,7 +404,7 @@ metadata:
             "iamOnboarding": {
               "imageName": "icp-iam-onboarding",
               "imageRegistry": "quay.io/opencloudio",
-              "imageTag": "3.6.0",
+              "imageTag": "3.7.0",
               "resources": {
                 "limits": {
                   "cpu": "200m",
@@ -418,14 +418,14 @@ metadata:
             },
             "imageName": "icp-iam-onboarding",
             "imageRegistry": "quay.io/opencloudio",
-            "imageTag": "3.6.0",
+            "imageTag": "3.7.0",
             "impersonation": {
               "enableImpersonation": false
             },
             "initAuthService": {
               "imageName": "icp-platform-auth",
               "imageRegistry": "quay.io/opencloudio",
-              "imageTag": "3.6.0",
+              "imageTag": "3.7.0",
               "resources": {
                 "limits": {
                   "cpu": "200m",
@@ -440,7 +440,7 @@ metadata:
             "initIdentityManager": {
               "imageName": "icp-platform-auth",
               "imageRegistry": "quay.io/opencloudio",
-              "imageTag": "3.6.0",
+              "imageTag": "3.7.0",
               "resources": {
                 "limits": {
                   "cpu": "200m",
@@ -455,7 +455,7 @@ metadata:
             "initIdentityProvider": {
               "imageName": "icp-platform-auth",
               "imageRegistry": "quay.io/opencloudio",
-              "imageTag": "3.6.0",
+              "imageTag": "3.7.0",
               "resources": {
                 "limits": {
                   "cpu": "200m",
@@ -470,7 +470,7 @@ metadata:
             "initPAPSpec": {
               "imageName": "icp-platform-auth",
               "imageRegistry": "quay.io/opencloudio",
-              "imageTag": "3.6.0",
+              "imageTag": "3.7.0",
               "resources": {
                 "limits": {
                   "cpu": "200m",
@@ -485,7 +485,7 @@ metadata:
             "initTokenService": {
               "imageName": "icp-platform-auth",
               "imageRegistry": "quay.io/opencloudio",
-              "imageTag": "3.6.0",
+              "imageTag": "3.7.0",
               "resources": {
                 "limits": {
                   "cpu": "200m",
@@ -597,23 +597,23 @@ spec:
     - name: ibm-iam-operator
       image: quay.io/opencloudio/ibm-iam-operator:3.12.0
     - name: icp-platform-auth
-      image: quay.io/opencloudio/icp-platform-auth:3.6.2
+      image: quay.io/opencloudio/icp-platform-auth:3.7.0
     - name: icp-identity-provider
-      image: quay.io/opencloudio/icp-identity-provider:3.6.2
+      image: quay.io/opencloudio/icp-identity-provider:3.7.0
     - name: icp-identity-manager
-      image: quay.io/opencloudio/icp-identity-manager:3.6.2
+      image: quay.io/opencloudio/icp-identity-manager:3.7.0
     - name: iam-policy-administration
-      image: quay.io/opencloudio/iam-policy-administration:3.6.2
+      image: quay.io/opencloudio/iam-policy-administration:3.7.0
     - name: iam-policy-decision
-      image: quay.io/opencloudio/iam-policy-decision:3.6.2
+      image: quay.io/opencloudio/iam-policy-decision:3.7.0
     - name: icp-secret-watcher
-      image: quay.io/opencloudio/icp-secret-watcher:3.6.2
+      image: quay.io/opencloudio/icp-secret-watcher:3.7.0
     - name: icp-oidcclient-watcher
-      image: quay.io/opencloudio/icp-oidcclient-watcher:3.6.2
+      image: quay.io/opencloudio/icp-oidcclient-watcher:3.7.0
     - name: iam-policy-controller
-      image: quay.io/opencloudio/iam-policy-controller:3.6.2
+      image: quay.io/opencloudio/iam-policy-controller:3.7.0
     - name: icp-iam-onboarding
-      image: quay.io/opencloudio/icp-iam-onboarding:3.6.2
+      image: quay.io/opencloudio/icp-iam-onboarding:3.7.0
     - name: audit-syslog-service
       image: quay.io/opencloudio/audit-syslog-service:1.0.8
   apiservicedefinitions: {}

--- a/deploy/olm-catalog/ibm-iam-operator/3.12.0/oidc_v1_client_crd.yaml
+++ b/deploy/olm-catalog/ibm-iam-operator/3.12.0/oidc_v1_client_crd.yaml
@@ -1,0 +1,52 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    app.kubernetes.io/instance: ibm-iam-operator
+    app.kubernetes.io/managed-by: ibm-iam-operator
+    app.kubernetes.io/name: ibm-iam-operator
+  name: clients.oidc.security.ibm.com
+spec:
+  conversion:
+    strategy: None
+  group: oidc.security.ibm.com
+  names:
+    kind: Client
+    listKind: ClientList
+    plural: clients
+    singular: client
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            x-kubernetes-preserve-unknown-fields: true
+            type: object
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: Client
+    listKind: ClientList
+    plural: clients
+    singular: client
+  conditions: []
+  storedVersions:
+  - v1

--- a/deploy/olm-catalog/ibm-iam-operator/3.12.0/operator.ibm.com_authentications_crd.yaml
+++ b/deploy/olm-catalog/ibm-iam-operator/3.12.0/operator.ibm.com_authentications_crd.yaml
@@ -1,0 +1,418 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: authentications.operator.ibm.com
+  labels:
+    app.kubernetes.io/instance: ibm-iam-operator
+    app.kubernetes.io/managed-by: ibm-iam-operator
+    app.kubernetes.io/name: ibm-iam-operator
+spec:
+  group: operator.ibm.com
+  names:
+    kind: Authentication
+    listKind: AuthenticationList
+    plural: authentications
+    singular: authentication
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Authentication is the Schema for the authentications API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: AuthenticationSpec defines the desired state of Authentication
+            properties:
+              auditService:
+                properties:
+                  imageName:
+                    type: string
+                  imageRegistry:
+                    type: string
+                  imageTag:
+                    type: string
+                  resources:
+                    description: ResourceRequirements describes the compute resource
+                      requirements.
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                    type: object
+                  syslogTlsPath:
+                    type: string
+                required:
+                - imageName
+                - imageRegistry
+                - imageTag
+                type: object
+              authService:
+                properties:
+                  imageName:
+                    type: string
+                  imageRegistry:
+                    type: string
+                  imageTag:
+                    type: string
+                  ldapsCACert:
+                    type: string
+                  resources:
+                    description: ResourceRequirements describes the compute resource
+                      requirements.
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                    type: object
+                  routerCertSecret:
+                    type: string
+                required:
+                - imageName
+                - imageRegistry
+                - imageTag
+                - ldapsCACert
+                - routerCertSecret
+                type: object
+              clientRegistration:
+                properties:
+                  imageName:
+                    type: string
+                  imageRegistry:
+                    type: string
+                  imageTag:
+                    type: string
+                  resources:
+                    description: ResourceRequirements describes the compute resource
+                      requirements.
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                    type: object
+                required:
+                - imageName
+                - imageRegistry
+                - imageTag
+                type: object
+              config:
+                properties:
+                  authUniqueHosts:
+                    type: string
+                  bootstrapUserId:
+                    type: string
+                  claimsMap:
+                    type: string
+                  claimsSupported:
+                    type: string
+                  clusterCADomain:
+                    type: string
+                  clusterExternalAddress:
+                    type: string
+                  clusterInternalAddress:
+                    type: string
+                  clusterName:
+                    type: string
+                  defaultAdminPassword:
+                    type: string
+                  defaultAdminUser:
+                    type: string
+                  enableImpersonation:
+                    type: boolean
+                  fipsEnabled:
+                    type: boolean
+                  onPremMultipleDeploy:
+                    type: boolean  
+                  ibmCloudSaas:
+                    type: boolean
+                  icpPort:
+                    format: int32
+                    type: integer
+                  installType:
+                    type: string
+                  isOpenshiftEnv:
+                    type: boolean
+                  nonceEnabled:
+                    type: boolean
+                  oidcIssuerURL:
+                    type: string
+                  openshiftPort:
+                    format: int32
+                    type: integer
+                  preferredLogin:
+                    type: string
+                  providerIssuerURL:
+                    type: string
+                  roksEnabled:
+                    type: boolean
+                  roksURL:
+                    type: string
+                  roksUserPrefix:
+                    type: string
+                  saasClientRedirectUrl:
+                    type: string
+                  scopeClaim:
+                    type: string
+                  wlpClientID:
+                    type: string
+                  wlpClientRegistrationSecret:
+                    type: string
+                  wlpClientSecret:
+                    type: string
+                  xframeDomain:
+                    type: string
+                  attrMappingFromConfig:
+                    type: boolean
+                required:
+                - authUniqueHosts
+                - clusterCADomain
+                - clusterExternalAddress
+                - clusterInternalAddress
+                - clusterName
+                - defaultAdminPassword
+                - defaultAdminUser
+                - enableImpersonation
+                - fipsEnabled
+                - icpPort
+                - installType
+                - isOpenshiftEnv
+                - nonceEnabled
+                - oidcIssuerURL
+                - openshiftPort
+                - roksEnabled
+                - roksURL
+                - roksUserPrefix
+                - wlpClientID
+                - wlpClientRegistrationSecret
+                - wlpClientSecret
+                type: object
+              identityManager:
+                properties:
+                  imageName:
+                    type: string
+                  imageRegistry:
+                    type: string
+                  imageTag:
+                    type: string
+                  masterNodesList:
+                    type: string
+                  resources:
+                    description: ResourceRequirements describes the compute resource
+                      requirements.
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                    type: object
+                required:
+                - imageName
+                - imageRegistry
+                - imageTag
+                - masterNodesList
+                type: object
+              identityProvider:
+                properties:
+                  imageName:
+                    type: string
+                  imageRegistry:
+                    type: string
+                  imageTag:
+                    type: string
+                  resources:
+                    description: ResourceRequirements describes the compute resource
+                      requirements.
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                    type: object
+                required:
+                - imageName
+                - imageRegistry
+                - imageTag
+                type: object
+              initMongodb:
+                properties:
+                  imageName:
+                    type: string
+                  imageRegistry:
+                    type: string
+                  imageTag:
+                    type: string
+                  resources:
+                    description: ResourceRequirements describes the compute resource
+                      requirements.
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                    type: object
+                required:
+                - imageName
+                - imageRegistry
+                - imageTag
+                type: object
+              operatorVersion:
+                description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
+                  Important: Run "operator-sdk generate k8s" to regenerate code after
+                  modifying this file Add custom validation using kubebuilder tags:
+                  https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
+                type: string
+              replicas:
+                format: int32
+                type: integer
+            required:
+            - auditService
+            - authService
+            - clientRegistration
+            - config
+            - identityManager
+            - identityProvider
+            - initMongodb
+            - operatorVersion
+            - replicas
+            type: object
+          status:
+            description: AuthenticationStatus defines the observed state of Authentication
+            properties:
+              nodes:
+                description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
+                  of cluster Important: Run "operator-sdk generate k8s" to regenerate
+                  code after modifying this file Add custom validation using kubebuilder
+                  tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
+                items:
+                  type: string
+                type: array
+            required:
+            - nodes
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/deploy/olm-catalog/ibm-iam-operator/3.12.0/operator.ibm.com_oidcclientwatchers_crd.yaml
+++ b/deploy/olm-catalog/ibm-iam-operator/3.12.0/operator.ibm.com_oidcclientwatchers_crd.yaml
@@ -1,0 +1,206 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: oidcclientwatchers.operator.ibm.com
+  labels:
+    app.kubernetes.io/instance: ibm-iam-operator
+    app.kubernetes.io/managed-by: ibm-iam-operator
+    app.kubernetes.io/name: ibm-iam-operator
+spec:
+  group: operator.ibm.com
+  names:
+    kind: OIDCClientWatcher
+    listKind: OIDCClientWatcherList
+    plural: oidcclientwatchers
+    singular: oidcclientwatcher
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: OIDCClientWatcher is the Schema for the oidcclientwatchers API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: OIDCClientWatcherSpec defines the desired state of OIDCClientWatcher
+            properties:
+              imageRegistry:
+                type: string
+              imageTagPostfix:
+                type: string
+              oidcInitAuthService:
+                properties:
+                  imageName:
+                    type: string
+                  imageRegistry:
+                    type: string
+                  imageTag:
+                    type: string
+                  resources:
+                    description: ResourceRequirements describes the compute resource
+                      requirements.
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                    type: object
+                type: object
+              oidcInitIdentityManager:
+                properties:
+                  imageName:
+                    type: string
+                  imageRegistry:
+                    type: string
+                  imageTag:
+                    type: string
+                  resources:
+                    description: ResourceRequirements describes the compute resource
+                      requirements.
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                    type: object
+                type: object
+              oidcInitIdentityProvider:
+                properties:
+                  imageName:
+                    type: string
+                  imageRegistry:
+                    type: string
+                  imageTag:
+                    type: string
+                  resources:
+                    description: ResourceRequirements describes the compute resource
+                      requirements.
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                    type: object
+                type: object
+              operatorVersion:
+                description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
+                  Important: Run "operator-sdk generate k8s" to regenerate code after
+                  modifying this file Add custom validation using kubebuilder tags:
+                  https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
+                type: string
+              replicas:
+                format: int32
+                type: integer
+              resources:
+                description: ResourceRequirements describes the compute resource requirements.
+                properties:
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Limits describes the maximum amount of compute resources
+                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                    type: object
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Requests describes the minimum amount of compute
+                      resources required. If Requests is omitted for a container,
+                      it defaults to Limits if that is explicitly specified, otherwise
+                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                    type: object
+                type: object
+            required:
+            - replicas
+            type: object
+          status:
+            description: OIDCClientWatcherStatus defines the observed state of OIDCClientWatcher
+            properties:
+              nodes:
+                description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
+                  of cluster Important: Run "operator-sdk generate k8s" to regenerate
+                  code after modifying this file Add custom validation using kubebuilder
+                  tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
+                items:
+                  type: string
+                type: array
+            required:
+            - nodes
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/deploy/olm-catalog/ibm-iam-operator/3.12.0/operator.ibm.com_paps_crd.yaml
+++ b/deploy/olm-catalog/ibm-iam-operator/3.12.0/operator.ibm.com_paps_crd.yaml
@@ -1,0 +1,155 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: paps.operator.ibm.com
+  labels:
+    app.kubernetes.io/instance: ibm-iam-operator
+    app.kubernetes.io/managed-by: ibm-iam-operator
+    app.kubernetes.io/name: ibm-iam-operator
+spec:
+  group: operator.ibm.com
+  names:
+    kind: Pap
+    listKind: PapList
+    plural: paps
+    singular: pap
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Pap is the Schema for the paps API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PapSpec defines the desired state of Pap
+            properties:
+              auditService:
+                properties:
+                  imageName:
+                    type: string
+                  imageRegistry:
+                    type: string
+                  imageTag:
+                    type: string
+                  resources:
+                    description: ResourceRequirements describes the compute resource
+                      requirements.
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                    type: object
+                  syslogTlsPath:
+                    type: string
+                required:
+                - imageName
+                - imageRegistry
+                - imageTag
+                type: object
+              operatorVersion:
+                description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
+                  Important: Run "operator-sdk generate k8s" to regenerate code after
+                  modifying this file Add custom validation using kubebuilder tags:
+                  https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
+                type: string
+              papService:
+                description: PapServiceSpec defined the desired state of PapService
+                  Container
+                properties:
+                  imageName:
+                    type: string
+                  imageRegistry:
+                    type: string
+                  imageTag:
+                    type: string
+                  resources:
+                    description: ResourceRequirements describes the compute resource
+                      requirements.
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                    type: object
+                required:
+                - imageName
+                - imageRegistry
+                - imageTag
+                type: object
+              replicas:
+                format: int32
+                type: integer
+            required:
+            - auditService
+            - operatorVersion
+            - papService
+            - replicas
+            type: object
+          status:
+            description: PapStatus defines the observed state of Pap
+            properties:
+              nodes:
+                description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
+                  of cluster Important: Run "operator-sdk generate k8s" to regenerate
+                  code after modifying this file Add custom validation using kubebuilder
+                  tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
+                items:
+                  type: string
+                type: array
+            required:
+            - nodes
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/deploy/olm-catalog/ibm-iam-operator/3.12.0/operator.ibm.com_policycontrollers_crd.yaml
+++ b/deploy/olm-catalog/ibm-iam-operator/3.12.0/operator.ibm.com_policycontrollers_crd.yaml
@@ -1,0 +1,103 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: policycontrollers.operator.ibm.com
+  labels:
+    app.kubernetes.io/instance: ibm-iam-operator
+    app.kubernetes.io/managed-by: ibm-iam-operator
+    app.kubernetes.io/name: ibm-iam-operator
+spec:
+  group: operator.ibm.com
+  names:
+    kind: PolicyController
+    listKind: PolicyControllerList
+    plural: policycontrollers
+    singular: policycontroller
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: PolicyController is the Schema for the policycontrollers API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PolicyControllerSpec defines the desired state of PolicyController
+            properties:
+              config:
+                properties:
+                  excludeOperand:
+                    type: boolean
+                type: object
+              imageRegistry:
+                type: string
+              imageTagPostfix:
+                type: string
+              operatorVersion:
+                description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
+                  Important: Run "operator-sdk generate k8s" to regenerate code after
+                  modifying this file Add custom validation using kubebuilder tags:
+                  https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
+                type: string
+              replicas:
+                format: int32
+                type: integer
+              resources:
+                description: ResourceRequirements describes the compute resource requirements.
+                properties:
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Limits describes the maximum amount of compute resources
+                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                    type: object
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Requests describes the minimum amount of compute
+                      resources required. If Requests is omitted for a container,
+                      it defaults to Limits if that is explicitly specified, otherwise
+                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                    type: object
+                type: object
+            required:
+            - replicas
+            type: object
+          status:
+            description: PolicyControllerStatus defines the observed state of PolicyController
+            properties:
+              nodes:
+                description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
+                  of cluster Important: Run "operator-sdk generate k8s" to regenerate
+                  code after modifying this file Add custom validation using kubebuilder
+                  tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
+                items:
+                  type: string
+                type: array
+            required:
+            - nodes
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/deploy/olm-catalog/ibm-iam-operator/3.12.0/operator.ibm.com_policydecisions_crd.yaml
+++ b/deploy/olm-catalog/ibm-iam-operator/3.12.0/operator.ibm.com_policydecisions_crd.yaml
@@ -1,0 +1,188 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: policydecisions.operator.ibm.com
+  labels:
+    app.kubernetes.io/instance: ibm-iam-operator
+    app.kubernetes.io/managed-by: ibm-iam-operator
+    app.kubernetes.io/name: ibm-iam-operator
+spec:
+  group: operator.ibm.com
+  names:
+    kind: PolicyDecision
+    listKind: PolicyDecisionList
+    plural: policydecisions
+    singular: policydecision
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: PolicyDecision is the Schema for the policydecisions API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: PolicyDecisionSpec defines the desired state of PolicyDecision
+            properties:
+              auditService:
+                properties:
+                  imageName:
+                    type: string
+                  imageRegistry:
+                    type: string
+                  imageTag:
+                    type: string
+                  resources:
+                    description: ResourceRequirements describes the compute resource
+                      requirements.
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                    type: object
+                  syslogTlsPath:
+                    type: string
+                required:
+                - imageName
+                - imageRegistry
+                - imageTag
+                type: object
+              imageName:
+                type: string
+              imageRegistry:
+                type: string
+              imageTag:
+                type: string
+              initMongodb:
+                properties:
+                  imageName:
+                    type: string
+                  imageRegistry:
+                    type: string
+                  imageTag:
+                    type: string
+                  resources:
+                    description: ResourceRequirements describes the compute resource
+                      requirements.
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                    type: object
+                required:
+                - imageName
+                - imageRegistry
+                - imageTag
+                type: object
+              operatorVersion:
+                description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
+                  Important: Run "operator-sdk generate k8s" to regenerate code after
+                  modifying this file Add custom validation using kubebuilder tags:
+                  https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
+                type: string
+              replicas:
+                format: int32
+                type: integer
+              resources:
+                description: ResourceRequirements describes the compute resource requirements.
+                properties:
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Limits describes the maximum amount of compute resources
+                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                    type: object
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Requests describes the minimum amount of compute
+                      resources required. If Requests is omitted for a container,
+                      it defaults to Limits if that is explicitly specified, otherwise
+                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                    type: object
+                type: object
+            required:
+            - auditService
+            - imageName
+            - imageRegistry
+            - imageTag
+            - initMongodb
+            - operatorVersion
+            - replicas
+            type: object
+          status:
+            description: PolicyDecisionStatus defines the observed state of PolicyDecision
+            properties:
+              nodes:
+                description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
+                  of cluster Important: Run "operator-sdk generate k8s" to regenerate
+                  code after modifying this file Add custom validation using kubebuilder
+                  tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
+                items:
+                  type: string
+                type: array
+            required:
+            - nodes
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/deploy/olm-catalog/ibm-iam-operator/3.12.0/operator.ibm.com_secretwatchers_crd.yaml
+++ b/deploy/olm-catalog/ibm-iam-operator/3.12.0/operator.ibm.com_secretwatchers_crd.yaml
@@ -1,0 +1,103 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: secretwatchers.operator.ibm.com
+  labels:
+    app.kubernetes.io/instance: ibm-iam-operator
+    app.kubernetes.io/managed-by: ibm-iam-operator
+    app.kubernetes.io/name: ibm-iam-operator
+spec:
+  group: operator.ibm.com
+  names:
+    kind: SecretWatcher
+    listKind: SecretWatcherList
+    plural: secretwatchers
+    singular: secretwatcher
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: SecretWatcher is the Schema for the secretwatchers API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: SecretWatcherSpec defines the desired state of SecretWatcher
+            properties:
+              config:
+                properties:
+                  excludeOperand:
+                    type: boolean
+                type: object
+              imageRegistry:
+                type: string
+              imageTagPostfix:
+                type: string
+              operatorVersion:
+                description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
+                  Important: Run "operator-sdk generate k8s" to regenerate code after
+                  modifying this file Add custom validation using kubebuilder tags:
+                  https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
+                type: string
+              replicas:
+                format: int32
+                type: integer
+              resources:
+                description: ResourceRequirements describes the compute resource requirements.
+                properties:
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Limits describes the maximum amount of compute resources
+                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                    type: object
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Requests describes the minimum amount of compute
+                      resources required. If Requests is omitted for a container,
+                      it defaults to Limits if that is explicitly specified, otherwise
+                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                    type: object
+                type: object
+            required:
+            - replicas
+            type: object
+          status:
+            description: SecretWatcherStatus defines the observed state of SecretWatcher
+            properties:
+              nodes:
+                description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
+                  of cluster Important: Run "operator-sdk generate k8s" to regenerate
+                  code after modifying this file Add custom validation using kubebuilder
+                  tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
+                items:
+                  type: string
+                type: array
+            required:
+            - nodes
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/deploy/olm-catalog/ibm-iam-operator/3.12.0/operator.ibm.com_securityonboardings_crd.yaml
+++ b/deploy/olm-catalog/ibm-iam-operator/3.12.0/operator.ibm.com_securityonboardings_crd.yaml
@@ -1,0 +1,359 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: securityonboardings.operator.ibm.com
+  labels:
+    app.kubernetes.io/instance: ibm-iam-operator
+    app.kubernetes.io/managed-by: ibm-iam-operator
+    app.kubernetes.io/name: ibm-iam-operator
+spec:
+  group: operator.ibm.com
+  names:
+    kind: SecurityOnboarding
+    listKind: SecurityOnboardingList
+    plural: securityonboardings
+    singular: securityonboarding
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: SecurityOnboarding is the Schema for the securityonboardings
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: SecurityOnboardingSpec defines the desired state of SecurityOnboarding
+            properties:
+              iamOnboarding:
+                properties:
+                  imageName:
+                    type: string
+                  imageRegistry:
+                    type: string
+                  imageTag:
+                    type: string
+                  resources:
+                    description: ResourceRequirements describes the compute resource
+                      requirements.
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                    type: object
+                required:
+                - imageName
+                - imageRegistry
+                - imageTag
+                type: object
+              imageName:
+                type: string
+              imageRegistry:
+                type: string
+              imageTag:
+                type: string
+              impersonation:
+                properties:
+                  enableImpersonation:
+                    type: boolean
+                required:
+                - enableImpersonation
+                type: object
+              initAuthService:
+                properties:
+                  imageName:
+                    type: string
+                  imageRegistry:
+                    type: string
+                  imageTag:
+                    type: string
+                  resources:
+                    description: ResourceRequirements describes the compute resource
+                      requirements.
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                    type: object
+                required:
+                - imageName
+                - imageRegistry
+                - imageTag
+                type: object
+              initIdentityManager:
+                properties:
+                  imageName:
+                    type: string
+                  imageRegistry:
+                    type: string
+                  imageTag:
+                    type: string
+                  resources:
+                    description: ResourceRequirements describes the compute resource
+                      requirements.
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                    type: object
+                required:
+                - imageName
+                - imageRegistry
+                - imageTag
+                type: object
+              initIdentityProvider:
+                properties:
+                  imageName:
+                    type: string
+                  imageRegistry:
+                    type: string
+                  imageTag:
+                    type: string
+                  resources:
+                    description: ResourceRequirements describes the compute resource
+                      requirements.
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                    type: object
+                required:
+                - imageName
+                - imageRegistry
+                - imageTag
+                type: object
+              initPAPSpec:
+                properties:
+                  imageName:
+                    type: string
+                  imageRegistry:
+                    type: string
+                  imageTag:
+                    type: string
+                  resources:
+                    description: ResourceRequirements describes the compute resource
+                      requirements.
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                    type: object
+                required:
+                - imageName
+                - imageRegistry
+                - imageTag
+                type: object
+              initTokenService:
+                properties:
+                  imageName:
+                    type: string
+                  imageRegistry:
+                    type: string
+                  imageTag:
+                    type: string
+                  resources:
+                    description: ResourceRequirements describes the compute resource
+                      requirements.
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                    type: object
+                required:
+                - imageName
+                - imageRegistry
+                - imageTag
+                type: object
+              operatorVersion:
+                description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
+                  Important: Run "operator-sdk generate k8s" to regenerate code after
+                  modifying this file Add custom validation using kubebuilder tags:
+                  https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
+                type: string
+              replicas:
+                format: int32
+                type: integer
+              resources:
+                description: ResourceRequirements describes the compute resource requirements.
+                properties:
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Limits describes the maximum amount of compute resources
+                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                    type: object
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: 'Requests describes the minimum amount of compute
+                      resources required. If Requests is omitted for a container,
+                      it defaults to Limits if that is explicitly specified, otherwise
+                      to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                    type: object
+                type: object
+            required:
+            - iamOnboarding
+            - imageName
+            - imageRegistry
+            - imageTag
+            - impersonation
+            - initAuthService
+            - initIdentityManager
+            - initIdentityProvider
+            - initPAPSpec
+            - initTokenService
+            - operatorVersion
+            - replicas
+            type: object
+          status:
+            description: SecurityOnboardingStatus defines the observed state of SecurityOnboarding
+            properties:
+              podNames:
+                description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
+                  of cluster Important: Run "operator-sdk generate k8s" to regenerate
+                  code after modifying this file Add custom validation using kubebuilder
+                  tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
+                items:
+                  type: string
+                type: array
+            required:
+            - podNames
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -44,23 +44,23 @@ spec:
           imagePullPolicy: Always
           env:
             - name: ICP_PLATFORM_AUTH_IMAGE
-              value: quay.io/opencloudio/icp-platform-auth:3.6.2
+              value: quay.io/opencloudio/icp-platform-auth:3.7.0
             - name: ICP_IDENTITY_PROVIDER_IMAGE
-              value: quay.io/opencloudio/icp-identity-provider:3.6.2
+              value: quay.io/opencloudio/icp-identity-provider:3.7.0
             - name: ICP_IDENTITY_MANAGER_IMAGE
-              value: quay.io/opencloudio/icp-identity-manager:3.6.2
+              value: quay.io/opencloudio/icp-identity-manager:3.7.0
             - name: IAM_POLICY_ADMINISTRATION_IMAGE
-              value: quay.io/opencloudio/iam-policy-administration:3.6.2
+              value: quay.io/opencloudio/iam-policy-administration:3.7.0
             - name: IAM_POLICY_DECISION_IMAGE
-              value: quay.io/opencloudio/iam-policy-decision:3.6.2
+              value: quay.io/opencloudio/iam-policy-decision:3.7.0
             - name: ICP_SECRET_WATCHER_IMAGE
-              value: quay.io/opencloudio/icp-secret-watcher:3.6.2
+              value: quay.io/opencloudio/icp-secret-watcher:3.7.0
             - name: ICP_OIDCCLIENT_WATCHER_IMAGE
-              value: quay.io/opencloudio/icp-oidcclient-watcher:3.6.2
+              value: quay.io/opencloudio/icp-oidcclient-watcher:3.7.0
             - name: IAM_POLICY_CONTROLLER_IMAGE
-              value: quay.io/opencloudio/iam-policy-controller:3.6.2
+              value: quay.io/opencloudio/iam-policy-controller:3.7.0
             - name: ICP_IAM_ONBOARDING_IMAGE
-              value: quay.io/opencloudio/icp-iam-onboarding:3.6.2
+              value: quay.io/opencloudio/icp-iam-onboarding:3.7.0
             - name: AUDIT_SYSLOG_SERVICE_IMAGE
               value: quay.io/opencloudio/audit-syslog-service:1.0.8
             - name: WATCH_NAMESPACE

--- a/version/version.go
+++ b/version/version.go
@@ -16,5 +16,5 @@
 package version
 
 var (
-	Version = "3.11.2"
+	Version = "3.12.0"
 )


### PR DESCRIPTION
update next-csv.sh to:
1.support manually enter new-version and prev-version, therefore support bump up version x/y
if new-version not manually provided, will use the current logic to bump up version z by 1
2.fix missing " in several commands

bump up version from 3.11.2 to 3.12.0