### PR TITLE
Add ODLM service status to Authentications

### DIFF
--- a/deploy/olm-catalog/ibm-iam-operator/4.0.0/operator.ibm.com_authentications_crd.yaml
+++ b/deploy/olm-catalog/ibm-iam-operator/4.0.0/operator.ibm.com_authentications_crd.yaml
@@ -373,6 +373,7 @@ spec:
             required:
             - nodes
             type: object
+            x-kubernetes-preserve-unknown-fields: true
         type: object
     served: true
     storage: true

--- a/pkg/apis/operator/v1alpha1/authentication_types.go
+++ b/pkg/apis/operator/v1alpha1/authentication_types.go
@@ -17,8 +17,12 @@
 package v1alpha1
 
 import (
+  "context"
+  "sync"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
@@ -115,12 +119,84 @@ type ConfigSpec struct {
 	AttrMappingFromConfig       bool   `json:"attrMappingFromConfig,omitempty"`
 }
 
+type ManagedResourceStatus struct {
+	ObjectName string `json:"objectName,omitempty"`
+	APIVersion string `json:"apiVersion,omitempty"`
+	Namespace  string `json:"namespace,omitempty"`
+	Kind       string `json:"kind,omitempty"`
+	Status string `json:"status,omitempty"`
+}
+
+type ServiceStatus struct {
+  ObjectName string `json:"objectName,omitempty"`
+  APIVersion string `json:"apiVersion,omitempty"`
+  Namespace  string `json:"namespace,omitempty"`
+  Kind       string `json:"kind,omitempty"`
+  Status string `json:"status,omitempty"`
+  ManagedResources []ManagedResourceStatus `json:"managedResources,omitempty"`
+}
+
+func (a *Authentication) SetService(ctx context.Context, service ServiceStatus, statusClient client.StatusClient, mu sync.Locker) (err error) {
+  reqLogger := logf.FromContext(ctx).WithName("SetService").V(3)
+  mu.Lock()
+  defer mu.Unlock()
+  if a.Status.Service.ObjectName == "" {
+    reqLogger.Info("ObjectName is empty")
+    a.Status.Service = service
+    reqLogger.Info("Updating service", "service", a.Status.Service)
+    err = statusClient.Status().Update(ctx, a)
+    if err != nil {
+      reqLogger.Error(err, "Attempt to update failed")
+    }
+    return
+  }
+  reqLogger.Info("ObjectName is set", "ObjectName", a.Status.Service.ObjectName)
+  for _, managedResource := range service.ManagedResources {
+    if managedResource.ObjectName != "" {
+      reqLogger.Info("Review managed resource", "mangedResource", managedResource)
+      pos, _ := getResourceStatus(a.Status.Service.ManagedResources, managedResource.ObjectName)
+      if pos != -1 {
+        reqLogger.Info("Found in existing status", "prev", a.Status.Service.ManagedResources[pos], "current", managedResource)
+        a.Status.Service.ManagedResources[pos] = managedResource
+        err = statusClient.Status().Update(ctx, a)
+        if err != nil {
+          reqLogger.Error(err, "Attempt to update failed")
+          return
+        }
+      } else {
+        reqLogger.Info("Not found in existing status", "current", managedResource)
+        a.Status.Service.ManagedResources = append(a.Status.Service.ManagedResources, managedResource)
+        err = statusClient.Status().Update(ctx, a)
+        if err != nil {
+          reqLogger.Error(err, "Attempt to update failed")
+          return
+        }
+      }
+    }
+  }
+  if a.Status.Service.Status != service.Status {
+    a.Status.Service.Status = service.Status
+  }
+  err = statusClient.Status().Update(ctx, a)
+  if err != nil {
+    reqLogger.Error(err, "Attempt to update failed")
+  }
+  return
+}
+
+func getResourceStatus(resources []ManagedResourceStatus, name string) (pos int, resourceStatus *ManagedResourceStatus) {
+  for i, r := range resources {
+    if name == resources[i].ObjectName {
+      return i, &r
+    }
+  }
+  return -1, nil
+}
+
 // AuthenticationStatus defines the observed state of Authentication
 type AuthenticationStatus struct {
-	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
-	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
-	// Add custom validation using kubebuilder tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html
 	Nodes []string `json:"nodes"`
+  Service ServiceStatus `json:"service,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -131,7 +207,6 @@ type AuthenticationStatus struct {
 type Authentication struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-
 	Spec   AuthenticationSpec   `json:"spec,omitempty"`
 	Status AuthenticationStatus `json:"status,omitempty"`
 }

--- a/pkg/controller/authentication/resourcestatus.go
+++ b/pkg/controller/authentication/resourcestatus.go
@@ -17,134 +17,176 @@
 package authentication
 
 import (
-  "context"
+	"context"
+
 	operatorv1alpha1 "github.com/IBM/ibm-iam-operator/pkg/apis/operator/v1alpha1"
-	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	routev1 "github.com/openshift/api/route/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-func getServiceStatus(s *corev1.Service) (status operatorv1alpha1.ManagedResourceStatus) {
-  status = operatorv1alpha1.ManagedResourceStatus{
-    ObjectName: s.Name,
-    APIVersion: s.APIVersion,
-    Namespace: s.Namespace,
-    Kind: "Service",
-    Status: "NotReady",
-  }
-  if s == nil {
-    return
-  }
-  status.Status = "Ready"
-  return
-}
-
-func getDeploymentStatus(d *appsv1.Deployment) (status operatorv1alpha1.ManagedResourceStatus) {
-  status = operatorv1alpha1.ManagedResourceStatus{
-    ObjectName: d.Name,
-    APIVersion: d.APIVersion,
-    Namespace: d.Namespace,
-    Kind: "Deployment",
-    Status: "NotReady",
-  }
-  for _, condition := range d.Status.Conditions {
-    if condition.Type == appsv1.DeploymentAvailable && condition.Status == corev1.ConditionTrue {
-      status.Status = "Ready"
-      return
-    }
-  }
-  return
-}
-
-func getJobStatus(j *batchv1.Job) (status operatorv1alpha1.ManagedResourceStatus) {
-  status = operatorv1alpha1.ManagedResourceStatus{
-    ObjectName: j.Name,
-    APIVersion: j.APIVersion,
-    Namespace: j.Namespace,
-    Kind: "Job",
-    Status: "NotReady",
-  }
-  if j == nil {
-    return
-  }
-
-  for _, condition := range j.Status.Conditions {
-    if condition.Type == batchv1.JobComplete && condition.Status == corev1.ConditionTrue {
-      status.Status = "Ready"
-      return
-    }
-  }
-  return
-}
-
-func getRouteStatus(r *routev1.Route) (status operatorv1alpha1.ManagedResourceStatus) {
-  status = operatorv1alpha1.ManagedResourceStatus{
-    ObjectName: r.Name,
-    APIVersion: r.APIVersion,
-    Namespace: r.Namespace,
-    Kind: "Route",
-    Status: "NotReady",
-  }
-  for _, routeIngress := range r.Status.Ingress {
-    for _, condition := range routeIngress.Conditions {
-      if condition.Type == routev1.RouteAdmitted && condition.Status != corev1.ConditionTrue {
-        return
-      }
-    }
-  }
-  status.Status = "Ready"
-  return
-}
-
 type statusRetrievalFunc func(context.Context, client.Client, []string, string) []operatorv1alpha1.ManagedResourceStatus
+
+const (
+  UnknownAPIVersion string = "Unknown"
+  ResourceReadyState string = "Ready"
+  ResourceNotReadyState string = "NotReady"
+)
+
+func getServiceStatus(ctx context.Context, k8sClient client.Client, namespacedName types.NamespacedName) (status operatorv1alpha1.ManagedResourceStatus) {
+  reqLogger := logf.FromContext(ctx).WithName("getServiceStatus")
+  kind := "Service"
+  status = operatorv1alpha1.ManagedResourceStatus{
+    ObjectName: namespacedName.Name,
+    APIVersion: UnknownAPIVersion,
+    Namespace: namespacedName.Namespace,
+    Kind: kind,
+    Status: ResourceNotReadyState,
+  }
+  service := &corev1.Service{}
+  err := k8sClient.Get(ctx, namespacedName, service)
+  if err != nil {
+    if errors.IsNotFound(err) {
+      reqLogger.Info("Could not find resource for status update", "kind", kind, "name", namespacedName.Name, "namespace", namespacedName.Namespace)
+    } else {
+      reqLogger.Error(err, "Error reading resource for status update", "kind", kind, "name", namespacedName.Name, "namespace", namespacedName.Namespace)
+    }
+    return
+  }
+  status.APIVersion = service.APIVersion
+  status.Status = ResourceReadyState
+  return
+}
 
 func getAllServiceStatus(ctx context.Context, k8sClient client.Client, names []string, namespace string) (statuses []operatorv1alpha1.ManagedResourceStatus) {
   reqLogger := logf.FromContext(ctx).WithName("getAllServiceStatus").V(3)
   for _, name := range names {
-    s := &corev1.Service{}
     nsn := types.NamespacedName{ Name: name, Namespace: namespace }
-    _ = k8sClient.Get(ctx, nsn, s)
-    statuses = append(statuses, getServiceStatus(s))
+    statuses = append(statuses, getServiceStatus(ctx, k8sClient, nsn))
   }
   reqLogger.Info("New statuses", "statuses", statuses)
+  return
+}
+
+func getDeploymentStatus(ctx context.Context, k8sClient client.Client, namespacedName types.NamespacedName) (status operatorv1alpha1.ManagedResourceStatus) {
+  reqLogger := logf.FromContext(ctx).WithName("getDeploymentStatus")
+  kind := "Deployment"
+  status = operatorv1alpha1.ManagedResourceStatus{
+    ObjectName: namespacedName.Name,
+    APIVersion: UnknownAPIVersion,
+    Namespace: namespacedName.Namespace,
+    Kind: kind,
+    Status: ResourceNotReadyState,
+  }
+  deployment := &appsv1.Deployment{}
+  err := k8sClient.Get(ctx, namespacedName, deployment)
+  if err != nil {
+    if errors.IsNotFound(err) {
+      reqLogger.Info("Could not find resource for status update", "kind", kind, "name", namespacedName.Name, "namespace", namespacedName.Namespace)
+    } else {
+      reqLogger.Error(err, "Error reading resource for status update", "kind", kind, "name", namespacedName.Name, "namespace", namespacedName.Namespace)
+    }
+    return
+  }
+  for _, condition := range deployment.Status.Conditions {
+    if condition.Type == appsv1.DeploymentAvailable && condition.Status == corev1.ConditionTrue {
+      status.Status = ResourceReadyState
+      return
+    }
+  }
   return
 }
 
 func getAllDeploymentStatus(ctx context.Context, k8sClient client.Client, names []string, namespace string) (statuses []operatorv1alpha1.ManagedResourceStatus) {
   reqLogger := logf.FromContext(ctx).WithName("getAllDeploymentStatus").V(3)
   for _, name := range names {
-    d := &appsv1.Deployment{}
     nsn := types.NamespacedName{ Name: name, Namespace: namespace }
-    _ = k8sClient.Get(ctx, nsn, d)
-    statuses = append(statuses, getDeploymentStatus(d))
+    statuses = append(statuses, getDeploymentStatus(ctx, k8sClient, nsn))
   }
   reqLogger.Info("New statuses", "statuses", statuses)
+  return
+}
+
+func getJobStatus(ctx context.Context, k8sClient client.Client, namespacedName types.NamespacedName) (status operatorv1alpha1.ManagedResourceStatus) {
+  reqLogger := logf.FromContext(ctx).WithName("getJobStatus")
+  kind := "Job"
+  status = operatorv1alpha1.ManagedResourceStatus{
+    ObjectName: namespacedName.Name,
+    APIVersion: UnknownAPIVersion,
+    Namespace: namespacedName.Namespace,
+    Kind: kind,
+    Status: ResourceNotReadyState,
+  }
+  job := &batchv1.Job{}
+  err := k8sClient.Get(ctx, namespacedName, job)
+  if err != nil {
+    if errors.IsNotFound(err) {
+      reqLogger.Info("Could not find resource for status update", "kind", kind, "name", namespacedName.Name, "namespace", namespacedName.Namespace)
+    } else {
+      reqLogger.Error(err, "Error reading resource for status update", "kind", kind, "name", namespacedName.Name, "namespace", namespacedName.Namespace)
+    }
+    return
+  }
+  for _, condition := range job.Status.Conditions {
+    if condition.Type == batchv1.JobComplete && condition.Status == corev1.ConditionTrue {
+      status.Status = ResourceReadyState
+      return
+    }
+  }
   return
 }
 
 func getAllJobStatus(ctx context.Context, k8sClient client.Client, names []string, namespace string) (statuses []operatorv1alpha1.ManagedResourceStatus) {
   reqLogger := logf.FromContext(ctx).WithName("getAllJobStatus").V(3)
   for _, name := range names {
-    j := &batchv1.Job{}
     nsn := types.NamespacedName{ Name: name, Namespace: namespace }
-    _ = k8sClient.Get(ctx, nsn, j)
-    statuses = append(statuses, getJobStatus(j))
+    statuses = append(statuses, getJobStatus(ctx, k8sClient, nsn))
   }
   reqLogger.Info("New statuses", "statuses", statuses)
+  return
+}
+
+func getRouteStatus(ctx context.Context, k8sClient client.Client, namespacedName types.NamespacedName) (status operatorv1alpha1.ManagedResourceStatus) {
+  reqLogger := logf.FromContext(ctx).WithName("getRouteStatus")
+  kind := "Route"
+  status = operatorv1alpha1.ManagedResourceStatus{
+    ObjectName: namespacedName.Name,
+    APIVersion: UnknownAPIVersion,
+    Namespace: namespacedName.Namespace,
+    Kind: kind,
+    Status: ResourceNotReadyState,
+  }
+  route := &routev1.Route{}
+  err := k8sClient.Get(ctx, namespacedName, route)
+  if err != nil {
+    if errors.IsNotFound(err) {
+      reqLogger.Info("Could not find resource for status update", "kind", kind, "name", namespacedName.Name, "namespace", namespacedName.Namespace)
+    } else {
+      reqLogger.Error(err, "Error reading resource for status update", "kind", kind, "name", namespacedName.Name, "namespace", namespacedName.Namespace)
+    }
+    return
+  }
+  for _, routeIngress := range route.Status.Ingress {
+    for _, condition := range routeIngress.Conditions {
+      if condition.Type == routev1.RouteAdmitted && condition.Status != corev1.ConditionTrue {
+        return
+      }
+    }
+  }
+  status.Status = ResourceReadyState
   return
 }
 
 func getAllRouteStatus(ctx context.Context, k8sClient client.Client, names []string, namespace string) (statuses []operatorv1alpha1.ManagedResourceStatus) {
   reqLogger := logf.FromContext(ctx).WithName("getAllRouteStatus").V(3)
   for _, name := range names {
-    r := &routev1.Route{}
     nsn := types.NamespacedName{ Name: name, Namespace: namespace }
-    _ = k8sClient.Get(ctx, nsn, r)
-    statuses = append(statuses, getRouteStatus(r))
+    statuses = append(statuses, getRouteStatus(ctx, k8sClient, nsn))
   }
   reqLogger.Info("New statuses", "statuses", statuses)
   return
@@ -195,13 +237,14 @@ func getCurrentServiceStatus(ctx context.Context, k8sClient client.Client, authe
     },
   }
 
+  kind := "Authentication"
   status = operatorv1alpha1.ServiceStatus{
     ObjectName: authentication.Name,
     Namespace: authentication.Namespace,
     APIVersion: authentication.APIVersion,
-    Kind: "Authentication",
+    Kind: kind,
     ManagedResources: []operatorv1alpha1.ManagedResourceStatus{},
-    Status: "NotReady",
+    Status: ResourceNotReadyState,
   }
 
   reqLogger.Info("Getting statuses")
@@ -210,10 +253,10 @@ func getCurrentServiceStatus(ctx context.Context, k8sClient client.Client, authe
   }
 
   for _, managedResourceStatus := range status.ManagedResources {
-    if managedResourceStatus.Status == "NotReady" {
+    if managedResourceStatus.Status == ResourceNotReadyState {
       return
     }
   }
-  status.Status = "Ready"
+  status.Status = ResourceReadyState
   return
 }

--- a/pkg/controller/authentication/resourcestatus.go
+++ b/pkg/controller/authentication/resourcestatus.go
@@ -1,0 +1,219 @@
+//
+// Copyright 2020 IBM Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package authentication
+
+import (
+  "context"
+	operatorv1alpha1 "github.com/IBM/ibm-iam-operator/pkg/apis/operator/v1alpha1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	routev1 "github.com/openshift/api/route/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+func getServiceStatus(s *corev1.Service) (status operatorv1alpha1.ManagedResourceStatus) {
+  status = operatorv1alpha1.ManagedResourceStatus{
+    ObjectName: s.Name,
+    APIVersion: s.APIVersion,
+    Namespace: s.Namespace,
+    Kind: "Service",
+    Status: "NotReady",
+  }
+  if s == nil {
+    return
+  }
+  status.Status = "Ready"
+  return
+}
+
+func getDeploymentStatus(d *appsv1.Deployment) (status operatorv1alpha1.ManagedResourceStatus) {
+  status = operatorv1alpha1.ManagedResourceStatus{
+    ObjectName: d.Name,
+    APIVersion: d.APIVersion,
+    Namespace: d.Namespace,
+    Kind: "Deployment",
+    Status: "NotReady",
+  }
+  for _, condition := range d.Status.Conditions {
+    if condition.Type == appsv1.DeploymentAvailable && condition.Status == corev1.ConditionTrue {
+      status.Status = "Ready"
+      return
+    }
+  }
+  return
+}
+
+func getJobStatus(j *batchv1.Job) (status operatorv1alpha1.ManagedResourceStatus) {
+  status = operatorv1alpha1.ManagedResourceStatus{
+    ObjectName: j.Name,
+    APIVersion: j.APIVersion,
+    Namespace: j.Namespace,
+    Kind: "Job",
+    Status: "NotReady",
+  }
+  if j == nil {
+    return
+  }
+
+  for _, condition := range j.Status.Conditions {
+    if condition.Type == batchv1.JobComplete && condition.Status == corev1.ConditionTrue {
+      status.Status = "Ready"
+      return
+    }
+  }
+  return
+}
+
+func getRouteStatus(r *routev1.Route) (status operatorv1alpha1.ManagedResourceStatus) {
+  status = operatorv1alpha1.ManagedResourceStatus{
+    ObjectName: r.Name,
+    APIVersion: r.APIVersion,
+    Namespace: r.Namespace,
+    Kind: "Route",
+    Status: "NotReady",
+  }
+  for _, routeIngress := range r.Status.Ingress {
+    for _, condition := range routeIngress.Conditions {
+      if condition.Type == routev1.RouteAdmitted && condition.Status != corev1.ConditionTrue {
+        return
+      }
+    }
+  }
+  status.Status = "Ready"
+  return
+}
+
+type statusRetrievalFunc func(context.Context, client.Client, []string, string) []operatorv1alpha1.ManagedResourceStatus
+
+func getAllServiceStatus(ctx context.Context, k8sClient client.Client, names []string, namespace string) (statuses []operatorv1alpha1.ManagedResourceStatus) {
+  reqLogger := logf.FromContext(ctx).WithName("getAllServiceStatus").V(3)
+  for _, name := range names {
+    s := &corev1.Service{}
+    nsn := types.NamespacedName{ Name: name, Namespace: namespace }
+    _ = k8sClient.Get(ctx, nsn, s)
+    statuses = append(statuses, getServiceStatus(s))
+  }
+  reqLogger.Info("New statuses", "statuses", statuses)
+  return
+}
+
+func getAllDeploymentStatus(ctx context.Context, k8sClient client.Client, names []string, namespace string) (statuses []operatorv1alpha1.ManagedResourceStatus) {
+  reqLogger := logf.FromContext(ctx).WithName("getAllDeploymentStatus").V(3)
+  for _, name := range names {
+    d := &appsv1.Deployment{}
+    nsn := types.NamespacedName{ Name: name, Namespace: namespace }
+    _ = k8sClient.Get(ctx, nsn, d)
+    statuses = append(statuses, getDeploymentStatus(d))
+  }
+  reqLogger.Info("New statuses", "statuses", statuses)
+  return
+}
+
+func getAllJobStatus(ctx context.Context, k8sClient client.Client, names []string, namespace string) (statuses []operatorv1alpha1.ManagedResourceStatus) {
+  reqLogger := logf.FromContext(ctx).WithName("getAllJobStatus").V(3)
+  for _, name := range names {
+    j := &batchv1.Job{}
+    nsn := types.NamespacedName{ Name: name, Namespace: namespace }
+    _ = k8sClient.Get(ctx, nsn, j)
+    statuses = append(statuses, getJobStatus(j))
+  }
+  reqLogger.Info("New statuses", "statuses", statuses)
+  return
+}
+
+func getAllRouteStatus(ctx context.Context, k8sClient client.Client, names []string, namespace string) (statuses []operatorv1alpha1.ManagedResourceStatus) {
+  reqLogger := logf.FromContext(ctx).WithName("getAllRouteStatus").V(3)
+  for _, name := range names {
+    r := &routev1.Route{}
+    nsn := types.NamespacedName{ Name: name, Namespace: namespace }
+    _ = k8sClient.Get(ctx, nsn, r)
+    statuses = append(statuses, getRouteStatus(r))
+  }
+  reqLogger.Info("New statuses", "statuses", statuses)
+  return
+}
+
+func getCurrentServiceStatus(ctx context.Context, k8sClient client.Client, authentication *operatorv1alpha1.Authentication) (status operatorv1alpha1.ServiceStatus) {
+  reqLogger := logf.FromContext(ctx).WithName("getCurrentServiceStatus").V(3)
+  type statusRetrieval struct {
+    names []string
+    f statusRetrievalFunc
+  }
+
+  // 
+  statusRetrievals := []statusRetrieval {
+    {
+      names: []string {
+        "iam-token-service",
+        "platform-auth-service",
+        "platform-identity-management",
+        "platform-identity-provider",
+      },
+      f: getAllServiceStatus,
+    },
+    {
+      names: []string {
+        "platform-auth-service",
+        "platform-identity-management",
+        "platform-identity-provider",
+      },
+      f: getAllDeploymentStatus,
+    },
+    {
+      names: []string { "oidc-client-registration" },
+      f: getAllJobStatus,
+    },
+    {
+      names: []string {
+        "id-mgmt",
+        "platform-auth",
+        "platform-id-auth",
+        "platform-id-provider",
+        "platform-login",
+        "platform-oidc",
+        "saml-ui-callback",
+        "social-login-callback",
+      },
+      f: getAllRouteStatus,
+    },
+  }
+
+  status = operatorv1alpha1.ServiceStatus{
+    ObjectName: authentication.Name,
+    Namespace: authentication.Namespace,
+    APIVersion: authentication.APIVersion,
+    Kind: "Authentication",
+    ManagedResources: []operatorv1alpha1.ManagedResourceStatus{},
+    Status: "NotReady",
+  }
+
+  reqLogger.Info("Getting statuses")
+  for _, getStatuses := range statusRetrievals {
+    status.ManagedResources = append(status.ManagedResources, getStatuses.f(ctx, k8sClient, getStatuses.names, status.Namespace)...)
+  }
+
+  for _, managedResourceStatus := range status.ManagedResources {
+    if managedResourceStatus.Status == "NotReady" {
+      return
+    }
+  }
+  status.Status = "Ready"
+  return
+}


### PR DESCRIPTION
Originating issue: [IBMPrivateCloud/roadmap#56761](https://github.ibm.com/ibmprivatecloud/roadmap/issues/56761)

- Add service block to Authentication status that reports a red/green status of each of the Authentication's owned resources; meant to be consumed by ODLM.