### PR TITLE
Enable cpclient_credentials grant type

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,7 @@ build-image-amd64: build $(CONFIG_DOCKER_TARGET)
 	docker run --rm --privileged multiarch/qemu-user-static:register --reset
 	docker build ${IMAGE_BUILD_OPTS}  -t $(REGISTRY)/$(IMG)-amd64:$(VERSION) -f build/Dockerfile.amd64 .
 	@\rm -f build/_output/bin/ibm-iam-operator-amd64
-	@if [ $(BUILD_LOCALLY) -ne 1 ]; then docker push $(REGISTRY)/$(IMG)-$(ARCH):$(VERSION); fi
+	@if [ $(BUILD_LOCALLY) -ne 1 ]; then $(CONTAINER_CLI) push $(REGISTRY)/$(IMG)-amd64:$(VERSION); fi
 
 # runs on amd64 machine
 build-image-ppc64le: $(CONFIG_DOCKER_TARGET)

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ IMAGE_BUILD_OPTS=--build-arg "VCS_REF=$(GIT_COMMIT_ID)" --build-arg "VCS_URL=$(G
 # Use your own docker registry and image name for dev/test by overridding the IMG and REGISTRY environment variable.
 IMG ?= ibm-iam-operator
 REGISTRY ?= "docker-na-public.artifactory.swg-devops.com/hyc-cloud-private-integration-docker-local/ibmcom"
+CONTAINER_CLI ?= docker
 
 CSV_VERSION ?= 4.0.0
 
@@ -142,39 +143,39 @@ endif
 
 ##@ Build
 
-build:
+build: ## Build the Operator binary for the host OS and architecture
 	@echo "Building the ibm-iam-operator binary"
 	@CGO_ENABLED=0 go build -o build/_output/bin/$(IMG) ./cmd/manager
 	@strip $(STRIP_FLAGS) build/_output/bin/$(IMG)
 
-build-image: build $(CONFIG_DOCKER_TARGET)
+build-image: build $(CONFIG_DOCKER_TARGET) ## Build the Operator for Linux on amd64
 	$(eval ARCH := $(shell uname -m|sed 's/x86_64/amd64/'))
-	docker build ${IMAGE_BUILD_OPTS}  -t $(REGISTRY)/$(IMG)-$(ARCH):$(VERSION) -f build/Dockerfile .
+	$(CONTAINER_CLI) build ${IMAGE_BUILD_OPTS}  -t $(REGISTRY)/$(IMG)-$(ARCH):$(VERSION) -f build/Dockerfile .
 	@\rm -f build/_output/bin/ibm-iam-operator
-	@if [ $(BUILD_LOCALLY) -ne 1 ] && [ "$(ARCH)" = "amd64" ]; then docker push $(REGISTRY)/$(IMG)-$(ARCH):$(VERSION); fi
+	@if [ $(BUILD_LOCALLY) -ne 1 ] && [ "$(ARCH)" = "amd64" ]; then $(CONTAINER_CLI) push $(REGISTRY)/$(IMG)-$(ARCH):$(VERSION); fi
 
-build-image-amd64: build $(CONFIG_DOCKER_TARGET)
+build-image-amd64: build $(CONFIG_DOCKER_TARGET) ## Build the Operator for Linux on amd64
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o build/_output/bin/ibm-iam-operator-amd64 ./cmd/manager
-	docker run --rm --privileged multiarch/qemu-user-static:register --reset
-	docker build ${IMAGE_BUILD_OPTS}  -t $(REGISTRY)/$(IMG)-amd64:$(VERSION) -f build/Dockerfile.amd64 .
+	$(CONTAINER_CLI) run --rm --privileged multiarch/qemu-user-static:register --reset
+	$(CONTAINER_CLI) build ${IMAGE_BUILD_OPTS}  -t $(REGISTRY)/$(IMG)-amd64:$(VERSION) -f build/Dockerfile.amd64 .
 	@\rm -f build/_output/bin/ibm-iam-operator-amd64
 	@if [ $(BUILD_LOCALLY) -ne 1 ]; then $(CONTAINER_CLI) push $(REGISTRY)/$(IMG)-amd64:$(VERSION); fi
 
 # runs on amd64 machine
-build-image-ppc64le: $(CONFIG_DOCKER_TARGET)
+build-image-ppc64le: $(CONFIG_DOCKER_TARGET) ## Build the Operator for Linux on ppc64le
 	GOOS=linux GOARCH=ppc64le CGO_ENABLED=0 go build -o build/_output/bin/ibm-iam-operator-ppc64le ./cmd/manager
