### PR TITLE
Fix Dockerfile arch compile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,6 @@
 # If set to 1, then you need to also set 'DOCKER_USERNAME' and 'DOCKER_PASSWORD'
 # environment variables before build the repo.
 BUILD_LOCALLY ?= 1
-TARGET_GOARCH=amd64
 
 # The namespace that operator will be deployed in
 NAMESPACE=ibm-common-services
@@ -365,19 +364,19 @@ build-dev-image:
 
 build-image-amd64: $(CONFIG_DOCKER_TARGET) ## Build the Operator for Linux on amd64
 	$(CONTAINER_CLI) run --rm --privileged docker.io/multiarch/qemu-user-static:register --reset
-	$(CONTAINER_CLI) build ${IMAGE_BUILD_OPTS} --build-arg="TARGET_GOARCH=amd64" -t $(REGISTRY)/$(IMG)-amd64:$(VERSION) -f build/Dockerfile.amd64 .
+	$(CONTAINER_CLI) build ${IMAGE_BUILD_OPTS} -t $(REGISTRY)/$(IMG)-amd64:$(VERSION) -f build/Dockerfile.amd64 .
 	@\rm -f build/_output/bin/ibm-iam-operator-amd64
 	@if [ $(BUILD_LOCALLY) -ne 1 ]; then $(CONTAINER_CLI) push $(REGISTRY)/$(IMG)-amd64:$(VERSION); fi
 
 build-image-ppc64le: $(CONFIG_DOCKER_TARGET) ## Build the Operator for Linux on ppc64le
 	$(CONTAINER_CLI) run --rm --privileged docker.io/multiarch/qemu-user-static:register --reset
-	$(CONTAINER_CLI) build ${IMAGE_BUILD_OPTS} --build-arg="TARGET_GOARCH=ppc64le"  -t $(REGISTRY)/$(IMG)-ppc64le:$(VERSION) -f build/Dockerfile.ppc64le .
+	$(CONTAINER_CLI) build ${IMAGE_BUILD_OPTS} -t $(REGISTRY)/$(IMG)-ppc64le:$(VERSION) -f build/Dockerfile.ppc64le .
 	@\rm -f build/_output/bin/ibm-iam-operator-ppc64le
 	@if [ $(BUILD_LOCALLY) -ne 1 ]; then $(CONTAINER_CLI) push $(REGISTRY)/$(IMG)-ppc64le:$(VERSION); fi
 
 build-image-s390x: $(CONFIG_DOCKER_TARGET) ## Build the Operator for Linux on s390x
 	$(CONTAINER_CLI) run --rm --privileged docker.io/multiarch/qemu-user-static:register --reset
-	$(CONTAINER_CLI) build ${IMAGE_BUILD_OPTS} --build-arg="TARGET_GOARCH=s390x" -t $(REGISTRY)/$(IMG)-s390x:$(VERSION) -f build/Dockerfile.s390x .
+	$(CONTAINER_CLI) build ${IMAGE_BUILD_OPTS} -t $(REGISTRY)/$(IMG)-s390x:$(VERSION) -f build/Dockerfile.s390x .
 	@\rm -f build/_output/bin/ibm-iam-operator-s390x
 	@if [ $(BUILD_LOCALLY) -ne 1 ]; then $(CONTAINER_CLI) push $(REGISTRY)/$(IMG)-s390x:$(VERSION); fi
 

--- a/build/Dockerfile.amd64
+++ b/build/Dockerfile.amd64
@@ -15,7 +15,6 @@
 
 # Build the manager binary
 FROM docker.io/golang:1.21-bullseye as builder
-ARG TARGETARCH
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -35,7 +34,7 @@ COPY controllers/ controllers/
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
 
 # Swap default image for ubi8-minimal
 FROM docker-na-public.artifactory.swg-devops.com/hyc-cloud-private-edge-docker-local/build-images/ubi8-minimal:latest-amd64

--- a/build/Dockerfile.ppc64le
+++ b/build/Dockerfile.ppc64le
@@ -16,7 +16,6 @@
 
 # Build the manager binary
 FROM docker.io/golang:1.21-bullseye as builder
-ARG TARGETARCH
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -36,7 +35,7 @@ COPY controllers/ controllers/
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=ppc64le go build -a -o manager main.go
 
 FROM alpine as qemu-builder
 

--- a/build/Dockerfile.s390x
+++ b/build/Dockerfile.s390x
@@ -16,7 +16,6 @@
 
 # Build the manager binary
 FROM docker.io/golang:1.21-bullseye as builder
-ARG TARGETARCH
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -36,7 +35,7 @@ COPY controllers/ controllers/
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=s390x go build -a -o manager main.go
 
 FROM alpine as qemu-builder
 


### PR DESCRIPTION
Originating issue: [IBMPrivateCloud/roadmap#61811](https://github.ibm.com/IBMPrivateCloud/roadmap/issues/61811)

The Makefile was using the wrong build argument to pass the `GOARCH` value to the compiler for the manager. This resulted in the desired value not being properly set for image builds, which then led to the binaries only being compiled for Linux on whatever the host architecture happened to be.

Given there are already separate Dockerfiles for each architecture the project supports, the Dockerfiles no longer take this build argument and, instead, the build stage in each file explicitly states the desired `GOARCH` value.