### PR TITLE
Added X-Content Type Options Header

### DIFF
--- a/pkg/controller/authentication/ingress.go
+++ b/pkg/controller/authentication/ingress.go
@@ -220,6 +220,7 @@ func iamTokenIngress(instance *operatorv1alpha1.Authentication, scheme *runtime.
 				"icp.management.ibm.com/rewrite-target":  "/",
 				"icp.management.ibm.com/configuration-snippet": `
 				add_header 'Content-Security-Policy' "default-src 'self';";
+				add_header 'X-Content-Type-Options' 'nosniff';
 				`,
 			},
 		},


### PR DESCRIPTION
Added X-Content Type Options Header to `/iam-token`
dynamic scan fix: [#60529](https://github.ibm.com/IBMPrivateCloud/roadmap/issues/60529)