### PR TITLE
Remove `state` parameter from platform-login Route

### DIFF
--- a/pkg/controller/authentication/routes.go
+++ b/pkg/controller/authentication/routes.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"reflect"
-	"time"
 
 	routev1 "github.com/openshift/api/route/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -140,8 +139,6 @@ func (r *ReconcileAuthentication) handleRoutes(ctx context.Context, instance *op
 	routeHost = clusterInfoConfigMap.Data["cluster_address"]
 	wlpClientID := string(secret.Data["WLP_CLIENT_ID"][:])
 
-	now := time.Now().Unix()
-
 	var (
 		platformAuthCert               []byte
 		platformIdentityManagementCert []byte
@@ -211,7 +208,7 @@ func (r *ReconcileAuthentication) handleRoutes(ctx context.Context, instance *op
 		},
 		"platform-login": {
 			Annotations: map[string]string{
-				"haproxy.router.openshift.io/rewrite-target": fmt.Sprintf("/v1/auth/authorize?client_id=%s&redirect_uri=https://%s/auth/liberty/callback&response_type=code&scope=openid+email+profile&state=%d&orig=/login", wlpClientID, routeHost, now),
+				"haproxy.router.openshift.io/rewrite-target": fmt.Sprintf("/v1/auth/authorize?client_id=%s&redirect_uri=https://%s/auth/liberty/callback&response_type=code&scope=openid+email+profile&orig=/login", wlpClientID, routeHost),
 			},
 			Name:              "platform-login",
 			RouteHost:         routeHost,


### PR DESCRIPTION
Originating issue: [IBMPrivateCloud/roadmap#58513](https://github.ibm.com/IBMPrivateCloud/roadmap/issues/58513)

As part of authorization flow in OIDC, a state parameter is set to track requests and defend against CSRF. When Common Services was using IBM management ingress, it could define various nginx customizations within annotations on its Ingress objects such as rewriting targets or even scripted behaviors. Among other things, the IAM Operator's Ingress for platform-login had been customized to generate a timestamp and submit that as the `state` parameter for inbound authorize requests.

When Common Services moved away from using management ingress in favor of using OpenShift Routes and the default OpenShift Router, it meant that many of these customizations needed to be reevaluated and reworked if they were to continue to be of use. In this case, generating timestamps when requests arrived was not an option with the default Router configuration, and so a hack was put in place so that the authorize flow would continue to work in development.

This commit undoes that hack by no longer setting a state. The ID provider will assign a timestamp and perform any additional redirects as needed.