### PR TITLE
Undo audit service spec removal and add dummy data

### DIFF
--- a/deploy/olm-catalog/ibm-iam-operator/4.0.0/ibm-iam-operator.v4.0.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/ibm-iam-operator/4.0.0/ibm-iam-operator.v4.0.0.clusterserviceversion.yaml
@@ -16,6 +16,22 @@ metadata:
             "name": "example-authentication"
           },
           "spec": {
+            "auditService": {
+              "imageName": "audit-syslog-service",
+              "imageRegistry": "quay.io/opencloudio",
+              "imageTag": "1.8.0",
+              "syslogTlsPath": "/etc/audit-tls",
+              "resources": {
+                "limits": {
+                  "cpu": "100m",
+                  "memory": "128Mi"
+                },
+                "requests": {
+                  "cpu": "10m",
+                  "memory": "100Mi"
+                }
+              }
+            },
             "authService": {
               "imageName": "icp-platform-auth",
               "imageRegistry": "quay.io/opencloudio",
@@ -315,6 +331,11 @@ spec:
       - description: A list defines the catalog information for operator version.
         displayName: OperatorVersion
         path: operatorVersion
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: A list defines the catalog information for audit service.
+        displayName: AuditService
+        path: auditService
         x-descriptors:
         - 'urn:alm:descriptor:com.tectonic.ui:text'
       - description: A list defines the catalog information for auth service.

--- a/deploy/olm-catalog/ibm-iam-operator/4.0.0/operator.ibm.com_authentications_crd.yaml
+++ b/deploy/olm-catalog/ibm-iam-operator/4.0.0/operator.ibm.com_authentications_crd.yaml
@@ -36,6 +36,48 @@ spec:
             x-kubernetes-preserve-unknown-fields: true
             description: AuthenticationSpec defines the desired state of Authentication
             properties:
+              auditService:
+                properties:
+                  imageName:
+                    type: string
+                  imageRegistry:
+                    type: string
+                  imageTag:
+                    type: string
+                  resources:
+                    description: ResourceRequirements describes the compute resource
+                      requirements.
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                    type: object
+                  syslogTlsPath:
+                    type: string
+                required:
+                - imageName
+                - imageRegistry
+                - imageTag
+                type: object
               authService:
                 properties:
                   imageName:
@@ -350,6 +392,7 @@ spec:
                 format: int32
                 type: integer
             required:
+            - auditService
             - authService
             - clientRegistration
             - config

--- a/pkg/apis/operator/v1alpha1/authentication_types.go
+++ b/pkg/apis/operator/v1alpha1/authentication_types.go
@@ -35,12 +35,39 @@ type AuthenticationSpec struct {
 	// Add custom validation using kubebuilder tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html
 	OperatorVersion    string                 `json:"operatorVersion"`
 	Replicas           int32                  `json:"replicas"`
+  AuditService       AuditServiceSpec       `json:"auditService"`
 	AuthService        AuthServiceSpec        `json:"authService"`
 	IdentityProvider   IdentityProviderSpec   `json:"identityProvider"`
 	IdentityManager    IdentityManagerSpec    `json:"identityManager"`
 	InitMongodb        InitMongodbSpec        `json:"initMongodb"`
 	ClientRegistration ClientRegistrationSpec `json:"clientRegistration"`
 	Config             ConfigSpec             `json:"config"`
+}
+
+type AuditServiceSpec struct {
+	ImageRegistry string                       `json:"imageRegistry"`
+	ImageName     string                       `json:"imageName"`
+	ImageTag      string                       `json:"imageTag"`
+	SyslogTlsPath string                       `json:"syslogTlsPath,omitempty"`
+	Resources     *corev1.ResourceRequirements `json:"resources,omitempty"`
+}
+
+const AuditServiceIgnoreString string = "auditService no longer used - ignore"
+
+// setRequiredDummyData writes dummy AuditServiceSpec data to an Authentication in order to maintain backwards- and
+// forwards-compatibility with previous Authentication CRD releases. Running this function ensures that, if an earlier
+// version of the Authentication CRD is installed on a cluster where this version's CRD was previously, the CRs created
+// based upon this version's CRD will not break in a multi-tenancy scenario.
+func (a *Authentication) SetRequiredDummyData() {
+  if a == nil {
+    return
+  }
+
+  a.Spec.AuditService = AuditServiceSpec{
+    ImageRegistry: AuditServiceIgnoreString,
+    ImageName: AuditServiceIgnoreString,
+    ImageTag: AuditServiceIgnoreString,
+  }
 }
 
 type AuthServiceSpec struct {

--- a/pkg/controller/authentication/authentication_controller.go
+++ b/pkg/controller/authentication/authentication_controller.go
@@ -254,14 +254,6 @@ func (r *ReconcileAuthentication) Reconcile(ctx context.Context, request reconci
 		return
 	}
 
-  if needsAuditServiceDummyDataReset(instance) {
-    instance.SetRequiredDummyData()
-		err = r.client.Update(ctx, instance)
-		if err != nil {
-			return
-		}
-  }
-
   // Be sure to update status before returning if Authentication is found
   defer func() {
     reqLogger.Info("Gather current service status")
@@ -356,6 +348,14 @@ func (r *ReconcileAuthentication) Reconcile(ctx context.Context, request reconci
 	if err != nil {
 		return
 	}
+
+  if needsAuditServiceDummyDataReset(instance) {
+    instance.SetRequiredDummyData()
+		err = r.client.Update(ctx, instance)
+		if err != nil {
+			return
+		}
+  }
 
 	if r.needToRequeue {
 		return reconcile.Result{Requeue: true}, nil


### PR DESCRIPTION
Originating Issues:
- https://github.ibm.com/IBMPrivateCloud/roadmap/issues/57006
- https://github.ibm.com/IBMPrivateCloud/roadmap/issues/57372

- Reintroduce `auditService` property to the `Authentication` CR/CRD in order to avoid breaking Common Services 3.x installs in scenarios where Common Services 2.x is installed after it.
- Set dummy data within the `auditService` to make it clear that the fields should be ignored in Common Services 3.x given they do not map back to any meaningful changes in behavior.