### PR TITLE
Update ibm-iam-operator.v4.0.0.clusterserviceversion.yaml to read from namespace scope

### DIFF
--- a/deploy/olm-catalog/ibm-iam-operator/4.0.0/ibm-iam-operator.v4.0.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-iam-operator/4.0.0/ibm-iam-operator.v4.0.0.clusterserviceversion.yaml
@@ -1386,8 +1386,9 @@ spec:
                   value: quay.io/opencloudio/audit-syslog-service:1.8.0
                 - name: WATCH_NAMESPACE
                   valueFrom:
-                    fieldRef:
-                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                    configMapKeyRef:
+                      name: namespace-scope
+                      key: namespaces
                 - name: POD_NAME
                   valueFrom:
                     fieldRef:


### PR DESCRIPTION
Update to map the content of OperatorGroup and namespace-scope ConfigMap within the namespace it is deployed, to provide the backwards-compatibility for the contributed services which rely on the NSS interface for getting a list of watched namespaces.

https://github.ibm.com/IBMPrivateCloud/roadmap/issues/56808