### PR TITLE
Revert "Update webhook.go" to remove new cert annotation

### DIFF
--- a/pkg/controller/authentication/webhook.go
+++ b/pkg/controller/authentication/webhook.go
@@ -125,7 +125,6 @@ func generateWebhookObject(instance *operatorv1alpha1.Authentication, scheme *ru
 			Name: webhook,
 			Annotations: map[string]string{
 				"certmanager.k8s.io/inject-ca-from": instance.Namespace + "/platform-identity-management",
-				"cert-manager.io/inject-ca-from":    instance.Namespace + "/platform-identity-management",
 			},
 		},
 		Webhooks: []reg.MutatingWebhook{


### PR DESCRIPTION
Reverts IBM/ibm-iam-operator#421
https://github.ibm.com/IBMPrivateCloud/roadmap/issues/49888