### PR TITLE
fix SA update for clients

### DIFF
--- a/pkg/controller/authentication/sacc.go
+++ b/pkg/controller/authentication/sacc.go
@@ -20,7 +20,6 @@ import (
 	"context"
 
 	operatorv1alpha1 "github.com/IBM/ibm-iam-operator/pkg/apis/operator/v1alpha1"
-	"github.com/IBM/ibm-iam-operator/pkg/controller/common"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -73,7 +72,7 @@ func (r *ReconcileAuthentication) handleServiceAccount(instance *operatorv1alpha
 	err := r.client.Get(context.TODO(), types.NamespacedName{Name: sAccName, Namespace: instance.Namespace}, serviceAccount)
 	if err != nil {
 		reqLogger.Error(err, "failed to GET ServiceAccount ibm-iam-operand-restricted")
-	} else if !common.IsOAuthAnnotationExists(serviceAccount.ObjectMeta.Annotations) {
+	} else {
 		if serviceAccount.ObjectMeta.Annotations != nil {
 			serviceAccount.ObjectMeta.Annotations["serviceaccounts.openshift.io/oauth-redirecturi.first"] = redirectURI
 		} else {
@@ -89,11 +88,7 @@ func (r *ReconcileAuthentication) handleServiceAccount(instance *operatorv1alpha
 			// annotation got updated properly
 			reqLogger.Info("ibm-iam-operand-restricted SA is updated with annotation successfully")
 		}
-	} else {
-		reqLogger.Info("Annotation already present")
-		//do nothing
 	}
-
 	return
 }
 

--- a/pkg/controller/common/resources.go
+++ b/pkg/controller/common/resources.go
@@ -50,21 +50,3 @@ func IsCsConfigAnnotationExists(annotations map[string]string) bool {
 	}
 	return false
 }
-
-func IsOAuthAnnotationExists(annotations map[string]string) bool {
-	if len(annotations) == 0 {
-		return false
-	}
-	csOauthAnnotationFound := false
-	reg, _ := regexp.Compile(`^(.*)\/oauth-redirectreference`)
-	for anno := range annotations {
-		if reg.MatchString(anno) {
-			csOauthAnnotationFound = true
-			break
-		}
-	}
-	if csOauthAnnotationFound {
-		return true
-	}
-	return false
-}


### PR DESCRIPTION
When updating operand Service account with annotations for Client CR scenario, namespace need to be the one where IAM operand is running
https://github.ibm.com/IBMPrivateCloud/roadmap/issues/58410