### PR TITLE
Service Upgrade handling for IM4.0 

### DIFF
--- a/pkg/controller/authentication/service.go
+++ b/pkg/controller/authentication/service.go
@@ -46,6 +46,33 @@ func (r *ReconcileAuthentication) handleService(instance *operatorv1alpha1.Authe
 	} else if err != nil {
 		reqLogger.Error(err, "Failed to get Service")
 		return err
+	} else {
+		// Going to validate pod-selector for CP3 upgrade
+		var cp2podselector bool = false
+		var cp2podlabel bool = false
+		podSelector := currentService.Spec.Selector
+		value, ok := podSelector["k8s-app"]
+		if ok && value != "platform-auth-service" {
+			currentService.Spec.Selector = map[string]string{"k8s-app": "platform-auth-service"}
+			cp2podselector = true
+		}
+		// Going to validate label for CP3 upgrade
+		label := currentService.Labels
+		value, ok = label["app"]
+		if ok && value != "platform-auth-service" {
+			currentService.Labels = map[string]string{"app": "platform-auth-service"}
+			cp2podlabel = true
+		}
+		if cp2podselector || cp2podlabel {
+			err = r.client.Update(context.Background(), currentService)
+			if err != nil {
+				reqLogger.Error(err, "Upgrade check : Failed to update service podSelector , label details ", "Service.Namespace", instance.Namespace, "Service.Name", "platform-auth-service", "Error.message", err)
+				r.needToRequeue = true
+				return err
+			} else {
+				reqLogger.Info("Upgrade check : Successfully updated service podSelector , label details ", "Service.Name", "platform-auth-service")
+			}
+		}
 	}
 
 	err = r.client.Get(context.TODO(), types.NamespacedName{Name: "platform-identity-provider", Namespace: instance.Namespace}, currentService)
@@ -63,6 +90,33 @@ func (r *ReconcileAuthentication) handleService(instance *operatorv1alpha1.Authe
 	} else if err != nil {
 		reqLogger.Error(err, "Failed to get Service")
 		return err
+	} else {
+		// Going to validate pod-selector for CP3 upgrade
+		var cp2podselector bool = false
+		var cp2podlabel bool = false
+		podSelector := currentService.Spec.Selector
+		value, ok := podSelector["k8s-app"]
+		if ok && value != "platform-identity-provider" {
+			currentService.Spec.Selector = map[string]string{"k8s-app": "platform-identity-provider"}
+			cp2podselector = true
+		}
+		// Going to validate label for CP3 upgrade
+		label := currentService.Labels
+		value, ok = label["app"]
+		if ok && value != "platform-identity-provider" {
+			currentService.Labels = map[string]string{"app": "platform-identity-provider"}
+			cp2podlabel = true
+		}
+		if cp2podselector || cp2podlabel {
+			err = r.client.Update(context.Background(), currentService)
+			if err != nil {
+				reqLogger.Error(err, "Upgrade check : Failed to update service podSelector , label details ", "Service.Namespace", instance.Namespace, "Service.Name", "platform-identity-provider", "Error.message", err)
+				r.needToRequeue = true
+				return err
+			} else {
+				reqLogger.Info("Upgrade check : Successfully updated service podSelector , label details ", "Service.Name", "platform-identity-provider")
+			}
+		}
 	}
 
 	err = r.client.Get(context.TODO(), types.NamespacedName{Name: "platform-identity-management", Namespace: instance.Namespace}, currentService)
@@ -80,9 +134,36 @@ func (r *ReconcileAuthentication) handleService(instance *operatorv1alpha1.Authe
 	} else if err != nil {
 		reqLogger.Error(err, "Failed to get Service")
 		return err
+	} else {
+		// Going to validate pod-selector for CP3 upgrade
+		var cp2podselector bool = false
+		var cp2podlabel bool = false
+		podSelector := currentService.Spec.Selector
+		value, ok := podSelector["k8s-app"]
+		if ok && value != "platform-identity-management" {
+			currentService.Spec.Selector = map[string]string{"k8s-app": "platform-identity-management"}
+			cp2podselector = true
+		}
+		// Going to validate label for CP3 upgrade
+		label := currentService.Labels
+		value, ok = label["app"]
+		if ok && value != "platform-identity-management" {
+			currentService.Labels = map[string]string{"app": "platform-identity-management"}
+			cp2podlabel = true
+		}
+		if cp2podselector || cp2podlabel {
+			err = r.client.Update(context.Background(), currentService)
+			if err != nil {
+				reqLogger.Error(err, "Upgrade check : Failed to update service podSelector , label details ", "Service.Namespace", instance.Namespace, "Service.Name", "platform-identity-management", "Error.message", err)
+				r.needToRequeue = true
+				return err
+			} else {
+				reqLogger.Info("Upgrade check : Successfully updated service podSelector , label details ", "Service.Name", "platform-identity-management")
+			}
+		}
 	}
