### PR TITLE
dynamic scan - x-content-type header set to nosniff

### DIFF
--- a/pkg/controller/authentication/ingress.go
+++ b/pkg/controller/authentication/ingress.go
@@ -535,6 +535,7 @@ func platformIdAuthBlockIngress(instance *operatorv1alpha1.Authentication, schem
 				"icp.management.ibm.com/location-modifier": "=",
 				"icp.management.ibm.com/configuration-snippet": `
 					add_header 'X-XSS-Protection' '1' always;
+					add_header 'X-Content-Type-Options' 'nosniff';
 					`,
 			},
 		},


### PR DESCRIPTION
Fix: [#59730](https://github.ibm.com/IBMPrivateCloud/roadmap/issues/59730)

Affected url : [/idauth/oidc/endpoint/OP/registration](https://cp-console.apps.sober.cp.fyre.ibm.com/idauth/oidc/endpoint/OP/registration)

set content-type to nosniff for **/idauth/oidc**