### PR TITLE
Revert ReconcileAuthentication.needToRequeue

### DIFF
--- a/pkg/apis/apis.go
+++ b/pkg/apis/apis.go
@@ -1,4 +1,3 @@
-//
 // Copyright 2020 IBM Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 package apis
 
 import (

--- a/pkg/apis/certmanager/v1alpha1/certificate_common.go
+++ b/pkg/apis/certmanager/v1alpha1/certificate_common.go
@@ -39,11 +39,14 @@ const (
 
 // KeyUsage specifies valid usage contexts for keys.
 // See: https://tools.ietf.org/html/rfc5280#section-4.2.1.3
-//      https://tools.ietf.org/html/rfc5280#section-4.2.1.12
+//
+//	https://tools.ietf.org/html/rfc5280#section-4.2.1.12
+//
 // +kubebuilder:validation:Enum="signing";"digital signature";"content commitment";"key encipherment";"key agreement";
-//    "data encipherment";"cert sign";"crl sign";"encipher only";"decipher only";"any";"server auth";"client auth";
-//    "code signing";"email protection";"s/mime";"ipsec end system";"ipsec tunnel";"ipsec user";"timestamping";
-//    "ocsp signing";"microsoft sgc";"netscape sgc"
+//
+//	"data encipherment";"cert sign";"crl sign";"encipher only";"decipher only";"any";"server auth";"client auth";
+//	"code signing";"email protection";"s/mime";"ipsec end system";"ipsec tunnel";"ipsec user";"timestamping";
+//	"ocsp signing";"microsoft sgc";"netscape sgc"
 type KeyUsage string
 
 const (

--- a/pkg/apis/oidc/v1/client_types.go
+++ b/pkg/apis/oidc/v1/client_types.go
@@ -1,4 +1,3 @@
-//
 // Copyright 2020 IBM Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 package v1
 
 import (

--- a/pkg/controller/authentication/deployment.go
+++ b/pkg/controller/authentication/deployment.go
@@ -33,7 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-func (r *ReconcileAuthentication) handleDeployment(instance *operatorv1alpha1.Authentication, currentDeployment *appsv1.Deployment, currentProviderDeployment *appsv1.Deployment, currentManagerDeployment *appsv1.Deployment) error {
+func (r *ReconcileAuthentication) handleDeployment(instance *operatorv1alpha1.Authentication, currentDeployment *appsv1.Deployment, currentProviderDeployment *appsv1.Deployment, currentManagerDeployment *appsv1.Deployment, needToRequeue *bool) error {
 
 	reqLogger := log.WithValues("Instance.Namespace", instance.Namespace, "Instance.Name", instance.Name)
 
@@ -80,7 +80,7 @@ func (r *ReconcileAuthentication) handleDeployment(instance *operatorv1alpha1.Au
 	}
 	if ownRef != "Authentication" {
 		reqLogger.Info("Reconcile Deployment : Can't find ibmcloud-cluster-info Configmap created by IM operator , IM deployment may not proceed", "Configmap.Namespace", consoleConfigMap.Namespace, "ConfigMap.Name", "ibmcloud-cluster-info")
-		r.needToRequeue = true
+		*needToRequeue = true
 		return nil
 	}
 
@@ -123,7 +123,7 @@ func (r *ReconcileAuthentication) handleDeployment(instance *operatorv1alpha1.Au
 				return err
 			}
 			// Deployment created successfully - return and requeue
-			r.needToRequeue = true
+			*needToRequeue = true
 		} else {
 			return err
 		}
@@ -175,7 +175,7 @@ func (r *ReconcileAuthentication) handleDeployment(instance *operatorv1alpha1.Au
 				return err
 			}
 			// Deployment created successfully - return and requeue
-			r.needToRequeue = true
+			*needToRequeue = true
 		} else {
 			return err
 		}
@@ -230,7 +230,7 @@ func (r *ReconcileAuthentication) handleDeployment(instance *operatorv1alpha1.Au
 				return err
 			}
 			// Deployment created successfully - return and requeue
-			r.needToRequeue = true
+			*needToRequeue = true
 		} else {
 			return err
 		}

--- a/pkg/controller/client/conditions.go
+++ b/pkg/controller/client/conditions.go
@@ -42,13 +42,13 @@ func ClientHasCondition(client *oidcv1.Client, c oidcv1.ClientCondition) bool {
 }
 
 // SetClientCondition will set a 'condition' on the given Client.
-// - If no condition of the same type already exists, the condition will be
-//   inserted with the LastTransitionTime set to the current time.
-// - If a condition of the same type and state already exists, the condition
-//   will be updated but the LastTransitionTime will not be modified.
-// - If a condition of the same type and different state already exists, the
-//   condition will be updated and the LastTransitionTime set to the current
-//   time.
+//   - If no condition of the same type already exists, the condition will be
+//     inserted with the LastTransitionTime set to the current time.
+//   - If a condition of the same type and state already exists, the condition
+//     will be updated but the LastTransitionTime will not be modified.
+//   - If a condition of the same type and different state already exists, the
+//     condition will be updated and the LastTransitionTime set to the current
+//     time.
 func SetClientCondition(client *oidcv1.Client, conditionType oidcv1.ClientConditionType, status oidcv1.ConditionStatus, reason, message string) {
 	newCondition := oidcv1.ClientCondition{
 		Type:    conditionType,

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -1,4 +1,3 @@
-//
 // Copyright 2020 IBM Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 package controller
 
 import (

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,3 @@
-//
 // Copyright 2020 IBM Corporation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 package version
 
 var (


### PR DESCRIPTION
Previous changes in this stream moved the flag used to indicate that another reconcile loop was needed into the Authentication controller's ReconcileAuthentication struct. This incorrectly scopes this information, so the code has been reverted back to using a series of bool*'s to set a common flag when appropriate changes justify another reconcile loop.