-	docker run --rm --privileged multiarch/qemu-user-static:register --reset
-	docker build ${IMAGE_BUILD_OPTS}  -t $(REGISTRY)/$(IMG)-ppc64le:$(VERSION) -f build/Dockerfile.ppc64le .
+	$(CONTAINER_CLI) run --rm --privileged multiarch/qemu-user-static:register --reset
+	$(CONTAINER_CLI) build ${IMAGE_BUILD_OPTS}  -t $(REGISTRY)/$(IMG)-ppc64le:$(VERSION) -f build/Dockerfile.ppc64le .
 	@\rm -f build/_output/bin/ibm-iam-operator-ppc64le
-	@if [ $(BUILD_LOCALLY) -ne 1 ]; then docker push $(REGISTRY)/$(IMG)-ppc64le:$(VERSION); fi
+	@if [ $(BUILD_LOCALLY) -ne 1 ]; then $(CONTAINER_CLI) push $(REGISTRY)/$(IMG)-ppc64le:$(VERSION); fi
 
 # runs on amd64 machine
-build-image-s390x: $(CONFIG_DOCKER_TARGET)
+build-image-s390x: $(CONFIG_DOCKER_TARGET) ## Build the Operator for Linux on s390x
 	GOOS=linux GOARCH=s390x CGO_ENABLED=0 go build -o build/_output/bin/ibm-iam-operator-s390x ./cmd/manager
-	docker run --rm --privileged multiarch/qemu-user-static:register --reset
-	docker build ${IMAGE_BUILD_OPTS}  -t $(REGISTRY)/$(IMG)-s390x:$(VERSION) -f build/Dockerfile.s390x .
+	$(CONTAINER_CLI) run --rm --privileged multiarch/qemu-user-static:register --reset
+	$(CONTAINER_CLI) build ${IMAGE_BUILD_OPTS}  -t $(REGISTRY)/$(IMG)-s390x:$(VERSION) -f build/Dockerfile.s390x .
 	@\rm -f build/_output/bin/ibm-iam-operator-s390x
-	@if [ $(BUILD_LOCALLY) -ne 1 ]; then docker push $(REGISTRY)/$(IMG)-s390x:$(VERSION); fi
+	@if [ $(BUILD_LOCALLY) -ne 1 ]; then $(CONTAINER_CLI) push $(REGISTRY)/$(IMG)-s390x:$(VERSION); fi
 
 ##@ Test
 
@@ -195,7 +196,7 @@ scorecard: ## Run scorecard test
 ##@ Release
 
 images: build-image build-image-ppc64le build-image-s390x
-	@curl -L -o /tmp/manifest-tool https://github.com/estesp/manifest-tool/releases/download/v1.0.3/manifest-tool-linux-amd64
+	@curl -L -o /tmp/manifest-tool https://github.com/estesp/manifest-tool/releases/download/v1.0.3/manifest-tool-$(TARGET_OS)-amd64
 	@chmod +x /tmp/manifest-tool
 	/tmp/manifest-tool push from-args --platforms linux/amd64,linux/ppc64le,linux/s390x --template $(REGISTRY)/$(IMG)-ARCH:$(VERSION) --target $(REGISTRY)/$(IMG) --ignore-missing
 	/tmp/manifest-tool push from-args --platforms linux/amd64,linux/ppc64le,linux/s390x --template $(REGISTRY)/$(IMG)-ARCH:$(VERSION) --target $(REGISTRY)/$(IMG):$(VERSION) --ignore-missing

