### PR TITLE
Simplify Client reconciler cert usage

### DIFF
--- a/pkg/controller/client/client_controller.go
+++ b/pkg/controller/client/client_controller.go
@@ -109,7 +109,6 @@ type ReconcileClient struct {
 	recorder                record.EventRecorder
 	scheme                  *runtime.Scheme
 	config                  ClientControllerConfig
-	csCACertSecret          *corev1.Secret
 	sharedServicesNamespace string
 }
 
@@ -127,11 +126,6 @@ func (r *ReconcileClient) SetConfig(ctx context.Context, namespace string) (err 
 		if err != nil {
 			return fmt.Errorf("failed to get ConfigMap: %w", err)
 		}
-	}
-
-	err = r.checkCSCACertificateSecret(ctx)
-	if err != nil {
-		return
 	}
 
 	configMap := &corev1.ConfigMap{}
@@ -160,52 +154,6 @@ func (r *ReconcileClient) SetConfig(ctx context.Context, namespace string) (err 
 	err = r.config.ApplySecret(platformOIDCCredentialsSecret, oAuthAdminPasswordKey)
 	if err != nil {
 		return fmt.Errorf("failed to configure: %w", err)
-	}
-	return
-}
-
-// checkCSCACertificateSecret synchronizes the state of cached certificates from the Common Services CA based
-// upon events received from the cluster.
-func (r *ReconcileClient) checkCSCACertificateSecret(ctx context.Context) (err error) {
-	reqLogger := logf.FromContext(ctx).WithName("checkCSCACertificateSecret")
-	currentCertSecret := &corev1.Secret{}
-	namespacedName := types.NamespacedName{Name: CSCACertificateSecretName, Namespace: r.sharedServicesNamespace}
-	var verb string
-	err = r.Reader.Get(ctx, namespacedName, currentCertSecret)
-	if errors.IsNotFound(err) {
-		reqLogger.Info("cs-ca-certificate-secret not found; removing cached certificate")
-		verb = "delete"
-		r.deleteCSCACertificateSecret(ctx)
-		reqLogger.Info("certificate registration succeeded", "action", verb)
-		return nil
-	} else if err != nil {
-		// Some other issue arose
-		return
-	}
-
-	oldCertSecret := r.csCACertSecret
-	if oldCertSecret == nil {
-		reqLogger.Info("cs-ca-certificate-secret not registered; caching certificate")
-		err = r.setCSCACertificateSecret(ctx, currentCertSecret)
-		verb = "create"
-	} else if currentCertSecret.GetDeletionTimestamp() != nil {
-		reqLogger.Info("cs-ca-certificate-secret deleted; removing cached certificate")
-		r.deleteCSCACertificateSecret(ctx)
-		verb = "delete"
-	} else {
-		if string(oldCertSecret.Data[corev1.TLSCertKey]) != string(currentCertSecret.Data[corev1.TLSCertKey]) {
-			reqLogger.Info("cs-ca-certificate-secret was updated; caching updated certificate")
-			err = r.setCSCACertificateSecret(ctx, currentCertSecret)
-			verb = "update"
-		} else {
-			reqLogger.Info("cs-ca-certificate-secret has not changed")
-			return
-		}
-	}
-	if err != nil {
-		reqLogger.Info("certificate registration failed", "action", verb)
-	} else {
-		reqLogger.Info("certificate registration succeeded", "action", verb)
 	}
 	return
 }

--- a/pkg/controller/client/clientreg.go
+++ b/pkg/controller/client/clientreg.go
@@ -195,51 +195,18 @@ func (r *ReconcileClient) GetClientRegistration(ctx context.Context, client *oid
 	return
 }
 
-// setCSCACertificateSecret caches a copy of the Secret that contains the Common Services CA certificate for the
-// provided namespace. If a Secret has already been cached for the namespace, this function replaces it with the new
-// Secret.
-func (r *ReconcileClient) setCSCACertificateSecret(ctx context.Context, secret *corev1.Secret) (err error) {
-	if secret == nil {
-		return fmt.Errorf("provided Secret pointer was nil")
-	}
-	r.csCACertSecret = secret
-	return
-}
-
-// deleteCSCACertificateSecret deletes the cached copy of the Secret that contains the Common Services CA certificate
-// for the provided namespace.
-func (r *ReconcileClient) deleteCSCACertificateSecret(ctx context.Context) {
-	r.csCACertSecret = nil
-}
-
 // getCSCACertificateSecret gets the Secret that contains the Common Services CA certificate for the provided namespace.
 // It will return the ReconcileClient's cached Secret for the namespace if it has one registered, or it will look up and
 // return whatever matching Secret exists in the cluster and cache it for future use.
 func (r *ReconcileClient) getCSCACertificateSecret(ctx context.Context) (secret *corev1.Secret, err error) {
-	logger := logf.FromContext(ctx).WithName("getCSCACertificateSecret")
-	secret = r.csCACertSecret
-	// Have the secret locally; return it
-	if secret != nil {
-		logger.Info("found CA certificate secret")
-		return
-	}
-	logger.Info("CA certificate secret not found")
+	logger := logf.FromContext(ctx).WithName("getCSCACertificateSecret").WithValues("secretName", CSCACertificateSecretName)
 	secret = &corev1.Secret{}
-	// Need to perform lookup of secret in the cluster
-	logger.Info("Attempt to get secret from namespace", "secretName", CSCACertificateSecretName)
 	err = r.client.Get(ctx, types.NamespacedName{Name: CSCACertificateSecretName, Namespace: r.sharedServicesNamespace}, secret)
 	if err != nil {
-		logger.Error(err, "failed to get secret", "secretName", CSCACertificateSecretName)
+		logger.Error(err, "Failed to get secret")
 		return nil, err
 	} else {
-		logger.Info("found secret on the cluster")
-	}
-
-	err = r.setCSCACertificateSecret(ctx, secret)
-	if err != nil {
-		logger.Error(err, "failed to set secret", "secretName", CSCACertificateSecretName)
-	} else {
-		logger.Info("found CA certificate secret")
+		logger.Info("Got secret")
 	}
 
 	return


### PR DESCRIPTION
- Removes unneeded logic surrounding caching of certificate Secret and replaces with a plain getter.