### PR TITLE
Remove iam-token-service from .status.service

### DIFF
--- a/pkg/controller/authentication/resourcestatus.go
+++ b/pkg/controller/authentication/resourcestatus.go
@@ -206,7 +206,6 @@ func getCurrentServiceStatus(ctx context.Context, k8sClient client.Client, authe
   statusRetrievals := []statusRetrieval {
     {
       names: []string {
-        "iam-token-service",
         "platform-auth-service",
         "platform-identity-management",
         "platform-identity-provider",


### PR DESCRIPTION
The iam-token-service was removed in #588, so it no longer needs to be retrieved for reporting the health of IM.