### PR TITLE
Dynamic scan - set X-Content-Type-options to nosniff

### DIFF
--- a/pkg/controller/authentication/ingress.go
+++ b/pkg/controller/authentication/ingress.go
@@ -587,7 +587,9 @@ func platformIdAuthIngress(instance *operatorv1alpha1.Authentication, scheme *ru
 				"icp.management.ibm.com/secure-backends": "true",
 				"icp.management.ibm.com/rewrite-target":  "/",
 				"icp.management.ibm.com/configuration-snippet": `
-					add_header 'X-Frame-Options' 'SAMEORIGIN' always;`,
+					add_header 'X-Frame-Options' 'SAMEORIGIN' always;
+					add_header 'X-Content-Type-Options' 'nosniff';
+					`,
 			},
 		},
 		Spec: net.IngressSpec{
@@ -748,6 +750,7 @@ func platformOidcBlockIngress(instance *operatorv1alpha1.Authentication, scheme 
 				"icp.management.ibm.com/location-modifier": "=",
 				"icp.management.ibm.com/configuration-snippet": `
 										add_header 'X-XSS-Protection' '1' always;
+										add_header 'X-Content-Type-Options' 'nosniff';
 									`,
 			},
 		},


### PR DESCRIPTION
Fixes: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/59023
set header X-Content-Type-options to nosniff for paths '/idauth' and '/oidc/endpoint'