--- a/pkg/apis/oidc/v1/client_types.go
+++ b/pkg/apis/oidc/v1/client_types.go
@@ -31,8 +31,10 @@ type ClientSpec struct {
         OidcLibertyClient OidcLibertyClient `json:"oidcLibertyClient"`
         Secret            string            `json:"secret"`
         ClientId          string            `json:"clientId"`
+        ZenAuditUrl       string            `json:"zenAuditUrl,omitempty"`
         ZenInstanceId     string            `json:"zenInstanceId,omitempty"`
         ZenProductNameUrl string            `json:"zenProductNameUrl,omitempty"`
+        Roles             []string          `json:"roles,omitempty"`
 }
 
 type OidcLibertyClient struct {
@@ -105,6 +107,13 @@ type Client struct {
 
         Spec   ClientSpec   `json:"spec,omitempty"`
         Status ClientStatus `json:"status,omitempty"`
+}
+
+// IsCPClientCredentialsEnabled returns whether the fields required for a Client to be granted authentication tokens
+// with a Client ID and Secret are set
+func (c *Client) IsCPClientCredentialsEnabled() bool {
+  return len(c.Spec.Roles) > 0 &&
+    len(c.Spec.ZenAuditUrl) > 0
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/controller/client/client_controller_config.go
+++ b/pkg/controller/client/client_controller_config.go
@@ -41,6 +41,9 @@ const (
   defaultAdminUserKey string = "admin_username"
   // defaultAdminPasswordKey is the key in the ClientControllerConfig corresponding to the default admin password for the IAM API
   defaultAdminPasswordKey string = "admin_password"
+  // oauthAdminPasswordKey is the key in the ClientControllerConfig corresponding to the password for the oauthAdmin
+  // account
+  oAuthAdminPasswordKey string = "OAUTH2_CLIENT_REGISTRATION_SECRET"
 )
 
 // ApplyConfigMap takes the key value pairs found in a ConfigMap's Data field and sets the same keys and values in the
@@ -94,6 +97,9 @@ func (r *ReconcileClient) IsConfigured() bool {
   if _, err := r.GetROKSEnabled(); err != nil {
     return false
   }
+  if _, err := r.GetOSAuthEnabled(); err != nil {
+    return false
+  }
   if value, err := r.GetAuthServiceURL(); value != "" && err != nil {
     return false
   }
@@ -101,6 +107,9 @@ func (r *ReconcileClient) IsConfigured() bool {
     return false
   }
   if value, err := r.GetDefaultAdminPassword(); value != "" && err != nil {
+    return false
+  }
+  if value, err := r.GetOAuthAdminPassword(); value != "" && err != nil {
     return false
   }
   return true
@@ -130,6 +139,13 @@ func (r *ReconcileClient) GetDefaultAdminUser() (value string, err error) {
 // ClientControllerConfig. Produces an error if the ClientControllerConfig is empty or if the key is not present.
 func (r *ReconcileClient) GetDefaultAdminPassword() (value string, err error) {
   value, err = r.config.getConfigValue(defaultAdminPasswordKey)
+  return
+}
+
+// GetOauthAdminPassword gets the password for the OAuth Provider oauthadmin account from the ReconcileClient's
+// ClientControllerConfig. Produces an error if the ClientControllerConfig is empty or if the key is not present.
+func (r *ReconcileClient) GetOAuthAdminPassword() (value string, err error) {
+  value, err = r.config.getConfigValue(oAuthAdminPasswordKey)
   return
 }
 

--- a/pkg/controller/client/clientreg.go
+++ b/pkg/controller/client/clientreg.go
@@ -20,11 +20,6 @@ import (
 	"bytes"
 	"context"
 
-	//"crypto/rand"
-	"crypto/tls"
-	"crypto/x509"
-
-	//"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -34,15 +29,16 @@ import (
 	"strings"
 	"time"
 
-	securityv1 "github.com/IBM/ibm-iam-operator/pkg/apis/oidc/v1"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	oidcv1 "github.com/IBM/ibm-iam-operator/pkg/apis/oidc/v1"
 	regen "github.com/zach-klippenstein/goregen"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
 
 type ClientCredentials struct {
-	CLIENT_ID     string `json:"CLIENT_ID"`
-	CLIENT_SECRET string `json:"CLIENT_SECRET"`
+	ClientID     string `json:"CLIENT_ID"`
+	ClientSecret string `json:"CLIENT_SECRET"`
 }
 
 type OidcClientResponse struct {
@@ -59,8 +55,9 @@ type OidcClientResponse struct {
 	PreauthorizedScope      string        `json:"preauthorized_scope"`
 	IntrospectTokens        bool          `json:"introspect_tokens"`
 	TrustedURIPrefixes      []string      `json:"trusted_uri_prefixes"`
-	ResourceIds             []interface{} `json:"resource_ids"`
-	FunctionalUserGroupIds  []interface{} `json:"functional_user_groupIds"`
+	ResourceIds             []string      `json:"resource_ids"`
+	FunctionalUserGroupIds  []string      `json:"functional_user_groupIds"`
+  FunctionalUserID        string        `json:"functional_user_id"`
 	AppPasswordAllowed      bool          `json:"appPasswordAllowed"`
 	AppTokenAllowed         bool          `json:"appTokenAllowed"`
 	ClientID                string        `json:"client_id"`
@@ -91,179 +88,153 @@ const (
 	letterIdxMask = 1<<letterIdxBits - 1                                             // All 1-bits, as many as letterIdxBits
 )
 
-func (r *ReconcileClient) CreateClientCredentials(ctx context.Context, client *securityv1.Client) (*ClientCredentials, error) {
-  authServiceURL, err := r.GetAuthServiceURL()
+// CreateClientRegistration registers a new OIDC Client on the OP using information provided in the provided Client CR.
+func (r *ReconcileClient) CreateClientRegistration(ctx context.Context, client *oidcv1.Client, clientCreds *ClientCredentials) (response *http.Response, err error) {
+  var url, identityProviderURL string
+  identityProviderURL, err = r.GetIdentityProviderURL()
   if err != nil {
-    return nil, err
+    return
   }
-	url := strings.Join([]string{authServiceURL, "registration"}, "/")
-	serviceName := client.Name
-	clientCred := r.generateClientCredentials(serviceName)
-
-	payload := r.generateClientRegistrationPayload(client, clientCred)
-	response, err := r.invokeRegistration(ctx, client, PostType, url, payload)
-	if response != nil && response.Status == "201 Created" {
-		client.Spec.ClientId = clientCred.CLIENT_ID
-		defer response.Body.Close()
-		return clientCred, nil
-	} else {
-		handleOIDCClientError(client, response, err, PostType, r.recorder)
-		err = fmt.Errorf("Error occurred during create oidc client registration")
-		return nil, err
-	}
-
+  url = strings.Join([]string{identityProviderURL, "v1", "auth", "registration"}, "/")
+	payload := r.generateClientRegistrationPayload(client, clientCreds)
+	response, err = r.invokeClientRegistrationAPI(ctx, client, PostType, url, payload)
+  return
 }
 
-func (r *ReconcileClient) UpdateClientCredentials(ctx context.Context, client *securityv1.Client, secret *corev1.Secret) (*ClientCredentials, error) {
-	secretData := secret.Data
-	clientCred := &ClientCredentials{
-    CLIENT_ID:     string(secretData["CLIENT_ID"][:]),
-    CLIENT_SECRET: string(secretData["CLIENT_SECRET"][:]),
-	}
-  authServiceURL, err := r.GetAuthServiceURL()
+// UpdateClientRegistration updates the OIDC Client registration represented by the Client CR to use the credentials
+// stored in the provided Secret.
+func (r *ReconcileClient) UpdateClientRegistration(ctx context.Context, client *oidcv1.Client, clientCreds *ClientCredentials) (response *http.Response, err error) {
+  var url, identityProviderURL string
+	payload := r.generateClientRegistrationPayload(client, clientCreds)
+  identityProviderURL, err = r.GetIdentityProviderURL()
   if err != nil {
-    return nil, err
+    return
   }
-	payload := r.generateClientRegistrationPayload(client, clientCred)
-	url := strings.Join([]string{authServiceURL, "registration", clientCred.CLIENT_ID}, "/")
-	response, err := r.invokeRegistration(ctx, client, PutType, url, payload)
-	if response != nil && response.Status == "200 OK" {
-		defer response.Body.Close()
-		return clientCred, nil
-	} else {
-		handleOIDCClientError(client, response, err, PutType, r.recorder)
-		err = fmt.Errorf("Error occurred during update oidc client regstration")
-		return nil, err
-	}
+  url = strings.Join([]string{identityProviderURL, "v1", "auth", "registration", clientCreds.ClientID}, "/")
+	response, err = r.invokeClientRegistrationAPI(ctx, client, PutType, url, payload)
+  return
 }
 
-func (r *ReconcileClient) DeleteClientCredentials(ctx context.Context, client *securityv1.Client) error {
+// DeleteClientRegistration deletes from the OP the OIDC Client registration represented by the Client CR.
+func (r *ReconcileClient) DeleteClientRegistration(ctx context.Context, client *oidcv1.Client) (response *http.Response, err error) {
 	clientId := client.Spec.ClientId
 	if clientId != "" {
-    authServiceURL, err := r.GetAuthServiceURL()
+    var url, identityProviderURL string
+    identityProviderURL, err = r.GetIdentityProviderURL()
     if err != nil {
-      return err
+      return
     }
-		url := strings.Join([]string{authServiceURL, "registration", clientId}, "/")
-		response, err := r.invokeRegistration(ctx, client, DeleteType, url, "")
-		if response != nil && (response.Status == "204 No Content" || response.Status == "404 Not Found") {
-			defer response.Body.Close()
-			return nil
-		} else {
-			handleOIDCClientError(client, response, err, DeleteType, r.recorder)
-			err = fmt.Errorf("Error occurred during delete oidc client regstration")
-			return err
-		}
-	} else {
-		return nil
-	}
+    url = strings.Join([]string{identityProviderURL, "v1", "auth", "registration", clientId}, "/")
+		response, err = r.invokeClientRegistrationAPI(ctx, client, DeleteType, url, "")
+    return
+	} 
+  return
 }
 
-func (r *ReconcileClient) invokeRegistration(ctx context.Context, oidcreg *securityv1.Client, requestType string, requestURL string, payload string) (*http.Response, error) {
-  clientRegistrationSecretName := "platform-oidc-credentials"
-  secretObj := &corev1.Secret{}
-  err := r.client.Get(ctx, types.NamespacedName{Name: clientRegistrationSecretName, Namespace: oidcreg.GetNamespace()}, secretObj)
-  if err != nil {
-    log.Error(err, fmt.Sprintf("failed to get secret %q", clientRegistrationSecretName))
-    return nil, err
-  } 
-  log.Info(fmt.Sprintf("Retrieved secret %q", clientRegistrationSecretName))
+func (r *ReconcileClient) invokeClientRegistrationAPI(ctx context.Context, client *oidcv1.Client, requestType string, requestURL string, payload string) (response *http.Response, err error) {
+  reqLogger := logf.FromContext(ctx).WithName("invokeClientRegistrationAPI")
+  reqLogger.Info("params", "requestType", requestType, "requestURL", requestURL)
+  r.GetOAuthAdminPassword()
   oauthAdmin := "oauthadmin"
-  clientRegistrationSecret := string(secretObj.Data["OAUTH2_CLIENT_REGISTRATION_SECRET"][:])
-
-	req, _ := http.NewRequest(requestType, requestURL, bytes.NewBuffer([]byte(payload)))
-	req.Header.Set("Content-Type", "application/json")
-	req.SetBasicAuth(oauthAdmin, clientRegistrationSecret)
-	caCert, err := ioutil.ReadFile("/certs/ca.crt")
-	if err != nil {
-		return nil, err
-	}
-	caCertPool := x509.NewCertPool()
-	caCertPool.AppendCertsFromPEM(caCert)
-	transport := &http.Transport{TLSClientConfig: &tls.Config{RootCAs: caCertPool}}
-	client := &http.Client{Transport: transport}
-  resp, err := client.Do(req)
-	if resp != nil && resp.StatusCode >= 400 {
-		errorDetails, _ := ioutil.ReadAll(resp.Body)
-		log.Error(err, fmt.Sprintf("Invoke registration has failed: %s", string(errorDetails)))
-		err1 := errors.New(string(errorDetails))
-		return nil, err1
-	}
-	if err != nil {
-		return nil, err
-	}
-	return resp, nil
-}
-
-func (r *ReconcileClient) getClientCredentials(ctx context.Context, oidcreg *securityv1.Client) (*http.Response, error) {
-	clientId := oidcreg.Spec.ClientId
-  authServiceURL, err := r.GetAuthServiceURL()
+  var clientRegistrationSecret string
+  clientRegistrationSecret, err = r.GetOAuthAdminPassword()
   if err != nil {
-    return nil, err
+    return
   }
-	url := strings.Join([]string{authServiceURL, "registration", clientId}, "/")
-	response, err := r.invokeRegistration(ctx, oidcreg, GetType, url, "")
-	if response != nil && response.Status == "200 OK" {
-		return response, nil
-	} else {
-		handleOIDCClientError(oidcreg, response, err, GetType, r.recorder)
-		err = fmt.Errorf("Error occurred while getting oidc client registration")
-		return nil, err
-	}
+
+	request, _ := http.NewRequest(requestType, requestURL, bytes.NewBuffer([]byte(payload)))
+	request.Header.Set("Content-Type", "application/json")
+	request.SetBasicAuth(oauthAdmin, clientRegistrationSecret)
+	httpClient, err := createHTTPClient()
+  if err != nil {
+    return
+  }
+
+  response, err = httpClient.Do(request)
+  if err != nil {
+    return
+  }
+	return
 }
 
-func (r *ReconcileClient) ClientIdExists(ctx context.Context, client *securityv1.Client) (bool, *ClientCredentials, error) {
-	clientId := client.Spec.ClientId
-	if clientId != "" {
-		resp, err := r.getClientCredentials(ctx, client)
-		if err != nil {
-			return false, nil, err
-		} else if clientId != "" && resp.Status == "200 OK" {
-			clientCreds, errRes := r.getCredentialsFromResponse(resp)
-			if errRes != nil {
-				return false, nil, errRes
-			} else {
-				return true, clientCreds, nil
-			}
-		} else {
-			return false, nil, nil
-		}
-	} else {
-		return false, nil, nil
-	}
+// GetClientRegistration gets the registered Client from the OP, if it is there.
+func (r *ReconcileClient) GetClientRegistration(ctx context.Context, client *oidcv1.Client) (response *http.Response, err error) {
+  reqLogger := logf.FromContext(ctx).WithName("GetClientRegistration")
+  authServiceURL, err := r.GetIdentityProviderURL()
+  if err != nil {
+    return
+  }
+	url := strings.Join([]string{authServiceURL, "v1", "auth", "registration", client.Spec.ClientId}, "/")
+	response, err = r.invokeClientRegistrationAPI(ctx, client, GetType, url, "")
+	if response == nil {
+    err = fmt.Errorf("did not receive response from identity provider")
+  } else if response.StatusCode >= 400 {
+    defer response.Body.Close()
+    reqLogger.Info("response is non-nil and StatusCode is >=400")
+    responseBody, _ := ioutil.ReadAll(response.Body)
+    err = errors.New(string(responseBody))
+  } else if response.Status != "200 OK" {
+    err = fmt.Errorf("did not get client successfully; received status %q", response.Status)
+  }
+  return
 }
 
-func (r *ReconcileClient) getCredentialsFromResponse(response *http.Response) (*ClientCredentials, error) {
-	responseObj := &OidcClientResponse{}
-	buf := new(bytes.Buffer)
+// GetClientCreds uses information from a Client to obtain the Client's credentials from the cluster.
+// The Client must at a minimum have its ClientId, Secret, and namespace set.
+func (r *ReconcileClient) GetClientCreds(ctx context.Context, client *oidcv1.Client) (clientCreds *ClientCredentials, err error) {
+  if client == nil {
+    return nil, fmt.Errorf("provided nil client")
+  } else if client.Spec.ClientId == "" {
+    return nil, fmt.Errorf("clientId was not set on Client")
+  } 
+  reqLogger := logf.FromContext(ctx).WithName("GetClientCreds").WithValues("clientId", client.Spec.ClientId)
+  if client.Spec.Secret == "" {
+    return nil, fmt.Errorf("secret was not set on Client")
+  }
+  secret := &corev1.Secret{}
+  err = r.client.Get(ctx, types.NamespacedName{Name: client.Spec.Secret, Namespace: client.GetNamespace()}, secret)
+  if err != nil {
+    return
+  }
+  reqLogger.Info("successfully retrieved secret for Client", "secret", client.Spec.Secret)
+  clientId := string(secret.Data["CLIENT_ID"][:])
+  if clientId != client.Spec.ClientId {
+    return nil, fmt.Errorf("secret %q with CLIENT_ID %q did not match .spec.clientId %q", client.Spec.Secret, clientId, client.Spec.ClientId)
+  }
+  clientCreds = &ClientCredentials{
+    ClientID: clientId,
+    ClientSecret: string(secret.Data["CLIENT_SECRET"][:]),
+  }
+  return
+}
+
+// getCredentialsFromResponse unmarshals the Client ID and Secret from an Authorization Service *http.Response into a
+// *ClientCredentials struct.
+func (r *ReconcileClient) unmarshalClientCreds(response *http.Response) (clientCreds *ClientCredentials, err error) {
+  clientCreds = &ClientCredentials{}
+  buf := new(bytes.Buffer)
 	buf.ReadFrom(response.Body)
 	defer response.Body.Close()
-	regRespone := buf.String()
-	errParse := json.Unmarshal([]byte(regRespone), responseObj)
-	if errParse == nil {
-		clientCred := &ClientCredentials{
-			CLIENT_ID:     responseObj.ClientID,
-			CLIENT_SECRET: responseObj.ClientSecret,
-		}
-		return clientCred, nil
-	} else {
-		return nil, errParse
-	}
+	registrationAPIResponse := buf.String()
+	err = json.Unmarshal([]byte(registrationAPIResponse), clientCreds)
+  return
 }
 
-func (r *ReconcileClient) generateClientCredentials(serviceName string) *ClientCredentials {
+func (r *ReconcileClient) generateClientCredentials(clientID string) *ClientCredentials {
 	log.Info("OidcClient-Watcher, Generate ClientID & Secret")
 	rule := `^([a-z0-9]){32,}$`
-	clientId := generateRandomString(rule)
+  // If clientID is empty, generate a new Client ID
+  if len(clientID) == 0 {
+    clientID = generateRandomString(rule)
+  }
 	clientSecret := generateRandomString(rule)
 	return &ClientCredentials{
-		CLIENT_ID:     clientId,
-		CLIENT_SECRET: clientSecret,
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
 	}
 }
 
 func generateRandomString(rule string) string {
-
 	generator, _ := regen.NewGenerator(rule, &regen.GeneratorArgs{
 		RngSource:               rand.NewSource(time.Now().UnixNano()),
 		MaxUnboundedRepeatCount: 1})
@@ -271,65 +242,51 @@ func generateRandomString(rule string) string {
 	return randomString
 }
 
-func SecureRandomAlphaString(length int) string {
-
-	result := make([]byte, length)
-	bufferSize := int(float64(length) * 1.3)
-	for i, j, randomBytes := 0, 0, []byte{}; i < length; j++ {
-		if j%bufferSize == 0 {
-			randomBytes = SecureRandomBytes(bufferSize)
-		}
-		if idx := int(randomBytes[j%length] & letterIdxMask); idx < len(letterBytes) {
-			result[i] = letterBytes[idx]
-			i++
-		}
-	}
-
-	return string(result)
-}
-
-// SecureRandomBytes returns the requested number of bytes using crypto/rand
-func SecureRandomBytes(length int) []byte {
-	var randomBytes = make([]byte, length)
-	_, err := rand.Read(randomBytes)
-	if err != nil {
-		fmt.Println("Unable to generate random bytes")
-	}
-	return randomBytes
-}
-
-func (r *ReconcileClient) generateClientRegistrationPayload(oidcreg *securityv1.Client, clientCred *ClientCredentials) string {
+func (r *ReconcileClient) generateClientRegistrationPayload(client *oidcv1.Client, clientCred *ClientCredentials) (payload string) {
 	payloadJSON := map[string]interface{}{
 		"token_endpoint_auth_method": "client_secret_basic",
 		"scope":                      "openid profile email",
-		"client_id":                  clientCred.CLIENT_ID,
-		"client_secret":              clientCred.CLIENT_SECRET,
+		"client_id":                  clientCred.ClientID,
+		"client_secret":              clientCred.ClientSecret,
 		"grant_types": []string{
 			"authorization_code",
 			"client_credentials",
 			"password",
 			"implicit",
 			"refresh_token",
-			"urn:ietf:params:oauth:grant-type:jwt-bearer"},
+			"urn:ietf:params:oauth:grant-type:jwt-bearer",
+    },
 		"response_types": []string{
 			"code",
 			"token",
-			"id_token token"},
+			"id_token token",
+    },
 		"application_type":          "web",
 		"subject_type":              "public",
-		"post_logout_redirect_uris": oidcreg.Spec.OidcLibertyClient.LogoutUris,
+		"post_logout_redirect_uris": client.Spec.OidcLibertyClient.LogoutUris,
 		"preauthorized_scope":       "openid profile email general",
 		"introspect_tokens":         true,
-		"trusted_uri_prefixes":      oidcreg.Spec.OidcLibertyClient.TrustedUris,
-		"redirect_uris":             oidcreg.Spec.OidcLibertyClient.RedirectUris}
+		"trusted_uri_prefixes":      client.Spec.OidcLibertyClient.TrustedUris,
+		"redirect_uris":             client.Spec.OidcLibertyClient.RedirectUris,
+  }
+
+  if client.IsCPClientCredentialsEnabled() {
+    grant_types, ok := payloadJSON["grant_types"].([]string)
+    if !ok {
+      goto marshal
+    }
+    payloadJSON["grant_types"] = append(grant_types, "cpclient_credentials")
+    payloadJSON["functional_user_groupIds"] = client.Spec.Roles
+  }
+  marshal:
 	payloadBytes, _ := json.Marshal(payloadJSON)
-	payload := string(payloadBytes[:])
+	payload = string(payloadBytes[:])
 	return payload
 }
 
 
 // GetZenInstance returns the zen instance or nil if it does not exist
-func (r *ReconcileClient) GetZenInstance(client *securityv1.Client) (*ZenInstance, error) {
+func (r *ReconcileClient) GetZenInstance(ctx context.Context, client *oidcv1.Client) (zenInstance *ZenInstance, err error) {
 
 	if client.Spec.ZenInstanceId == "" {
 		return nil, fmt.Errorf("Zen instance id is required to query a zen instance")
@@ -337,15 +294,16 @@ func (r *ReconcileClient) GetZenInstance(client *securityv1.Client) (*ZenInstanc
 
   identityManagementURL, err := r.GetIdentityManagementURL()
   if err != nil {
-    return nil, err
+    return
   } 
 
-	requestURL := strings.Join([]string{identityManagementURL, "/identity/api/v1/zeninstance/", client.Spec.ZenInstanceId}, "")
+  requestURLSplit := []string{identityManagementURL, "identity", "api", "v1", "zeninstance", client.Spec.ZenInstanceId}
+	requestURL := strings.Join(requestURLSplit, "/")
 
-	response, err := r.invokeIamApi(GetType, requestURL, "")
+	response, err := r.invokeIamApi(ctx, client, GetType, requestURL, "")
 
 	if err != nil {
-		return nil, err
+		return
 	}
 	if response != nil {
 		if response.StatusCode == 404 {
@@ -371,7 +329,7 @@ func (r *ReconcileClient) GetZenInstance(client *securityv1.Client) (*ZenInstanc
 }
 
 // DeleteZenInstance deletes the requested zen instance
-func (r *ReconcileClient) DeleteZenInstance(client *securityv1.Client) error {
+func (r *ReconcileClient) DeleteZenInstance(ctx context.Context, client *oidcv1.Client) (err error) {
 	if client.Spec.ZenInstanceId == "" {
 		return fmt.Errorf("Zen instance id is required to delete a zen instance")
 	}
@@ -381,16 +339,20 @@ func (r *ReconcileClient) DeleteZenInstance(client *securityv1.Client) error {
   if err != nil {
     return err
   } 
-	requestURL := strings.Join([]string{identityManagementURL, "/identity/api/v1/zeninstance/", client.Spec.ZenInstanceId}, "")
-	response, err := r.invokeIamApi(DeleteType, requestURL, "")
+  requestURLSplit := []string{identityManagementURL, "identity", "api", "v1", "zeninstance", client.Spec.ZenInstanceId}
+	requestURL := strings.Join(requestURLSplit, "/")
+	response, err := r.invokeIamApi(ctx, client, DeleteType, requestURL, "")
+	if err != nil {
+		return
+	}
 
 	if err != nil {
-		return err
+		return 
 	}
 	if response != nil {
 		if response.StatusCode == 200 {
 			//zen instance deleted
-			return nil
+			return
 		}
 		//Read response body
 		buf := new(bytes.Buffer)
@@ -403,7 +365,7 @@ func (r *ReconcileClient) DeleteZenInstance(client *securityv1.Client) error {
 }
 
 // CreateZenInstance registers the zen instance with the iam identity mgmt service
-func (r *ReconcileClient) CreateZenInstance(client *securityv1.Client) error {
+func (r *ReconcileClient) CreateZenInstance(ctx context.Context, client *oidcv1.Client) (err error) {
 	payloadJSON := map[string]interface{}{
 		"clientId":       client.Spec.ClientId,
 		"instanceId":     client.Spec.ZenInstanceId,
@@ -415,21 +377,22 @@ func (r *ReconcileClient) CreateZenInstance(client *securityv1.Client) error {
 
   identityManagementURL, err := r.GetIdentityManagementURL()
   if err != nil {
-    return err
+    return
   } 
-	requestURL := strings.Join([]string{identityManagementURL, "/identity/api/v1/zeninstance"}, "")
+  requestURLSplit := []string{identityManagementURL, "identity", "api", "v1", "zeninstance"}
+	requestURL := strings.Join(requestURLSplit, "/")
 
-	response, err := r.invokeIamApi(PostType, requestURL, payload)
+	response, err := r.invokeIamApi(ctx, client, PostType, requestURL, payload)
 	if response != nil && response.Status == "200 OK" {
 		return nil
 	}
 	if err != nil {
-		return err
+		return
 	}
 	//Determine error and report
 	buf := new(bytes.Buffer)
 	buf.ReadFrom(response.Body)
 	errorMsg := buf.String()
 	err = fmt.Errorf("An error occurred while registering the zen instance: Status:%s Msg:%s", response.Status, errorMsg)
-	return err
+	return
 }

--- a/pkg/controller/client/icperror.go
+++ b/pkg/controller/client/icperror.go
@@ -18,10 +18,12 @@ package client
 
 import (
 	"bytes"
+  "context"
 	"encoding/json"
 	"net/http"
 
 	condition "github.com/IBM/ibm-iam-operator/pkg/api/util"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	securityv1 "github.com/IBM/ibm-iam-operator/pkg/apis/oidc/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/record"
@@ -58,7 +60,8 @@ const (
 	ReasonUnknown                     string = "Unknown"
 )
 
-func handleOIDCClientError(oidcreg *securityv1.Client, response *http.Response, err error, requestType string, recorder record.EventRecorder) {
+func handleOIDCClientError(ctx context.Context, oidcreg *securityv1.Client, response *http.Response, err error, requestType string, recorder record.EventRecorder) {
+  logger := logf.FromContext(ctx)
 	var errorMessage, reason string
 	errorObj := &OidcClientError{}
 
@@ -85,9 +88,12 @@ func handleOIDCClientError(oidcreg *securityv1.Client, response *http.Response, 
 		} else {
 			errorMessage = MessageUnknown
 		}
+    logger.Info("nil error", "errorMessage", errorMsg, "status", response.Status)
 	} else {
+    logger.Error(err, "error found from OIDC Client")
 		errorMessage = err.Error()
 	}
+
 
 	if requestType == PostType {
 		condition.SetClientCondition(oidcreg,


### PR DESCRIPTION
https://github.ibm.com/IBMPrivateCloud/roadmap/issues/55959

- Change all of the Client controller's direct interactions with the OP
  to route through the identity provider endpoints instead
- Provide the ability to use the cpclient_credentials grant type, which
  replaces the use of service ID tokens. This grant type is available
  whenever a Client CR has the following fields set:
  1. `zenAuditUrl`, which represents the URL of the Zen Audit service
     that usage is reported to, and
  2. `roles`, which is a list of strings that map to
     `functional_user_groupIds` in the OP.
- Update logging to more uniformly utilize the controller-runtime's
  logger for consistency.

Signed-off-by: Rob Hundley <rwhundle@us.ibm.com>