-	return nil
 
+	return nil
 }
 
 func (r *ReconcileAuthentication) platformAuthService(instance *operatorv1alpha1.Authentication) *corev1.Service {

--- a/pkg/controller/authentication/service.go
+++ b/pkg/controller/authentication/service.go
@@ -18,6 +18,7 @@ package authentication
 
 import (
 	"context"
+	"fmt"
 
 	operatorv1alpha1 "github.com/IBM/ibm-iam-operator/pkg/apis/operator/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
@@ -47,32 +48,7 @@ func (r *ReconcileAuthentication) handleService(instance *operatorv1alpha1.Authe
 		reqLogger.Error(err, "Failed to get Service")
 		return err
 	} else {
-		// Going to validate pod-selector for CP3 upgrade
-		var cp2podselector bool = false
-		var cp2podlabel bool = false
-		podSelector := currentService.Spec.Selector
-		value, ok := podSelector["k8s-app"]
-		if ok && value != "platform-auth-service" {
-			currentService.Spec.Selector = map[string]string{"k8s-app": "platform-auth-service"}
-			cp2podselector = true
-		}
-		// Going to validate label for CP3 upgrade
-		label := currentService.Labels
-		value, ok = label["app"]
-		if ok && value != "platform-auth-service" {
-			currentService.Labels = map[string]string{"app": "platform-auth-service"}
-			cp2podlabel = true
-		}
-		if cp2podselector || cp2podlabel {
-			err = r.client.Update(context.Background(), currentService)
-			if err != nil {
-				reqLogger.Error(err, "Upgrade check : Failed to update service podSelector , label details ", "Service.Namespace", instance.Namespace, "Service.Name", "platform-auth-service", "Error.message", err)
-				r.needToRequeue = true
-				return err
-			} else {
-				reqLogger.Info("Upgrade check : Successfully updated service podSelector , label details ", "Service.Name", "platform-auth-service")
-			}
-		}
+		r.validateCP3PodSelectorAndLabel(currentService)
 	}
 
 	err = r.client.Get(context.TODO(), types.NamespacedName{Name: "platform-identity-provider", Namespace: instance.Namespace}, currentService)
@@ -91,32 +67,7 @@ func (r *ReconcileAuthentication) handleService(instance *operatorv1alpha1.Authe
 		reqLogger.Error(err, "Failed to get Service")
 		return err
 	} else {
-		// Going to validate pod-selector for CP3 upgrade
-		var cp2podselector bool = false
-		var cp2podlabel bool = false
-		podSelector := currentService.Spec.Selector
-		value, ok := podSelector["k8s-app"]
-		if ok && value != "platform-identity-provider" {
-			currentService.Spec.Selector = map[string]string{"k8s-app": "platform-identity-provider"}
-			cp2podselector = true
-		}
-		// Going to validate label for CP3 upgrade
-		label := currentService.Labels
-		value, ok = label["app"]
-		if ok && value != "platform-identity-provider" {
-			currentService.Labels = map[string]string{"app": "platform-identity-provider"}
-			cp2podlabel = true
-		}
-		if cp2podselector || cp2podlabel {
-			err = r.client.Update(context.Background(), currentService)
-			if err != nil {
-				reqLogger.Error(err, "Upgrade check : Failed to update service podSelector , label details ", "Service.Namespace", instance.Namespace, "Service.Name", "platform-identity-provider", "Error.message", err)
-				r.needToRequeue = true
-				return err
-			} else {
-				reqLogger.Info("Upgrade check : Successfully updated service podSelector , label details ", "Service.Name", "platform-identity-provider")
-			}
-		}
+		r.validateCP3PodSelectorAndLabel(currentService)
 	}
 
 	err = r.client.Get(context.TODO(), types.NamespacedName{Name: "platform-identity-management", Namespace: instance.Namespace}, currentService)
@@ -135,35 +86,49 @@ func (r *ReconcileAuthentication) handleService(instance *operatorv1alpha1.Authe
 		reqLogger.Error(err, "Failed to get Service")
 		return err
 	} else {
-		// Going to validate pod-selector for CP3 upgrade
-		var cp2podselector bool = false
-		var cp2podlabel bool = false
-		podSelector := currentService.Spec.Selector
-		value, ok := podSelector["k8s-app"]
-		if ok && value != "platform-identity-management" {
-			currentService.Spec.Selector = map[string]string{"k8s-app": "platform-identity-management"}
-			cp2podselector = true
-		}
-		// Going to validate label for CP3 upgrade
-		label := currentService.Labels
-		value, ok = label["app"]
-		if ok && value != "platform-identity-management" {
-			currentService.Labels = map[string]string{"app": "platform-identity-management"}
-			cp2podlabel = true
-		}
-		if cp2podselector || cp2podlabel {
-			err = r.client.Update(context.Background(), currentService)
-			if err != nil {
-				reqLogger.Error(err, "Upgrade check : Failed to update service podSelector , label details ", "Service.Namespace", instance.Namespace, "Service.Name", "platform-identity-management", "Error.message", err)
-				r.needToRequeue = true
-				return err
-			} else {
-				reqLogger.Info("Upgrade check : Successfully updated service podSelector , label details ", "Service.Name", "platform-identity-management")
-			}
-		}
+		r.validateCP3PodSelectorAndLabel(currentService)
 	}
 
 	return nil
+}
+
+// validateCP3ServicePodSelectorAndLabel takes a *Service and attempts to update that Service's selectors and
+// labels if they do not match the desired CP3 values. Returns an error if the update fails or if the provided
+// *Service is nil or lacks a name or namespace.
+func (r *ReconcileAuthentication) validateCP3PodSelectorAndLabel(currentService *corev1.Service) (err error) {
+
+	if currentService == nil || currentService.Name == "" || currentService.Namespace == "" {
+		return fmt.Errorf("received invalid Service")
+	}
+
+	reqLogger := log.WithValues("Instance.Namespace", currentService.Namespace, "Instance.Name", currentService.Name)
+
+	var cp2podselector bool = false
+	var cp2podlabel bool = false
+	podSelector := currentService.Spec.Selector
+	value, ok := podSelector["k8s-app"]
+	if ok && value != currentService.Name {
+		currentService.Spec.Selector = map[string]string{"k8s-app": currentService.Name}
+		cp2podselector = true
+	}
+	// Going to validate label for CP3 upgrade
+	label := currentService.Labels
+	value, ok = label["app"]
+	if ok && value != currentService.Name {
+		currentService.Labels = map[string]string{"app": currentService.Name}
+		cp2podlabel = true
+	}
+	if cp2podselector || cp2podlabel {
+		err = r.client.Update(context.Background(), currentService)
+		if err != nil {
+			reqLogger.Error(err, "Upgrade check : Failed to update service podSelector , label details ", "Service.Namespace", currentService.Namespace, "Service.Name", currentService.Name, "Error.message", err)
+			r.needToRequeue = true
+			return
+		} else {
+			reqLogger.Info("Upgrade check : Successfully updated service podSelector , label details ", "Service.Name", currentService.Name)
+		}
+	}
+	return
 }
 
 func (r *ReconcileAuthentication) platformAuthService(instance *operatorv1alpha1.Authentication) *corev1.Service {


### PR DESCRIPTION
Handle update for both `label` and `podselector` during the CP3 upgrade for the below services :
```
platform-auth-service,
platform-identity-management,
platform-identity-provider
```
Operator logs -
```
{"level":"info","ts":1678972184.4709521,"logger":"controller_authentication","msg":"Upgrade check : Successfully updated service podSelector , label details ","Instance.Namespace":"ibm-common-services","Instance.Name":"example-authentication","Service.Name":"platform-auth-service"}
{"level":"info","ts":1678972184.4709523,"logger":"controller_authentication","msg":"Upgrade check : Successfully updated service podSelector , label details ","Instance.Namespace":"ibm-common-services","Instance.Name":"example-authentication","Service.Name":"platform-identity-provider"}
{"level":"info","ts":1678972184.563555,"logger":"controller_authentication","msg":"Upgrade check : Successfully updated service podSelector , label details ","Instance.Namespace":"ibm-common-services","Instance.Name":"example-authentication","Service.Name":"platform-identity-management"}
```

<img width="1418" alt="Screenshot 2023-03-16 at 6 48 14 PM" src="https://media.github.ibm.com/user/338159/files/76c4f674-1157-48f2-a32b-a7c6fac09622">
