### PR TITLE
update https for cluster ep

### DIFF
--- a/pkg/controller/authentication/configmap.go
+++ b/pkg/controller/authentication/configmap.go
@@ -708,7 +708,7 @@ func (r *ReconcileAuthentication) ibmcloudClusterInfoConfigMap(client client.Cli
 			},
 			Data: map[string]string{
 				ClusterAddr:          DomainName,
-				ClusterEP:            DomainName,
+				ClusterEP:            "https://" + DomainName,
 				RouteHTTPPort:        rhttpPort,
 				RouteHTTPSPort:       rhttpsPort,
 				ClusterName:          cname,


### PR DESCRIPTION
```
data:
  cluster_address: cp-console-ibm-common-services.ujjwal-roks-4-fae6c235d7a3aed6346697c0e75f4896-0000.jp-tok.containers.appdomain.cloud
  cluster_endpoint: https://cp-console-ibm-common-services.ujjwal-roks-4-fae6c235d7a3aed6346697c0e75f4896-0000.jp-tok.containers.appdomain.cloud
  cluster_kube_apiserver_host: c103-e.jp-tok.containers.cloud.ibm.com
  cluster_kube_apiserver_port: "30579"
  cluster_name: mycluster
  cluster_router_http_port: "80"
  cluster_router_https_port: "443"
  im_idmgmt_endpoint: https://platform-identity-management.ibm-common-services.svc:443
  im_idprovider_endpoint: https://platform-identity-provider.ibm-common-services.svc:4300
  proxy_address: cp-proxy-ibm-common-services.ujjwal-roks-4-fae6c235d7a3aed6346697c0e75f4896-0000.jp-tok.containers.appdomain.cloud
kind: ConfigMap
```

Appended "https://" for `cluster_endpoint`


https://github.ibm.com/IBMPrivateCloud/roadmap/issues/58621