### PR TITLE
[Cloudpak 3.0] - Update ibm-iam-operator.v4.0.0.clusterserviceversion.yaml

### DIFF
--- a/deploy/olm-catalog/ibm-iam-operator/4.0.0/ibm-iam-operator.v4.0.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-iam-operator/4.0.0/ibm-iam-operator.v4.0.0.clusterserviceversion.yaml
@@ -17,7 +17,7 @@ metadata:
           },
           "spec": {
             "imageRegistry": "quay.io/opencloudio/icp-oidcclient-watcher",
-            "imageTagPostfix": "4.0.0",
+            "imageTagPostfix": "3.10.0",
             "operatorVersion": "0.14.1",
             "replicas": 1,
             "resources": {
@@ -33,7 +33,7 @@ metadata:
             "oidcInitAuthService": {
               "imageName": "icp-platform-auth",
               "imageRegistry": "quay.io/opencloudio",
-              "imageTag": "4.0.0",
+              "imageTag": "3.10.0",
               "resources": {
                 "limits": {
                   "cpu": "200m",
@@ -48,7 +48,7 @@ metadata:
             "oidcInitIdentityProvider": {
               "imageName": "icp-platform-auth",
               "imageRegistry": "quay.io/opencloudio",
-              "imageTag": "4.0.0",
+              "imageTag": "3.10.0",
               "resources": {
                 "limits": {
                   "cpu": "200m",
@@ -92,7 +92,7 @@ metadata:
             "auditService": {
               "imageName": "audit-syslog-service",
               "imageRegistry": "quay.io/opencloudio",
-              "imageTag": "1.0.7",
+              "imageTag": "1.8.0",
               "syslogTlsPath": "/etc/audit-tls",
               "resources": {
                 "limits": {
@@ -107,11 +107,11 @@ metadata:
             },
             "imageName": "iam-policy-decision",
             "imageRegistry": "quay.io/opencloudio",
-            "imageTag": "4.0.0",
+            "imageTag": "3.10.0",
             "initMongodb": {
               "imageName": "icp-platform-auth",
               "imageRegistry": "quay.io/opencloudio",
-              "imageTag": "4.0.0",
+              "imageTag": "3.10.0",
               "resources": {
                 "limits": {
                   "cpu": "100m",
@@ -152,7 +152,7 @@ metadata:
             "auditService": {
               "imageName": "audit-syslog-service",
               "imageRegistry": "quay.io/opencloudio",
-              "imageTag": "1.0.7",
+              "imageTag": "1.8.0",
               "syslogTlsPath": "/etc/audit-tls",
               "resources": {
                 "limits": {
@@ -168,7 +168,7 @@ metadata:
             "authService": {
               "imageName": "icp-platform-auth",
               "imageRegistry": "quay.io/opencloudio",
-              "imageTag": "4.0.0",
+              "imageTag": "3.10.0",
               "ldapsCACert": "platform-auth-ldaps-ca-cert",
               "resources": {
                 "limits": {
@@ -185,7 +185,7 @@ metadata:
             "clientRegistration": {
               "imageName": "icp-platform-auth",
               "imageRegistry": "quay.io/opencloudio",
-              "imageTag": "4.0.0",
+              "imageTag": "3.10.0",
               "resources": {
                 "limits": {
                   "cpu": "1000m",
@@ -263,7 +263,7 @@ metadata:
             "initMongodb": {
               "imageName": "icp-platform-auth",
               "imageRegistry": "quay.io/opencloudio",
-              "imageTag": "4.0.0",
+              "imageTag": "3.10.0",
               "resources": {
                 "limits": {
                   "cpu": "100m",
@@ -294,7 +294,7 @@ metadata:
             "auditService": {
               "imageName": "audit-syslog-service",
               "imageRegistry": "quay.io/opencloudio",
-              "imageTag": "1.0.7",
+              "imageTag": "1.8.0",
               "syslogTlsPath": "/etc/audit-tls",
               "resources": {
                 "limits": {
@@ -311,7 +311,7 @@ metadata:
             "papService": {
               "imageName": "iam-policy-administration",
               "imageRegistry": "quay.io/opencloudio",
-              "imageTag": "4.0.0",
+              "imageTag": "3.10.0",
               "resources": {
                 "limits": {
                   "cpu": "1000m",
@@ -342,7 +342,7 @@ metadata:
               "excludeOperand": false
             },
             "imageRegistry": "quay.io/opencloudio/icp-secret-watcher",
-            "imageTagPostfix": "4.0.0",
+            "imageTagPostfix": "3.7.12",
             "operatorVersion": "0.14.1",
             "replicas": 1,
             "resources": {
@@ -372,7 +372,7 @@ metadata:
             "iamOnboarding": {
               "imageName": "icp-iam-onboarding",
               "imageRegistry": "quay.io/opencloudio",
-              "imageTag": "4.0.0",
+              "imageTag": "3.10.0",
               "resources": {
                 "limits": {
                   "cpu": "200m",
@@ -386,14 +386,14 @@ metadata:
             },
             "imageName": "icp-iam-onboarding",
             "imageRegistry": "quay.io/opencloudio",
-            "imageTag": "4.0.0",
+            "imageTag": "3.10.0",
             "impersonation": {
               "enableImpersonation": false
             },
             "initAuthService": {
               "imageName": "icp-platform-auth",
               "imageRegistry": "quay.io/opencloudio",
-              "imageTag": "4.0.0",
+              "imageTag": "3.10.0",
               "resources": {
                 "limits": {
                   "cpu": "200m",
@@ -438,7 +438,7 @@ metadata:
             "initPAPSpec": {
               "imageName": "icp-platform-auth",
               "imageRegistry": "quay.io/opencloudio",
-              "imageTag": "4.0.0",
+              "imageTag": "3.10.0",
               "resources": {
                 "limits": {
                   "cpu": "200m",
@@ -453,7 +453,7 @@ metadata:
             "initTokenService": {
               "imageName": "icp-platform-auth",
               "imageRegistry": "quay.io/opencloudio",
-              "imageTag": "4.0.0",
+              "imageTag": "3.10.0",
               "resources": {
                 "limits": {
                   "cpu": "200m",
@@ -1710,23 +1710,23 @@ spec:
                 - ibm-iam-operator
                 env:
                 - name: ICP_PLATFORM_AUTH_IMAGE
-                  value: quay.io/opencloudio/icp-platform-auth:4.0.0
+                  value: quay.io/opencloudio/icp-platform-auth:3.10.0
                 - name: ICP_IDENTITY_PROVIDER_IMAGE
                   value: quay.io/opencloudio/icp-identity-provider:4.0.0
                 - name: ICP_IDENTITY_MANAGER_IMAGE
                   value: quay.io/opencloudio/icp-identity-manager:4.0.0
                 - name: IAM_POLICY_ADMINISTRATION_IMAGE
-                  value: quay.io/opencloudio/iam-policy-administration:4.0.0
+                  value: quay.io/opencloudio/iam-policy-administration:3.10.0
                 - name: IAM_POLICY_DECISION_IMAGE
-                  value: quay.io/opencloudio/iam-policy-decision:4.0.0
+                  value: quay.io/opencloudio/iam-policy-decision:3.10.0
                 - name: ICP_SECRET_WATCHER_IMAGE
-                  value: quay.io/opencloudio/icp-secret-watcher:4.0.0
+                  value: quay.io/opencloudio/icp-secret-watcher:3.7.12
                 - name: ICP_OIDCCLIENT_WATCHER_IMAGE
-                  value: quay.io/opencloudio/icp-oidcclient-watcher:4.0.0
+                  value: quay.io/opencloudio/icp-oidcclient-watcher:3.10.0
                 - name: ICP_IAM_ONBOARDING_IMAGE
-                  value: quay.io/opencloudio/icp-iam-onboarding:4.0.0
+                  value: quay.io/opencloudio/icp-iam-onboarding:3.10.0
                 - name: AUDIT_SYSLOG_SERVICE_IMAGE
-                  value: quay.io/opencloudio/audit-syslog-service:1.0.7
+                  value: quay.io/opencloudio/audit-syslog-service:1.8.0
                 - name: WATCH_NAMESPACE
                   valueFrom:
                     fieldRef:

--- a/deploy/olm-catalog/ibm-iam-operator/4.0.0/ibm-iam-operator.v4.0.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-iam-operator/4.0.0/ibm-iam-operator.v4.0.0.clusterserviceversion.yaml
@@ -1755,6 +1755,16 @@ spec:
                   privileged: false
                   readOnlyRootFilesystem: true
               serviceAccountName: ibm-iam-operator
+              volumes:
+              - name: cluster-ca-cert
+                secret:
+                  defaultMode: 420
+                  items:
+                  - key: tls.key
+                    path: ca.key
+                  - key: tls.crt
+                    path: ca.crt
+                  secretName: cs-ca-certificate-secret
       permissions:
       - rules:
         - apiGroups:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -38,7 +38,7 @@ spec:
       containers:
         - name: ibm-iam-operator
           # Replace this with the built image name
-          image: icr.io/cpopen/ibm-iam-operator:3.22.0
+          image: icr.io/cpopen/ibm-iam-operator:4.0.0
           command:
           - ibm-iam-operator
           imagePullPolicy: Always
@@ -46,9 +46,9 @@ spec:
             - name: ICP_PLATFORM_AUTH_IMAGE
               value: icr.io/cpopen/cpfs/icp-platform-auth:3.10.0
             - name: ICP_IDENTITY_PROVIDER_IMAGE
-              value: icr.io/cpopen/cpfs/icp-identity-provider:3.10.0
+              value: icr.io/cpopen/cpfs/icp-identity-provider:4.0.0
             - name: ICP_IDENTITY_MANAGER_IMAGE
-              value: icr.io/cpopen/cpfs/icp-identity-manager:3.10.0
+              value: icr.io/cpopen/cpfs/icp-identity-manager:4.0.0
             - name: IAM_POLICY_ADMINISTRATION_IMAGE
               value: icr.io/cpopen/cpfs/iam-policy-administration:3.10.0
             - name: IAM_POLICY_DECISION_IMAGE


### PR DESCRIPTION
operand versions at 3.10.0 level except for platform-identity-manager and provider which contain most of the changes.

https://github.ibm.com/IBMPrivateCloud/roadmap/issues/55512