### PR TITLE
Update containers.go to remove JMX API check

### DIFF
--- a/pkg/controller/authentication/containers.go
+++ b/pkg/controller/authentication/containers.go
@@ -66,7 +66,7 @@ func buildInitForMngrAndProvider(mongoDBImage string) []corev1.Container {
 			Command: []string{
 				"bash",
 				"-c",
-				"until </dev/tcp/mongodb/27017 && curl -k https://platform-auth-service:9443/oidc/endpoint/OP/.well-known-openid-configuration; do sleep 5; done;",
+				"until </dev/tcp/mongodb/27017 && curl -k https://platform-auth-service:9443/oidc/endpoint/OP/.well-known/openid-configuration; do sleep 5; done;",
 			},
 			SecurityContext: &corev1.SecurityContext{
 				Privileged:               &falseVar,

--- a/pkg/controller/authentication/containers.go
+++ b/pkg/controller/authentication/containers.go
@@ -66,7 +66,7 @@ func buildInitForMngrAndProvider(mongoDBImage string) []corev1.Container {
 			Command: []string{
 				"bash",
 				"-c",
-				"AUTH=`echo -n \"oauthadmin:$OAUTH2_CLIENT_REGISTRATION_SECRET\"|base64`; until </dev/tcp/mongodb/27017 && curl -k https://platform-auth-service:9443/IBMJMXConnectorREST/api --header \"Authorization: Basic $AUTH\"; do sleep 5; done;",
+				until </dev/tcp/mongodb/27017 && curl -k https://platform-auth-service:9443/oidc/endpoint/OP/.well-known-openid-configuration; do sleep 5; done;",
 			},
 			SecurityContext: &corev1.SecurityContext{
 				Privileged:               &falseVar,

--- a/pkg/controller/authentication/containers.go
+++ b/pkg/controller/authentication/containers.go
@@ -66,7 +66,7 @@ func buildInitForMngrAndProvider(mongoDBImage string) []corev1.Container {
 			Command: []string{
 				"bash",
 				"-c",
-				"until </dev/tcp/mongodb/27017 && curl -k https://platform-auth-service:9443/oidc/endpoint/OP/.well-known/openid-configuration; do sleep 5; done;",
+				until </dev/tcp/mongodb/27017 && curl -k https://platform-auth-service:9443/oidc/endpoint/OP/.well-known/openid-configuration; do sleep 5; done;,
 			},
 			SecurityContext: &corev1.SecurityContext{
 				Privileged:               &falseVar,

--- a/pkg/controller/authentication/containers.go
+++ b/pkg/controller/authentication/containers.go
@@ -66,7 +66,7 @@ func buildInitForMngrAndProvider(mongoDBImage string) []corev1.Container {
 			Command: []string{
 				"bash",
 				"-c",
-				until </dev/tcp/mongodb/27017 && curl -k https://platform-auth-service:9443/oidc/endpoint/OP/.well-known/openid-configuration; do sleep 5; done;,
+				"until </dev/tcp/mongodb/27017 && curl -k https://platform-auth-service:9443/oidc/endpoint/OP/.well-known/openid-configuration; do sleep 5; done",
 			},
 			SecurityContext: &corev1.SecurityContext{
 				Privileged:               &falseVar,

--- a/pkg/controller/authentication/containers.go
+++ b/pkg/controller/authentication/containers.go
@@ -66,7 +66,7 @@ func buildInitForMngrAndProvider(mongoDBImage string) []corev1.Container {
 			Command: []string{
 				"bash",
 				"-c",
-				until </dev/tcp/mongodb/27017 && curl -k https://platform-auth-service:9443/oidc/endpoint/OP/.well-known-openid-configuration; do sleep 5; done;",
+				"until </dev/tcp/mongodb/27017 && curl -k https://platform-auth-service:9443/oidc/endpoint/OP/.well-known-openid-configuration; do sleep 5; done;",
 			},
 			SecurityContext: &corev1.SecurityContext{
 				Privileged:               &falseVar,


### PR DESCRIPTION
Invoking JMX API from provider is causing oauthadmin related errors in Liberty.
https://github.ibm.com/IBMPrivateCloud/roadmap/issues/58437

In some cases that is preventing client registration from succeeding using oauthadmin