### PR TITLE
Update ibm-iam-operator.v4.0.0.clusterserviceversion.yaml to remove cert-manager dependency

### DIFF
--- a/deploy/olm-catalog/ibm-iam-operator/4.0.0/ibm-iam-operator.v4.0.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-iam-operator/4.0.0/ibm-iam-operator.v4.0.0.clusterserviceversion.yaml
@@ -163,9 +163,6 @@ metadata:
                     "name": "ibm-mongodb-operator"
                   },
                   {
-                    "name": "ibm-cert-manager-operator"
-                  },
-                  {
                     "name": "ibm-management-ingress-operator"
                   },
                   {


### PR DESCRIPTION
Update ibm-iam-operator.v4.0.0.clusterserviceversion.yaml to remove cert-manager dependency:

https://github.ibm.com/IBMPrivateCloud/roadmap/issues/56784