### PR TITLE
Derive shared services namespace from Authentication

### DIFF
--- a/pkg/apis/addtoscheme_oidc_v1.go
+++ b/pkg/apis/addtoscheme_oidc_v1.go
@@ -19,6 +19,7 @@ package apis
 import (
 	v1 "github.com/IBM/ibm-iam-operator/pkg/apis/oidc/v1"
   oauthv1 "github.com/openshift/api/oauth/v1"
+  v1alpha1 "github.com/IBM/ibm-iam-operator/pkg/apis/operator/v1alpha1"
 )
 
 func init() {
@@ -26,4 +27,6 @@ func init() {
 	AddToSchemes = append(AddToSchemes, v1.SchemeBuilder.AddToScheme)
   // Register the Scheme that defines OAuthClient so the controller's client can manage them
   AddToSchemes = append(AddToSchemes, oauthv1.AddToScheme)
+  // Register v1alpha1 to get Authentication/AuthenticationList
+  AddToSchemes = append(AddToSchemes, v1alpha1.SchemeBuilder.AddToScheme)
 }

--- a/pkg/controller/client/iam.go
+++ b/pkg/controller/client/iam.go
@@ -62,7 +62,7 @@ func getTokenInfoFromResponse(response *http.Response) (tokenInfo *TokenInfo, er
 // in platform-auth-idp-credentials.
 func (r *ReconcileClient) getAuthnTokens(ctx context.Context, client *oidcv1.Client) (tokenInfo *TokenInfo, err error) {
   reqLogger := logf.FromContext(ctx).WithName("getAuthnTokens")
-  identityProviderURL, err := r.GetIdentityProviderURL(client.Namespace)
+  identityProviderURL, err := r.GetIdentityProviderURL()
   if err != nil {
     return nil, err
   }
@@ -83,11 +83,11 @@ func (r *ReconcileClient) getAuthnTokens(ctx context.Context, client *oidcv1.Cli
   } else {
     tokenType = "identitytoken"
     grantType = "password"
-    defaultAdminUser, err = r.GetDefaultAdminUser(client.Namespace)
+    defaultAdminUser, err = r.GetDefaultAdminUser()
     if err != nil {
       return
     }
-    defaultAdminPassword, err = r.GetDefaultAdminPassword(client.Namespace)
+    defaultAdminPassword, err = r.GetDefaultAdminPassword()
     if err != nil {
       return
     }
@@ -99,7 +99,7 @@ func (r *ReconcileClient) getAuthnTokens(ctx context.Context, client *oidcv1.Cli
   var req *http.Request
   var caCertSecret *corev1.Secret
   var httpClient *http.Client
-  oAuthAdminPassword, err := r.GetOAuthAdminPassword(client.Namespace)
+  oAuthAdminPassword, err := r.GetOAuthAdminPassword()
   if err != nil {
     return
   }
@@ -115,7 +115,8 @@ func (r *ReconcileClient) getAuthnTokens(ctx context.Context, client *oidcv1.Cli
     if client.IsCPClientCredentialsEnabled() {
       req.SetBasicAuth("oauthadmin", oAuthAdminPassword)
     }
-    caCertSecret, err = r.getCSCACertificateSecret(ctx, client.Namespace)
+
+    caCertSecret, err = r.getCSCACertificateSecret(ctx, r.sharedServicesNamespace)
     if err != nil {
       return
     }
@@ -169,7 +170,8 @@ func (r *ReconcileClient) invokeIamApi(ctx context.Context, client *oidcv1.Clien
 	request.Header.Set("Content-Type", "application/json")
 	request.Header.Set("Authorization", bearer)
 	request.Header.Set("Accept", "application/json")
-  caCertSecret, err := r.getCSCACertificateSecret(ctx, client.Namespace)
+
+  caCertSecret, err := r.getCSCACertificateSecret(ctx, r.sharedServicesNamespace)
   if err != nil {
     return nil, fmt.Errorf("failed to get certificate secret for namespace %q: %w", client.Namespace, err)
   }


### PR DESCRIPTION
Addresses the following:

- https://github.ibm.com/IBMPrivateCloud/roadmap/issues/57489
- https://github.ibm.com/IBMPrivateCloud/roadmap/issues/57490

Changes:

- Perform an intelligent guess on where the shared services namespace is based upon where the Operator is able to list an Authentication CR. There should only ever be one present among the namespaces the Operator can list. If no or more than one Authentication CR is found, an error is thrown as this is an unsupported usage of the Authentication CR.
- Use the shared services namespace for lookups of ConfigMaps, Secrets, etc.
- Revert use of namespace-to-ClientControllerConfig map to just a single ClientControllerConfig on ReconcileClient because the resources being looked up should always be in the shared services namespace, thus no longer requiring a map structure.
- When handling URLs that the code knows are based upon Service names, always convert them to the format `<Service name>.<Namespace of the Service>.svc`.