### PR TITLE
Add defaultAdmin credential update

### DIFF
--- a/pkg/apis/apis.go
+++ b/pkg/apis/apis.go
@@ -1,4 +1,3 @@
-//
 // Copyright 2020 IBM Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 package apis
 
 import (

--- a/pkg/apis/certmanager/v1alpha1/certificate_common.go
+++ b/pkg/apis/certmanager/v1alpha1/certificate_common.go
@@ -39,11 +39,14 @@ const (
 
 // KeyUsage specifies valid usage contexts for keys.
 // See: https://tools.ietf.org/html/rfc5280#section-4.2.1.3
-//      https://tools.ietf.org/html/rfc5280#section-4.2.1.12
+//
+//	https://tools.ietf.org/html/rfc5280#section-4.2.1.12
+//
 // +kubebuilder:validation:Enum="signing";"digital signature";"content commitment";"key encipherment";"key agreement";
-//    "data encipherment";"cert sign";"crl sign";"encipher only";"decipher only";"any";"server auth";"client auth";
-//    "code signing";"email protection";"s/mime";"ipsec end system";"ipsec tunnel";"ipsec user";"timestamping";
-//    "ocsp signing";"microsoft sgc";"netscape sgc"
+//
+//	"data encipherment";"cert sign";"crl sign";"encipher only";"decipher only";"any";"server auth";"client auth";
+//	"code signing";"email protection";"s/mime";"ipsec end system";"ipsec tunnel";"ipsec user";"timestamping";
+//	"ocsp signing";"microsoft sgc";"netscape sgc"
 type KeyUsage string
 
 const (

--- a/pkg/apis/oidc/v1/client_types.go
+++ b/pkg/apis/oidc/v1/client_types.go
@@ -1,4 +1,3 @@
-//
 // Copyright 2020 IBM Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 package v1
 
 import (

--- a/pkg/controller/authentication/authentication_controller.go
+++ b/pkg/controller/authentication/authentication_controller.go
@@ -185,10 +185,9 @@ var _ reconcile.Reconciler = &ReconcileAuthentication{}
 type ReconcileAuthentication struct {
 	// This client, initialized using mgr.Client() above, is a split client
 	// that reads objects from the cache and writes to the apiserver
-	client        client.Client
-	scheme        *runtime.Scheme
-	needToRequeue bool
-	Mutex         sync.Mutex
+	client client.Client
+	scheme *runtime.Scheme
+	Mutex  sync.Mutex
 }
 
 func (r *ReconcileAuthentication) addFinalizer(ctx context.Context, finalizerName string, instance *operatorv1alpha1.Authentication) (err error) {
@@ -234,9 +233,19 @@ func needsAuditServiceDummyDataReset(a *operatorv1alpha1.Authentication) bool {
 // Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
 func (r *ReconcileAuthentication) Reconcile(ctx context.Context, request reconcile.Request) (result reconcile.Result, err error) {
 	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
+	needToRequeue := false
+
 	reconcileCtx := logf.IntoContext(ctx, reqLogger)
 	// Set default result
 	result = reconcile.Result{}
+	// Set Requeue to true if requeue is needed at end of reconcile loop
+	defer func() {
+		if needToRequeue {
+			result.Requeue = true
+		}
+		reqLogger.Info("Reconcile return", "err", err, "result", result, "request", request)
+	}()
+
 	reqLogger.Info("Reconciling Authentication")
 
 	// Fetch the Authentication instance
@@ -256,7 +265,7 @@ func (r *ReconcileAuthentication) Reconcile(ctx context.Context, request reconci
 	// Be sure to update status before returning if Authentication is found
 	defer func() {
 		reqLogger.Info("Gather current service status")
-		currentServiceStatus := getCurrentServiceStatus(ctx, r.client, instance)
+		currentServiceStatus := getCurrentServiceStatus(reconcileCtx, r.client, instance)
 		instance.SetService(reconcileCtx, currentServiceStatus, r.client, &r.Mutex)
 	}()
 
@@ -278,7 +287,7 @@ func (r *ReconcileAuthentication) Reconcile(ctx context.Context, request reconci
 	// Check if this Certificate already exists and create it if it doesn't
 	reqLogger.Info("Creating ibm-iam-operand-restricted serviceaccount")
 	currentSA := &corev1.ServiceAccount{}
-	err = r.createSA(instance, currentSA)
+	err = r.createSA(instance, currentSA, &needToRequeue)
 	if err != nil {
 		return
 	}
@@ -288,35 +297,35 @@ func (r *ReconcileAuthentication) Reconcile(ctx context.Context, request reconci
 
 	// Check if this Certificate already exists and create it if it doesn't
 	currentCertificate := &certmgr.Certificate{}
-	err = r.handleCertificate(instance, currentCertificate)
+	err = r.handleCertificate(instance, currentCertificate, &needToRequeue)
 	if err != nil {
 		return
 	}
 
 	//Check if this ConfigMap already exists and create it if it doesn't
 	currentConfigMap := &corev1.ConfigMap{}
-	err = r.handleConfigMap(instance, wlpClientID, wlpClientSecret, currentConfigMap)
+	err = r.handleConfigMap(instance, wlpClientID, wlpClientSecret, currentConfigMap, &needToRequeue)
 	if err != nil {
 		return
 	}
 
 	// Check if this Service already exists and create it if it doesn't
 	currentService := &corev1.Service{}
-	err = r.handleService(instance, currentService)
+	err = r.handleService(instance, currentService, &needToRequeue)
 	if err != nil {
 		return
 	}
 
 	// Check if this Secret already exists and create it if it doesn't
 	currentSecret := &corev1.Secret{}
-	err = r.handleSecret(instance, wlpClientID, wlpClientSecret, currentSecret)
+	err = r.handleSecret(reconcileCtx, instance, wlpClientID, wlpClientSecret, currentSecret, &needToRequeue)
 	if err != nil {
 		return
 	}
 
 	// Check if this Job already exists and create it if it doesn't
 	currentJob := &batchv1.Job{}
-	err = r.handleJob(instance, currentJob)
+	err = r.handleJob(instance, currentJob, &needToRequeue)
 	if err != nil {
 		return
 	}
@@ -326,12 +335,12 @@ func (r *ReconcileAuthentication) Reconcile(ctx context.Context, request reconci
 		r.createClusterRoleBinding(instance)
 	}
 
-	r.ReconcileRemoveIngresses(ctx, instance)
+	r.ReconcileRemoveIngresses(reconcileCtx, instance, &needToRequeue)
 	// updates redirecturi annotations to serviceaccount
-	r.handleServiceAccount(instance)
+	r.handleServiceAccount(instance, &needToRequeue)
 
-	err = r.reconcileRoutes(ctx, instance)
-	if err != nil {
+	err = r.handleRoutes(reconcileCtx, instance, &needToRequeue)
+	if err != nil && !errors.IsNotFound(err) {
 		return
 	}
 
@@ -339,21 +348,17 @@ func (r *ReconcileAuthentication) Reconcile(ctx context.Context, request reconci
 	currentDeployment := &appsv1.Deployment{}
 	currentProviderDeployment := &appsv1.Deployment{}
 	currentManagerDeployment := &appsv1.Deployment{}
-	err = r.handleDeployment(instance, currentDeployment, currentProviderDeployment, currentManagerDeployment)
+	err = r.handleDeployment(instance, currentDeployment, currentProviderDeployment, currentManagerDeployment, &needToRequeue)
 	if err != nil {
 		return
 	}
 
 	if needsAuditServiceDummyDataReset(instance) {
 		instance.SetRequiredDummyData()
-		err = r.client.Update(ctx, instance)
+		err = r.client.Update(reconcileCtx, instance)
 		if err != nil {
 			return
 		}
-	}
-
-	if r.needToRequeue {
-		return reconcile.Result{Requeue: true}, nil
 	}
 
 	return

--- a/pkg/controller/authentication/deployment.go
+++ b/pkg/controller/authentication/deployment.go
@@ -33,7 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-func (r *ReconcileAuthentication) handleDeployment(instance *operatorv1alpha1.Authentication, currentDeployment *appsv1.Deployment, currentProviderDeployment *appsv1.Deployment, currentManagerDeployment *appsv1.Deployment) error {
+func (r *ReconcileAuthentication) handleDeployment(instance *operatorv1alpha1.Authentication, currentDeployment *appsv1.Deployment, currentProviderDeployment *appsv1.Deployment, currentManagerDeployment *appsv1.Deployment, needToRequeue *bool) error {
 
 	reqLogger := log.WithValues("Instance.Namespace", instance.Namespace, "Instance.Name", instance.Name)
 
@@ -80,7 +80,7 @@ func (r *ReconcileAuthentication) handleDeployment(instance *operatorv1alpha1.Au
 	}
 	if ownRef != "Authentication" {
 		reqLogger.Info("Reconcile Deployment : Can't find ibmcloud-cluster-info Configmap created by IM operator , IM deployment may not proceed", "Configmap.Namespace", consoleConfigMap.Namespace, "ConfigMap.Name", "ibmcloud-cluster-info")
-		r.needToRequeue = true
+		*needToRequeue = true
 		return nil
 	}
 
@@ -123,7 +123,7 @@ func (r *ReconcileAuthentication) handleDeployment(instance *operatorv1alpha1.Au
 				return err
 			}
 			// Deployment created successfully - return and requeue
-			r.needToRequeue = true
+			*needToRequeue = true
 		} else {
 			return err
 		}
@@ -175,7 +175,7 @@ func (r *ReconcileAuthentication) handleDeployment(instance *operatorv1alpha1.Au
 				return err
 			}
 			// Deployment created successfully - return and requeue
-			r.needToRequeue = true
+			*needToRequeue = true
 		} else {
 			return err
 		}
@@ -230,7 +230,7 @@ func (r *ReconcileAuthentication) handleDeployment(instance *operatorv1alpha1.Au
 				return err
 			}
 			// Deployment created successfully - return and requeue
-			r.needToRequeue = true
+			*needToRequeue = true
 		} else {
 			return err
 		}

--- a/pkg/controller/client/conditions.go
+++ b/pkg/controller/client/conditions.go
@@ -42,13 +42,13 @@ func ClientHasCondition(client *oidcv1.Client, c oidcv1.ClientCondition) bool {
 }
 
 // SetClientCondition will set a 'condition' on the given Client.
-// - If no condition of the same type already exists, the condition will be
-//   inserted with the LastTransitionTime set to the current time.
-// - If a condition of the same type and state already exists, the condition
-//   will be updated but the LastTransitionTime will not be modified.
-// - If a condition of the same type and different state already exists, the
-//   condition will be updated and the LastTransitionTime set to the current
-//   time.
+//   - If no condition of the same type already exists, the condition will be
+//     inserted with the LastTransitionTime set to the current time.
+//   - If a condition of the same type and state already exists, the condition
+//     will be updated but the LastTransitionTime will not be modified.
+//   - If a condition of the same type and different state already exists, the
+//     condition will be updated and the LastTransitionTime set to the current
+//     time.
 func SetClientCondition(client *oidcv1.Client, conditionType oidcv1.ClientConditionType, status oidcv1.ConditionStatus, reason, message string) {
 	newCondition := oidcv1.ClientCondition{
 		Type:    conditionType,

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -1,4 +1,3 @@
-//
 // Copyright 2020 IBM Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 package controller
 
 import (

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,3 @@
-//
 // Copyright 2020 IBM Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 package version
 
 var (


### PR DESCRIPTION
Originating issue: [IBMPrivateCloud/roadmap#56005](https://github.ibm.com/IBMPrivateCloud/roadmap/issues/56005)

- Revert changes scoping requeue flag to ReconcileAuthentication back to using bool*
- When platform-auth-idp-credentials Secret has its `.data.admin_username` field updated, the Operator will now restart the platform-identity-provider and platform-auth-service so that they can remount it