### PR TITLE
Fix ownership of ibmcloud-* resources issues

### DIFF
--- a/pkg/controller/authentication/configmap.go
+++ b/pkg/controller/authentication/configmap.go
@@ -392,7 +392,7 @@ func (r *ReconcileAuthentication) handleConfigMap(instance *operatorv1alpha1.Aut
 					err = fmt.Errorf("an error occurred during registration-json generation")
 					return err
 				}
-				reqLogger.Info("Calculated new platform-oidc-registration.json", "json", newConfigMap.Data["platform-oidc-registration.json"])
+				reqLogger.Info("Calculated new platform-oidc-registration.json")
 				var currentRegistrationJSON, newRegistrationJSON *registrationJSONData
 				newRegistrationJSON = &registrationJSONData{}
 				currentRegistrationJSON = &registrationJSONData{}

--- a/pkg/controller/authentication/configmap.go
+++ b/pkg/controller/authentication/configmap.go
@@ -33,6 +33,7 @@ import (
 
 	operatorv1alpha1 "github.com/IBM/ibm-iam-operator/pkg/apis/operator/v1alpha1"
 	pkgCommon "github.com/IBM/ibm-iam-operator/pkg/common"
+	ctrlCommon "github.com/IBM/ibm-iam-operator/pkg/controller/common"
 	osconfigv1 "github.com/openshift/api/config/v1"
 	"gopkg.in/yaml.v2"
 	batchv1 "k8s.io/api/batch/v1"
@@ -100,22 +101,29 @@ func (r *ReconcileAuthentication) handleConfigMap(instance *operatorv1alpha1.Aut
 		}
 	} else {
 		labels := currentConfigMap.Labels
-		ownerRefs := currentConfigMap.OwnerReferences
-		var ownRef string
-		for _, ownRefs := range ownerRefs {
-			ownRef = ownRefs.Kind
-		}
 
 		if labels != nil {
 			value, ok := labels["app"]
-			if ok && value == "auth-idp" && ownRef == "Authentication" {
+			if ok && value == "auth-idp" && ctrlCommon.IsControllerOf(instance, currentConfigMap) {
 				reqLogger.Info("ibmcloud-cluster-info Configmap is already created by IM operator", "Configmap.Namespace", currentConfigMap.Namespace, "ConfigMap.Name", "ibmcloud-cluster-info")
-			} else if ok && value == "management-ingress" && ownRef == "ManagementIngress" {
+			} else if ok && value == "management-ingress" && ctrlCommon.GetControllerKind(currentConfigMap) == "ManagementIngress" {
 				reqLogger.Info("Configmap is already created by managementingress , IM installation may not proceed further until the configmap is removed", "Configmap.Namespace", currentConfigMap.Namespace, "ConfigMap.Name", "ibmcloud-cluster-info")
 				*needToRequeue = true
 				return
 			} else {
-				reqLogger.Info("Can't determine the configmap ownership , IM installation may not proceed further until the configmap is removed", "Configmap.Namespace", currentConfigMap.Namespace, "ConfigMap.Name", "ibmcloud-cluster-info")
+				reqLogger.Info("ConfigMap is not owned by the current Authentication or a ManagementIngress; will attempt to become controller", "Configmap.Namespace", currentConfigMap.Namespace, "ConfigMap.Name", "ibmcloud-cluster-info")
+				if err = controllerutil.SetControllerReference(instance, currentConfigMap, r.client.Scheme()); err != nil {
+					reqLogger.Error(err, "Could not become the controller of the ConfigMap; it may need to be removed", "Configmap.Namespace", currentConfigMap.Namespace, "ConfigMap.Name", "ibmcloud-cluster-info")
+					return
+				}
+				currentConfigMap.Labels["app"] = "auth-idp"
+				reqLogger.Info("Became controller and labeled to indicate association with IM; attempting update", "Configmap.Namespace", currentConfigMap.Namespace, "ConfigMap.Name", "ibmcloud-cluster-info")
+				err = r.client.Update(context.TODO(), currentConfigMap)
+				if err != nil {
+					reqLogger.Error(err, "Failed to update ConfigMap", "Configmap.Namespace", currentConfigMap.Namespace, "ConfigMap.Name", "ibmcloud-cluster-info")
+					return
+				}
+				reqLogger.Info("Successfully updated ConfigMap; requeueing reconcile", "Configmap.Namespace", currentConfigMap.Namespace, "ConfigMap.Name", "ibmcloud-cluster-info")
 				*needToRequeue = true
 				return
 			}
@@ -421,14 +429,18 @@ func (r *ReconcileAuthentication) handleConfigMap(instance *operatorv1alpha1.Aut
 					reqLogger.Info("ConfigMap successfully updated")
 					if updatedJSON {
 						reqLogger.Info("Deleting Job to re-run with upated ConfigMap", "Job.Name", "oidc-client-registration")
-					
+
 						job := &batchv1.Job{
 							ObjectMeta: metav1.ObjectMeta{
-								Name: "oidc-client-registration",
+								Name:      "oidc-client-registration",
 								Namespace: instance.Namespace,
 							},
 						}
 						if err = r.client.Delete(context.TODO(), job); err != nil {
+							if errors.IsNotFound(err) {
+								reqLogger.Info("Job not found on cluster; continuing", "Job.Name", "oidc-client-registration")
+								return nil
+							}
 							reqLogger.Error(err, "Could not delete job", "Job.Name", "oidc-client-registration")
 							return
 						}

--- a/pkg/controller/authentication/resourcestatus.go
+++ b/pkg/controller/authentication/resourcestatus.go
@@ -39,7 +39,7 @@ const (
 )
 
 func getServiceStatus(ctx context.Context, k8sClient client.Client, namespacedName types.NamespacedName) (status operatorv1alpha1.ManagedResourceStatus) {
-	reqLogger := logf.FromContext(ctx).WithName("getServiceStatus")
+	reqLogger := logf.FromContext(ctx).WithName("getServiceStatus").V(3)
 	kind := "Service"
 	status = operatorv1alpha1.ManagedResourceStatus{
 		ObjectName: namespacedName.Name,
@@ -74,7 +74,7 @@ func getAllServiceStatus(ctx context.Context, k8sClient client.Client, names []s
 }
 
 func getDeploymentStatus(ctx context.Context, k8sClient client.Client, namespacedName types.NamespacedName) (status operatorv1alpha1.ManagedResourceStatus) {
-	reqLogger := logf.FromContext(ctx).WithName("getDeploymentStatus")
+	reqLogger := logf.FromContext(ctx).WithName("getDeploymentStatus").V(3)
 	kind := "Deployment"
 	status = operatorv1alpha1.ManagedResourceStatus{
 		ObjectName: namespacedName.Name,
@@ -114,7 +114,7 @@ func getAllDeploymentStatus(ctx context.Context, k8sClient client.Client, names 
 }
 
 func getJobStatus(ctx context.Context, k8sClient client.Client, namespacedName types.NamespacedName) (status operatorv1alpha1.ManagedResourceStatus) {
-	reqLogger := logf.FromContext(ctx).WithName("getJobStatus")
+	reqLogger := logf.FromContext(ctx).WithName("getJobStatus").V(3)
 	kind := "Job"
 	status = operatorv1alpha1.ManagedResourceStatus{
 		ObjectName: namespacedName.Name,
@@ -154,7 +154,7 @@ func getAllJobStatus(ctx context.Context, k8sClient client.Client, names []strin
 }
 
 func getRouteStatus(ctx context.Context, k8sClient client.Client, namespacedName types.NamespacedName) (status operatorv1alpha1.ManagedResourceStatus) {
-	reqLogger := logf.FromContext(ctx).WithName("getRouteStatus")
+	reqLogger := logf.FromContext(ctx).WithName("getRouteStatus").V(3)
 	kind := "Route"
 	status = operatorv1alpha1.ManagedResourceStatus{
 		ObjectName: namespacedName.Name,
@@ -196,7 +196,7 @@ func getAllRouteStatus(ctx context.Context, k8sClient client.Client, names []str
 }
 
 func (r *ReconcileAuthentication) getCurrentServiceStatus(ctx context.Context, k8sClient client.Client, authentication *operatorv1alpha1.Authentication) (status operatorv1alpha1.ServiceStatus) {
-	reqLogger := logf.FromContext(ctx).WithName("getCurrentServiceStatus")
+	reqLogger := logf.FromContext(ctx).WithName("getCurrentServiceStatus").V(3)
 	type statusRetrieval struct {
 		names []string
 		f     statusRetrievalFunc

--- a/pkg/controller/client/client_controller.go
+++ b/pkg/controller/client/client_controller.go
@@ -290,12 +290,12 @@ func (r *ReconcileClient) updateClient(ctx context.Context, client *oidcv1.Clien
 		err = fmt.Errorf("error occurred during update oidc client registration: %w", err)
 		return
 	}
-	responseBody, err := ioutil.ReadAll(response.Body)
+	_, err = ioutil.ReadAll(response.Body)
 	if err != nil {
 		log.Error(err, "Failed to read response body")
 		err = nil
 	}
-	reqLogger.Info("Received response", "body", responseBody)
+	reqLogger.Info("Received non-empty response")
 
 	// secret is nil if getSecretFromClient produces an error, which we assume to mean that the Secret sought after didn't
 	// turn up. If this happens, try to create a new secret using the clientCreds that were freshly generated and used for

--- a/pkg/controller/client/clientreg.go
+++ b/pkg/controller/client/clientreg.go
@@ -120,7 +120,7 @@ func (r *ReconcileClient) UpdateClientRegistration(ctx context.Context, client *
 		logger.Error(err, "Client registration update failed")
 		return nil, NewOIDCClientError(response)
 	}
-	logger.Info("Client registration update successful", "response", response)
+	logger.Info("Client registration update successful")
 	return
 }
 


### PR DESCRIPTION
Originating issue: [IBMPrivateCloud/roadmap#58841](https://github.ibm.com/IBMPrivateCloud/roadmap/issues/58841)

During backup and restore, the ibmcloud-cluster-info ConfigMap and the ibmcloud-cluster-ca-cert Secret would block the IM Operator from coming completely online because it expects that it owns those resources; however, when the resources were restored, the ownerReferences were not also restored. This fix to the IM Operator attempts to assert controller status on behalf of the Authentication CR upon the ibmcloud-cluster-info ConfigMap when it isn't controlled by that Authentication CR, and, in the case of ibmcloud-cluster-ca-cert, the IM Operator will simply delete the Secret and create a new one to replace it.