### PR TITLE
Fix registered API detection

### DIFF
--- a/pkg/apis/addtoscheme_operator_v1alpha1.go
+++ b/pkg/apis/addtoscheme_operator_v1alpha1.go
@@ -38,9 +38,14 @@ func init() {
 	logf.SetLogger(zap.Logger())
 	logger := logf.Log.WithName("operator_v1alpha1_init")
 	ctx := logf.IntoContext(context.Background(), logger)
-	err := addAPIsIfOnOpenShift(ctx, routev1.AddToScheme)
+	routeAddToSchemeTest := &addToSchemeTest{
+		AddToScheme:  routev1.AddToScheme,
+		ListType:     &routev1.RouteList{},
+		GroupVersion: routev1.GroupVersion,
+	}
+	err := addAPIfRegistered(ctx, routeAddToSchemeTest)
 	if err != nil {
-		logger.Error(nil, "Exiting due to failure to detect cluster type")
+		logger.Error(nil, "Exiting due to failure to while trying to verify APIs")
 		os.Exit(1)
 	}
 }

--- a/pkg/apis/utils.go
+++ b/pkg/apis/utils.go
@@ -18,26 +18,68 @@ package apis
 
 import (
 	"context"
-	"github.com/IBM/ibm-iam-operator/pkg/common"
+	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-// addAPIsIfOnOpenShift adds the provided AddToScheme functions to the AddToSchemes SchemeBuilder only if the cluster
-// this Operator is running on is an OpenShift cluster. This is done to avoid issues where OpenShift-specific CRDs are
+// addToSchemeTest structs contain an AddToScheme function for SchemeBuilders as well as list of types to test client
+// calls on.
+type addToSchemeTest struct {
+	AddToScheme  func(s *runtime.Scheme) error
+	ListType     client.ObjectList
+	GroupVersion schema.GroupVersion
+}
+
+// addAPIfRegistered adds the provided API's AddToScheme function to the AddToSchemes SchemeBuilder only if the cluster
+// this Operator is running on has the API registered. This is done to avoid issues where OpenShift-specific kinds are
 // not installed on the cluster, which lead to failures to start the controller.
-func addAPIsIfOnOpenShift(ctx context.Context, addToSchemeFuncs ...func(s *runtime.Scheme) error) (err error) {
-	logger := logf.FromContext(ctx).WithName("addAPIsIfOnOpenShift")
-	clusterType, err := common.GetClusterType(ctx, common.GlobalConfigMapName)
+func addAPIfRegistered(ctx context.Context, addToSchemeTests ...*addToSchemeTest) (err error) {
+	logger := logf.FromContext(ctx).WithName("addRouteV1APIfRegistered")
+	cfg, err := config.GetConfig()
 	if err != nil {
-		logger.Error(err, "Failed to detect cluster type")
+		logger.Error(err, "Could not obtain cluster config")
 		return
 	}
-	if clusterType == common.OpenShift {
-		logger.Info("Running on OpenShift - adding relevant schemes")
-		AddToSchemes = append(AddToSchemes, addToSchemeFuncs...)
-	} else {
-		logger.Info("Not running on OpenShift - skipping OpenShift-specific schemes")
+	addToSchemes := []func(s *runtime.Scheme) error{}
+	for _, test := range addToSchemeTests {
+		addToSchemes = append(addToSchemes, test.AddToScheme)
 	}
+	sb := runtime.NewSchemeBuilder(addToSchemes...)
+	scheme := runtime.NewScheme()
+	err = sb.AddToScheme(scheme)
+	if err != nil {
+		logger.Error(err, "Failed to construct test schema")
+		return
+	}
+
+	apiDetectClient, err := client.New(cfg, client.Options{Scheme: scheme})
+	if err != nil {
+		logger.Error(err, "Failed to create test client")
+		return
+	}
+
+	operatorNs, _ := k8sutil.GetOperatorNamespace()
+	opts := []client.ListOption{
+		client.InNamespace(operatorNs),
+	}
+	for _, test := range addToSchemeTests {
+		err = apiDetectClient.List(ctx, test.ListType, opts...)
+		if runtime.IsNotRegisteredError(err) {
+			logger.Info("API group not found on the cluster; skipping scheme", "groupversion", test.GroupVersion)
+			err = nil
+			continue
+		}
+		if err != nil {
+			logger.Error(err, "An unexpected error was encountered while trying to find API group on cluster", "groupversion", test.GroupVersion)
+			return
+		}
+		logger.Info("API group found on the cluster", "groupversion", test.GroupVersion)
+		AddToSchemes = append(AddToSchemes, test.AddToScheme)
+	}
+
 	return
 }

--- a/pkg/controller/client/clientreg.go
+++ b/pkg/controller/client/clientreg.go
@@ -172,9 +172,8 @@ func (r *ReconcileClient) invokeClientRegistrationAPI(ctx context.Context, clien
 	if err != nil {
 		reqLogger.Error(err, "Request failed")
 		return
-	} else {
-		reqLogger.Info("Request complete", "response", response)
 	}
+	reqLogger.Info("Request complete")
 	return
 }
 


### PR DESCRIPTION
Originating issue: [IBMPrivateCloud/roadmap#58413](https://github.ibm.com/ibmprivatecloud/roadmap/issues/58413)

Previously, whether or not to add the Route schema to the Manager was determined by values set within the ibm-cpp-config ConfigMap that indicated whether the cluster was OpenShift or CNCF. This approach was vulnerable to timing issues that led to the Operator Pod repeatedly crashing until the ConfigMap was made available.

Now, the code attempts to list Routes; if the error relates to the Routes API not being registered on the cluster, then loading the scheme will be skipped.