### PR TITLE
Fix dev-bundle target and kustomizations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -293,7 +293,7 @@ bundle-hacks: yq bundle/manifests/ibm-iam-operator.clusterserviceversion.yaml ha
 .PHONY: dev-bundle-base 
 dev-bundle-base: manifests kustomize yq
 	operator-sdk generate kustomize manifests -q
-	cd config/manager/dev && $(KUSTOMIZE) edit set image controller=$(IMAGE_TAG_BASE):$(VERSION)
+	cd config/manager/overlays/dev && $(KUSTOMIZE) edit set image controller=$(IMAGE_TAG_BASE):$(VERSION)
 	$(KUSTOMIZE) build config/manifests/overlays/dev | operator-sdk generate bundle $(BUNDLE_GEN_FLAGS)
 
 .PHONY: dev-bundle

--- a/Makefile
+++ b/Makefile
@@ -136,6 +136,88 @@ all: build
 help: ## Display this help.
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
+##@ Build Dependencies
+
+## Location to install dependencies to
+LOCALBIN ?= $(shell pwd)/bin
+$(LOCALBIN):
+	mkdir -p $(LOCALBIN)
+
+## Tool Binaries
+KUSTOMIZE ?= $(LOCALBIN)/kustomize
+YQ ?= $(LOCALBIN)/yq
+CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
+ENVTEST ?= $(LOCALBIN)/setup-envtest
+
+## Tool Versions
+KUSTOMIZE_VERSION ?= v3.8.9
+CONTROLLER_TOOLS_VERSION ?= v0.11.4
+YQ_VERSION ?= v4.40.5
+GO_VERSION ?= 1.21.7
+
+# This pinned version of go has its version pinned to its name, so order of operations is inverted here.
+GO ?= $(LOCALBIN)/go$(GO_VERSION)
+
+.PHONY: go
+go: $(GO) ## Install pinned version of go
+$(GO): $(LOCALBIN) # https://go.dev/doc/manage-install#installing-multiple
+ifeq (,$(shell which go 2>/dev/null))
+	@{ \
+		echo '"go" not found in PATH; install go before attempting again'; \
+		exit 1; \
+	}
+endif
+	test -s $(LOCALBIN)/go$(GO_VERSION) && $(LOCALBIN)/go$(GO_VERSION) version | grep -q $(GO_VERSION) || \
+	GOSUMDB=sum.golang.org GOBIN=$(LOCALBIN) go install golang.org/dl/go$(GO_VERSION)@latest && $(LOCALBIN)/go$(GO_VERSION) download
+
+KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
+.PHONY: kustomize
+kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary. If wrong version is installed, it will be removed before downloading.
+$(KUSTOMIZE): $(LOCALBIN) go
+	@if test -x $(LOCALBIN)/kustomize && ! $(LOCALBIN)/kustomize version | grep -q $(KUSTOMIZE_VERSION); then \
+		echo "$(LOCALBIN)/kustomize version is not expected $(KUSTOMIZE_VERSION). Removing it before installing."; \
+		rm -rf $(LOCALBIN)/kustomize; \
+	fi
+	test -s $(LOCALBIN)/kustomize || { curl -Ss $(KUSTOMIZE_INSTALL_SCRIPT) | bash -s -- $(subst v,,$(KUSTOMIZE_VERSION)) $(LOCALBIN); }
+
+.PHONY: controller-gen
+controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary. If wrong version is installed, it will be overwritten.
+$(CONTROLLER_GEN): $(LOCALBIN) go
+	test -s $(LOCALBIN)/controller-gen && $(LOCALBIN)/controller-gen --version | grep -q $(CONTROLLER_TOOLS_VERSION) || \
+	GOSUMDB=sum.golang.org GOBIN=$(LOCALBIN) $(GO) install sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_TOOLS_VERSION)
+
+.PHONY: yq
+yq: $(YQ)
+$(YQ): $(LOCALBIN) go
+	@if test -x $(LOCALBIN)/yq && ! $(LOCALBIN)/yq --version | grep -q $(YQ_VERSION); then \
+		echo "$(LOCALBIN)/yq version is not expected $(YQ_VERSION). Removing it before installing."; \
+		rm -rf $(LOCALBIN)/yq; \
+	fi
+	test -s $(LOCALBIN)/yq || GOSUMDB=sum.golang.org GOBIN=$(LOCALBIN) $(GO) install github.com/mikefarah/yq/v4@$(YQ_VERSION)
+
+.PHONY: envtest
+envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
+$(ENVTEST): $(LOCALBIN) go
+	test -s $(LOCALBIN)/setup-envtest || GOSUMDB=sum.golang.org GOBIN=$(LOCALBIN) $(GO) install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+
+.PHONY: opm
+OPM = ./bin/opm
+opm: ## Download opm locally if necessary.
+ifeq (,$(wildcard $(OPM)))
+ifeq (,$(shell which opm 2>/dev/null))
+	@{ \
+	set -e ;\
+	mkdir -p $(dir $(OPM)) ;\
+	OS=$(shell go env GOOS) && ARCH=$(shell go env GOARCH) && \
+	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.23.0/$${OS}-$${ARCH}-opm ;\
+	chmod +x $(OPM) ;\
+	}
+else
+OPM = $(shell which opm)
+endif
+endif
+
+
 ##@ Development
 
 .PHONY: manifests
@@ -146,10 +228,35 @@ manifests: controller-gen ## Generate WebhookConfiguration and ClusterRole objec
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
 
+.PHONY: bundle-hacks
+bundle-hacks: yq bundle/manifests/ibm-iam-operator.clusterserviceversion.yaml hack/external-crs.json
+	@# Hack to add in the OperandRequest/OperandBindInfo after bundle validation; bundle validation will fail if they are
+	@# included in the examples beforehand. alm-examples is a JSON string, which makes it somewhat awkward to deal with in
+	@# kustomize. Instead, use yq to get the Authentication CR example as a JSON file, merge that example with the
+	@# OperandRequest and OperandBindInfo examples, and set alm-examples to that merged result.
+	$(YQ) '.metadata.annotations.alm-examples' bundle/manifests/ibm-iam-operator.clusterserviceversion.yaml > internal-crs.json
+	$(YQ) '. += load("./hack/external-crs.json")' internal-crs.json > combined-crs.json
+	$(YQ) -i '.metadata.annotations.alm-examples = load_str("combined-crs.json")' bundle/manifests/ibm-iam-operator.clusterserviceversion.yaml
+	@# Also need to replace the WATCH_NAMESPACE value that operator-sdk seems to overwrite with a reference to the
+	@# namespace-scope ConfigMap
+	$(YQ) -i '.spec.install.spec.deployments[].spec.template.spec.containers[].env |= map(select(.name == "WATCH_NAMESPACE").valueFrom=load("./hack/manager_patch.yaml"))' bundle/manifests/ibm-iam-operator.clusterserviceversion.yaml
+	@# Trying to include relatedImages in the config base leads to it being clobbered by operator-sdk apparently
+	$(YQ) -i '.spec.relatedImages = load("./hack/relatedimages.yaml")' bundle/manifests/ibm-iam-operator.clusterserviceversion.yaml
+	rm combined-crs.json internal-crs.json
+
+.PHONY: bundle-base
+bundle-base: manifests kustomize yq
+	operator-sdk generate kustomize manifests -q
+	$(KUSTOMIZE) build config/manifests/overlays/prod | operator-sdk generate bundle $(BUNDLE_GEN_FLAGS)
+	operator-sdk bundle validate ./bundle
+
+.PHONY: bundle
+bundle: bundle-base bundle-hacks ## Build the bundle manifests
+
 .PHONY: fmt
-fmt: ## Run go fmt against code.
-	which gofmt 2>&1 || go build -o $(GOBIN)/gofmt /usr/local/go/src/cmd/gofmt
-	go fmt ./...
+fmt: go ## Run go fmt against code.
+	test -s $(LOCALBIN)/gofmt 2>&1 || $(GO) build -o $(LOCALBIN)/gofmt ${HOME}/sdk/go1.21.7/src/cmd/gofmt
+	$(GO) fmt ./...
 
 .PHONY: vet
 vet: ## Run go vet against code.
@@ -159,45 +266,60 @@ vet: ## Run go vet against code.
 test: manifests generate fmt vet envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./... -coverprofile cover.out
 
+.PHONY: dev-bundle
+dev-bundle: dev-bundle-base bundle-hacks
+
+.PHONY: update-version
+update-version: manifests kustomize yq ## Update the Operator SemVer across the project
+	./hack/update_operator_version
+
+
 ##@ Build
 
 .PHONY: build
-build: manifests generate fmt vet ## Build manager binary.
-	@echo "Building the ibm-iam-operator binary"
-	@CGO_ENABLED=0 go build -o build/_output/bin/$(IMG) main.go
-	@strip $(STRIP_FLAGS) build/_output/bin/$(IMG)
+build: go manifests generate fmt vet ## Build manager binary.
+	@echo "Building the manager binary"
+	@CGO_ENABLED=0 $(GO) build -o build/_output/bin/manager main.go
+	@strip $(STRIP_FLAGS) build/_output/bin/manager
 
 .PHONY: run
-run: manifests generate fmt vet ## Run a controller from your host.
-	go run ./main.go
+run: go manifests generate fmt vet ## Run a controller from your host.
+	$(GO) run ./main.go
 
-# If you wish built the manager image targeting other platforms you can use the --platform flag.
-# (i.e. docker build --platform linux/arm64 ). However, you must enable docker buildKit for it.
-# More info: https://docs.docker.com/develop/develop-images/build_enhancements/
-.PHONY: docker-build
-docker-build: test ## Build docker image with the manager.
-	docker build -t ${IMG} .
+# Build a catalog image by adding bundle images to an empty catalog using the operator package manager tool, 'opm'.
+# This recipe invokes 'opm' in 'semver' bundle add mode. For more information on add modes, see:
+# https://github.com/operator-framework/community-operators/blob/7f1438c/docs/packaging-operator.md#updating-your-existing-operator
+.PHONY: catalog-build
+catalog-build: opm ## Build a catalog image.
+	$(OPM) index add --container-tool docker --mode semver --tag $(CATALOG_IMG) --bundles $(BUNDLE_IMGS) $(FROM_INDEX_OPT)
 
-.PHONY: docker-push
-docker-push: ## Push docker image with the manager.
-	docker push ${IMG}
+.PHONY: bundle-build
+bundle-build: ## Build the bundle image.
+	docker build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
 
-# PLATFORMS defines the target platforms for  the manager image be build to provide support to multiple
-# architectures. (i.e. make docker-buildx IMG=myregistry/mypoperator:0.0.1). To use this option you need to:
-# - able to use docker buildx . More info: https://docs.docker.com/build/buildx/
-# - have enable BuildKit, More info: https://docs.docker.com/develop/develop-images/build_enhancements/
-# - be able to push the image for your registry (i.e. if you do not inform a valid value via IMG=<myregistry/image:<tag>> then the export will fail)
-# To properly provided solutions that supports more than one platform you should use this option.
-PLATFORMS ?= linux/arm64,linux/amd64,linux/s390x,linux/ppc64le
-.PHONY: docker-buildx
-docker-buildx: test ## Build and push docker image for the manager for cross-platform support
-	# copy existing Dockerfile and insert --platform=${BUILDPLATFORM} into Dockerfile.cross, and preserve the original Dockerfile
-	sed -e '1 s/\(^FROM\)/FROM --platform=\$$\{BUILDPLATFORM\}/; t' -e ' 1,// s//FROM --platform=\$$\{BUILDPLATFORM\}/' Dockerfile > Dockerfile.cross
-	- docker buildx create --name project-v3-builder
-	docker buildx use project-v3-builder
-	- docker buildx build --push --platform=$(PLATFORMS) --tag ${IMG} -f Dockerfile.cross .
-	- docker buildx rm project-v3-builder
-	rm Dockerfile.cross
+build-image-amd64: $(GO) $(CONFIG_DOCKER_TARGET) ## Build the Operator for Linux on amd64
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GO) build -a -o build/_output/bin/manager main.go
+	$(CONTAINER_CLI) run --rm --privileged docker.io/multiarch/qemu-user-static:register --reset
+	$(CONTAINER_CLI) build ${IMAGE_BUILD_OPTS} -t $(REGISTRY)/$(IMG)-amd64:$(GIT_COMMIT_ID) -f build/Dockerfile.amd64 .
+	@\rm -f build/_output/bin/manager
+	@if [ $(BUILD_LOCALLY) -ne 1 ]; then $(CONTAINER_CLI) push $(REGISTRY)/$(IMG)-amd64:$(GIT_COMMIT_ID); fi
+
+build-image-ppc64le: $(GO) $(CONFIG_DOCKER_TARGET) ## Build the Operator for Linux on ppc64le
+	CGO_ENABLED=0 GOOS=linux GOARCH=ppc64le $(GO) build -a -o build/_output/bin/manager main.go
+	$(CONTAINER_CLI) run --rm --privileged docker.io/multiarch/qemu-user-static:register --reset
+	$(CONTAINER_CLI) build ${IMAGE_BUILD_OPTS} -t $(REGISTRY)/$(IMG)-ppc64le:$(GIT_COMMIT_ID) -f build/Dockerfile.ppc64le .
+	@\rm -f build/_output/bin/manager
+	@if [ $(BUILD_LOCALLY) -ne 1 ]; then $(CONTAINER_CLI) push $(REGISTRY)/$(IMG)-ppc64le:$(GIT_COMMIT_ID); fi
+
+build-image-s390x: $(GO) $(CONFIG_DOCKER_TARGET) ## Build the Operator for Linux on s390x
+	CGO_ENABLED=0 GOOS=linux GOARCH=s390x $(GO) build -a -o build/_output/bin/manager main.go
+	$(CONTAINER_CLI) run --rm --privileged docker.io/multiarch/qemu-user-static:register --reset
+	$(CONTAINER_CLI) build ${IMAGE_BUILD_OPTS} -t $(REGISTRY)/$(IMG)-s390x:$(GIT_COMMIT_ID) -f build/Dockerfile.s390x .
+	@\rm -f build/_output/bin/manager
+	@if [ $(BUILD_LOCALLY) -ne 1 ]; then $(CONTAINER_CLI) push $(REGISTRY)/$(IMG)-s390x:$(GIT_COMMIT_ID); fi
+
+images: $(CONFIG_DOCKER_TARGET) build-image-amd64 build-image-ppc64le build-image-s390x ## Build the multi-arch manifest
+	@MAX_PULLING_RETRY=20 RETRY_INTERVAL=30 common/scripts/multiarch_image.sh $(REGISTRY) $(IMG) $(GIT_COMMIT_ID) $(VERSION)
 
 ##@ Deployment
 
@@ -217,78 +339,18 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	$(KUSTOMIZE) build config/default | kubectl apply -f -
+	- oc apply -f config/samples/bases/operator_v1alpha1_authentication.yaml -n ${NAMESPACE}
 
 .PHONY: undeploy
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
+	- oc delete -f config/samples/bases/operator_v1alpha1_authentication.yaml -n ${NAMESPACE}
 	$(KUSTOMIZE) build config/default | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
 
-##@ Build Dependencies
+build-dev-image: ## Build local 
+	@echo "Building ibm-iam-operator dev image for $(LOCAL_ARCH)"
+	$(CONTAINER_CLI) build ${IMAGE_BUILD_OPTS} -t $(REGISTRY)/$(IMG)-$(LOCAL_ARCH):$(VERSION) -f Dockerfile .
+	@if [ $(BUILD_LOCALLY) -ne 1 ]; then $(CONTAINER_CLI) push $(REGISTRY)/$(IMG)-$(LOCAL_ARCH):$(GIT_COMMIT_ID); fi
 
-## Location to install dependencies to
-LOCALBIN ?= $(shell pwd)/bin
-$(LOCALBIN):
-	mkdir -p $(LOCALBIN)
-
-## Tool Binaries
-KUSTOMIZE ?= $(LOCALBIN)/kustomize
-YQ ?= $(LOCALBIN)/yq
-CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
-ENVTEST ?= $(LOCALBIN)/setup-envtest
-
-## Tool Versions
-KUSTOMIZE_VERSION ?= v3.8.7
-CONTROLLER_TOOLS_VERSION ?= v0.11.1
-YQ_VERSION ?= v4.40.5
-
-KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
-.PHONY: kustomize
-kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary. If wrong version is installed, it will be removed before downloading.
-$(KUSTOMIZE): $(LOCALBIN)
-	@if test -x $(LOCALBIN)/kustomize && ! $(LOCALBIN)/kustomize version | grep -q $(KUSTOMIZE_VERSION); then \
-		echo "$(LOCALBIN)/kustomize version is not expected $(KUSTOMIZE_VERSION). Removing it before installing."; \
-		rm -rf $(LOCALBIN)/kustomize; \
-	fi
-	test -s $(LOCALBIN)/kustomize || { curl -Ss $(KUSTOMIZE_INSTALL_SCRIPT) | bash -s -- $(subst v,,$(KUSTOMIZE_VERSION)) $(LOCALBIN); }
-
-.PHONY: controller-gen
-controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary. If wrong version is installed, it will be overwritten.
-$(CONTROLLER_GEN): $(LOCALBIN)
-	test -s $(LOCALBIN)/controller-gen && $(LOCALBIN)/controller-gen --version | grep -q $(CONTROLLER_TOOLS_VERSION) || \
-	GOSUMDB=sum.golang.org GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_TOOLS_VERSION)
-
-.PHONY: yq
-yq: $(YQ)
-$(YQ): $(LOCALBIN)
-	@if test -x $(LOCALBIN)/yq && ! $(LOCALBIN)/yq --version | grep -q $(YQ_VERSION); then \
-		echo "$(LOCALBIN)/yq version is not expected $(YQ_VERSION). Removing it before installing."; \
-		rm -rf $(LOCALBIN)/yq; \
-	fi
-	test -s $(LOCALBIN)/yq || GOSUMDB=sum.golang.org GOBIN=$(LOCALBIN) go install github.com/mikefarah/yq/v4@$(YQ_VERSION)
-
-.PHONY: envtest
-envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
-$(ENVTEST): $(LOCALBIN)
-	test -s $(LOCALBIN)/setup-envtest || GOSUMDB=sum.golang.org GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
-
-.PHONY: update-version
-update-version: manifests kustomize yq 
-	./hack/update_operator_version
-
-.PHONY: bundle-hacks
-bundle-hacks: yq bundle/manifests/ibm-iam-operator.clusterserviceversion.yaml hack/external-crs.json
-	@# Hack to add in the OperandRequest/OperandBindInfo after bundle validation; bundle validation will fail if they are
-	@# included in the examples beforehand. alm-examples is a JSON string, which makes it somewhat awkward to deal with in
-	@# kustomize. Instead, use yq to get the Authentication CR example as a JSON file, merge that example with the
-	@# OperandRequest and OperandBindInfo examples, and set alm-examples to that merged result.
-	$(YQ) '.metadata.annotations.alm-examples' bundle/manifests/ibm-iam-operator.clusterserviceversion.yaml > internal-crs.json
-	$(YQ) '. += load("./hack/external-crs.json")' internal-crs.json > combined-crs.json
-	$(YQ) -i '.metadata.annotations.alm-examples = load_str("combined-crs.json")' bundle/manifests/ibm-iam-operator.clusterserviceversion.yaml
-	@# Also need to replace the WATCH_NAMESPACE value that operator-sdk seems to overwrite with a reference to the
-	@# namespace-scope ConfigMap
-	$(YQ) -i '.spec.install.spec.deployments[].spec.template.spec.containers[].env |= map(select(.name == "WATCH_NAMESPACE").valueFrom=load("./hack/manager_patch.yaml"))' bundle/manifests/ibm-iam-operator.clusterserviceversion.yaml
-	@# Trying to include relatedImages in the config base leads to it being clobbered by operator-sdk apparently
-	$(YQ) -i '.spec.relatedImages = load("./hack/relatedimages.yaml")' bundle/manifests/ibm-iam-operator.clusterserviceversion.yaml
-	rm combined-crs.json internal-crs.json
 
 .PHONY: dev-bundle-base 
 dev-bundle-base: manifests kustomize yq
@@ -296,42 +358,9 @@ dev-bundle-base: manifests kustomize yq
 	cd config/manager/overlays/dev && $(KUSTOMIZE) edit set image controller=$(IMAGE_TAG_BASE):$(VERSION)
 	$(KUSTOMIZE) build config/manifests/overlays/dev | operator-sdk generate bundle $(BUNDLE_GEN_FLAGS)
 
-.PHONY: dev-bundle
-dev-bundle: dev-bundle-base bundle-hacks
-
-.PHONY: bundle-base
-bundle-base: manifests kustomize yq ## Generate bundle manifests and metadata, then validate generated files.
-	operator-sdk generate kustomize manifests -q
-	$(KUSTOMIZE) build config/manifests/overlays/prod | operator-sdk generate bundle $(BUNDLE_GEN_FLAGS)
-	operator-sdk bundle validate ./bundle
-
-.PHONY: bundle
-bundle: bundle-base bundle-hacks ## Build the bundle manifests
-
-.PHONY: bundle-build
-bundle-build: ## Build the bundle image.
-	docker build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
-
 .PHONY: bundle-push
 bundle-push: ## Push the bundle image.
 	$(MAKE) docker-push IMG=$(BUNDLE_IMG)
-
-.PHONY: opm
-OPM = ./bin/opm
-opm: ## Download opm locally if necessary.
-ifeq (,$(wildcard $(OPM)))
-ifeq (,$(shell which opm 2>/dev/null))
-	@{ \
-	set -e ;\
-	mkdir -p $(dir $(OPM)) ;\
-	OS=$(shell go env GOOS) && ARCH=$(shell go env GOARCH) && \
-	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.23.0/$${OS}-$${ARCH}-opm ;\
-	chmod +x $(OPM) ;\
-	}
-else
-OPM = $(shell which opm)
-endif
-endif
 
 # A comma-separated list of bundle images (e.g. make catalog-build BUNDLE_IMGS=example.com/operator-bundle:v0.1.0,example.com/operator-bundle:v0.2.0).
 # These images MUST exist in a registry and be pull-able.
@@ -345,58 +374,18 @@ ifneq ($(origin CATALOG_BASE_IMG), undefined)
 FROM_INDEX_OPT := --from-index $(CATALOG_BASE_IMG)
 endif
 
-# Build a catalog image by adding bundle images to an empty catalog using the operator package manager tool, 'opm'.
-# This recipe invokes 'opm' in 'semver' bundle add mode. For more information on add modes, see:
-# https://github.com/operator-framework/community-operators/blob/7f1438c/docs/packaging-operator.md#updating-your-existing-operator
-.PHONY: catalog-build
-catalog-build: opm ## Build a catalog image.
-	$(OPM) index add --container-tool docker --mode semver --tag $(CATALOG_IMG) --bundles $(BUNDLE_IMGS) $(FROM_INDEX_OPT)
-
 # Push the catalog image.
 .PHONY: catalog-push
 catalog-push: ## Push a catalog image.
 	$(MAKE) docker-push IMG=$(CATALOG_IMG)
 
-build-dev-image:
-	@echo "Building ibm-iam-operator dev image for $(LOCAL_ARCH)"
-	$(CONTAINER_CLI) build ${IMAGE_BUILD_OPTS} -t $(REGISTRY)/$(IMG)-$(LOCAL_ARCH):$(VERSION) -f Dockerfile .
-	@if [ $(BUILD_LOCALLY) -ne 1 ]; then $(CONTAINER_CLI) push $(REGISTRY)/$(IMG)-$(LOCAL_ARCH):$(VERSION); fi
-
-build-image-amd64: $(CONFIG_DOCKER_TARGET) ## Build the Operator for Linux on amd64
-	$(CONTAINER_CLI) run --rm --privileged docker.io/multiarch/qemu-user-static:register --reset
-	$(CONTAINER_CLI) build ${IMAGE_BUILD_OPTS} -t $(REGISTRY)/$(IMG)-amd64:$(VERSION) -f build/Dockerfile.amd64 .
-	@\rm -f build/_output/bin/ibm-iam-operator-amd64
-	@if [ $(BUILD_LOCALLY) -ne 1 ]; then $(CONTAINER_CLI) push $(REGISTRY)/$(IMG)-amd64:$(VERSION); fi
-
-build-image-ppc64le: $(CONFIG_DOCKER_TARGET) ## Build the Operator for Linux on ppc64le
-	$(CONTAINER_CLI) run --rm --privileged docker.io/multiarch/qemu-user-static:register --reset
-	$(CONTAINER_CLI) build ${IMAGE_BUILD_OPTS} -t $(REGISTRY)/$(IMG)-ppc64le:$(VERSION) -f build/Dockerfile.ppc64le .
-	@\rm -f build/_output/bin/ibm-iam-operator-ppc64le
-	@if [ $(BUILD_LOCALLY) -ne 1 ]; then $(CONTAINER_CLI) push $(REGISTRY)/$(IMG)-ppc64le:$(VERSION); fi
-
-build-image-s390x: $(CONFIG_DOCKER_TARGET) ## Build the Operator for Linux on s390x
-	$(CONTAINER_CLI) run --rm --privileged docker.io/multiarch/qemu-user-static:register --reset
-	$(CONTAINER_CLI) build ${IMAGE_BUILD_OPTS} -t $(REGISTRY)/$(IMG)-s390x:$(VERSION) -f build/Dockerfile.s390x .
-	@\rm -f build/_output/bin/ibm-iam-operator-s390x
-	@if [ $(BUILD_LOCALLY) -ne 1 ]; then $(CONTAINER_CLI) push $(REGISTRY)/$(IMG)-s390x:$(VERSION); fi
-
-images: build-image-amd64 build-image-ppc64le build-image-s390x
-	@curl -L -o /tmp/manifest-tool https://github.com/estesp/manifest-tool/releases/download/v1.0.3/manifest-tool-linux-amd64
-	@chmod +x /tmp/manifest-tool
-	/tmp/manifest-tool push from-args --platforms linux/amd64,linux/ppc64le,linux/s390x --template $(REGISTRY)/$(IMG)-ARCH:$(VERSION) --target $(REGISTRY)/$(IMG) --ignore-missing
-	/tmp/manifest-tool push from-args --platforms linux/amd64,linux/ppc64le,linux/s390x --template $(REGISTRY)/$(IMG)-ARCH:$(VERSION) --target $(REGISTRY)/$(IMG):$(VERSION) --ignore-missing
 
 all: check test coverage build images
 
 ##@ Cleanup
-clean: ## Clean build binary
-	rm -f build/_output/bin/$(IMG)
-
-##@ Help
-help: ## Display this help
-	@echo "Usage:\n  make \033[36m<target>\033[0m"
-	@awk 'BEGIN {FS = ":.*##"}; \
-		/^[a-zA-Z0-9_-]+:.*?##/ { printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2 } \
-		/^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+clean: ## Clean build and bin directories
+	rm -f build/_output/bin/*
+	chmod -R +w bin/
+	rm -rf bin/*
 
 .PHONY: all build run check install uninstall code-dev test test-e2e coverage images csv clean help

--- a/build/Dockerfile.amd64
+++ b/build/Dockerfile.amd64
@@ -13,29 +13,6 @@
 # limitations under the License.
 #
 
-# Build the manager binary
-FROM docker.io/golang:1.21-bullseye as builder
-
-WORKDIR /workspace
-# Copy the Go Modules manifests
-COPY go.mod go.mod
-COPY go.sum go.sum
-# cache deps before building and copying source so that we don't need to re-download as much
-# and so that source changes don't invalidate our downloaded layer
-RUN go mod download
-
-# Copy the go source
-COPY main.go main.go
-COPY apis/ apis/
-COPY controllers/ controllers/
-
-# Build
-# the GOARCH has not a default value to allow the binary be built according to the host where the command
-# was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
-# the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
-# by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
-
 # Swap default image for ubi8-minimal
 FROM docker-na-public.artifactory.swg-devops.com/hyc-cloud-private-edge-docker-local/build-images/ubi8-minimal:latest-amd64
 
@@ -59,7 +36,7 @@ ENV OPERATOR=/usr/local/bin/ibm-iam-operator \
     USER_NAME=ibm-iam-operator
 
 WORKDIR /
-COPY --from=builder /workspace/manager ${OPERATOR}
+COPY build/_output/bin/manager ${OPERATOR}
 
 # Copy in licenses
 RUN mkdir /licenses

--- a/build/Dockerfile.ppc64le
+++ b/build/Dockerfile.ppc64le
@@ -14,29 +14,6 @@
 # limitations under the License.
 #
 
-# Build the manager binary
-FROM docker.io/golang:1.21-bullseye as builder
-
-WORKDIR /workspace
-# Copy the Go Modules manifests
-COPY go.mod go.mod
-COPY go.sum go.sum
-# cache deps before building and copying source so that we don't need to re-download as much
-# and so that source changes don't invalidate our downloaded layer
-RUN go mod download
-
-# Copy the go source
-COPY main.go main.go
-COPY apis/ apis/
-COPY controllers/ controllers/
-
-# Build
-# the GOARCH has not a default value to allow the binary be built according to the host where the command
-# was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
-# the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
-# by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=ppc64le go build -a -o manager main.go
-
 FROM alpine as qemu-builder
 
 RUN wget -O /qemu-ppc64le-static https://github.com/multiarch/qemu-user-static/releases/download/v5.2.0-2/qemu-ppc64le-static && chmod +x /qemu-ppc64le-static
@@ -64,7 +41,7 @@ ENV OPERATOR=/usr/local/bin/ibm-iam-operator \
     USER_NAME=ibm-iam-operator
 
 WORKDIR /
-COPY --from=builder /workspace/manager ${OPERATOR}
+COPY build/_output/bin/manager ${OPERATOR}
 COPY --from=qemu-builder /qemu-ppc64le-static /usr/bin
 
 # Copy in licenses

--- a/build/Dockerfile.s390x
+++ b/build/Dockerfile.s390x
@@ -14,29 +14,6 @@
 # limitations under the License.
 #
 
-# Build the manager binary
-FROM docker.io/golang:1.21-bullseye as builder
-
-WORKDIR /workspace
-# Copy the Go Modules manifests
-COPY go.mod go.mod
-COPY go.sum go.sum
-# cache deps before building and copying source so that we don't need to re-download as much
-# and so that source changes don't invalidate our downloaded layer
-RUN go mod download
-
-# Copy the go source
-COPY main.go main.go
-COPY apis/ apis/
-COPY controllers/ controllers/
-
-# Build
-# the GOARCH has not a default value to allow the binary be built according to the host where the command
-# was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
-# the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
-# by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=s390x go build -a -o manager main.go
-
 FROM alpine as qemu-builder
 
 RUN wget -O /qemu-s390x-static https://github.com/multiarch/qemu-user-static/releases/download/v5.2.0-2/qemu-s390x-static && chmod +x /qemu-s390x-static
@@ -63,7 +40,7 @@ ENV OPERATOR=/usr/local/bin/ibm-iam-operator \
   USER_NAME=ibm-iam-operator
 
 WORKDIR /
-COPY --from=builder /workspace/manager ${OPERATOR}
+COPY build/_output/bin/manager ${OPERATOR}
 COPY --from=qemu-builder /qemu-s390x-static /usr/bin/
 
 # Copy in licenses
@@ -74,6 +51,3 @@ USER ${USER_UID}
 
 ENTRYPOINT ["/usr/local/bin/ibm-iam-operator"]
 
-
-LABEL version="0.0.1"
-LABEL release="0.0.1"

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -1,19 +1,3 @@
-#
-# Copyright 2020, 2023 IBM Corporation
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-
 FROM scratch
 
 # Core bundle labels.

--- a/common/scripts/multiarch_image.sh
+++ b/common/scripts/multiarch_image.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+#
+# Copyright 2024 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This script build and push multiarch(amd64, ppc64le and s390x) image for the one specified by
+# IMAGE_REPO, IMAGE_NAME and VERSION.
+# It assumes the specified image for each platform is already pushed into corresponding docker registry.
+
+ALL_PLATFORMS="amd64 ppc64le s390x"
+
+IMAGE_REPO=${1}
+IMAGE_NAME=${2}
+VERSION=${3-"$(git describe --exact-match 2> /dev/null || git describe --match=$(git rev-parse --short=8 HEAD) --always --dirty --abbrev=8)"}
+RELEASE_VERSION=${4:-4.5.0}
+MAX_PULLING_RETRY=${MAX_PULLING_RETRY-10}
+RETRY_INTERVAL=${RETRY_INTERVAL-10}
+# support other container tools, e.g. podman
+CONTAINER_CLI=${CONTAINER_CLI:-docker}
+
+# Loop until the image for each single platform is ready in the docker registry.
+# TODO: remove this if prow job support dependency.
+for arch in ${ALL_PLATFORMS}
+do
+    for i in $(seq 1 "${MAX_PULLING_RETRY}")
+    do
+        echo "Checking image '${IMAGE_REPO}'/'${IMAGE_NAME}'-'${arch}':'${VERSION}'..."
+        ${CONTAINER_CLI} inspect "${IMAGE_REPO}"/"${IMAGE_NAME}"-"${arch}":"${VERSION}" && break
+        sleep "${RETRY_INTERVAL}"
+        if [ "${i}" -eq "${MAX_PULLING_RETRY}" ]; then
+            echo "Failed to found image '${IMAGE_REPO}'/'${IMAGE_NAME}'-'${arch}':'${VERSION}'!!!"
+            exit 1
+        fi
+    done
+done
+
+if [[ -n "$($CONTAINER_CLI images -f reference="${IMAGE_REPO}/${IMAGE_NAME}:${RELEASE_VERSION}" --format='{{.ID}}')" ]]
+then
+  echo "Remove local image with conflicting reference ${IMAGE_REPO}/${IMAGE_NAME}:${RELEASE_VERSION}"
+  podman rmi "${IMAGE_REPO}/${IMAGE_NAME}:${RELEASE_VERSION}"
+fi
+if [[ -n "$($CONTAINER_CLI images -f reference="${IMAGE_REPO}/${IMAGE_NAME}:latest" --format='{{.ID}}')" ]]
+then
+  echo "Remove local image with conflicting reference ${IMAGE_REPO}/${IMAGE_NAME}:latest"
+  podman rmi "${IMAGE_REPO}/${IMAGE_NAME}:latest"
+fi
+
+# create multi-arch manifest
+echo "Creating the multi-arch image manifest for ${IMAGE_REPO}/${IMAGE_NAME}:${RELEASE_VERSION}..."
+${CONTAINER_CLI} manifest create "${IMAGE_REPO}"/"${IMAGE_NAME}":"${RELEASE_VERSION}" \
+    "${IMAGE_REPO}"/"${IMAGE_NAME}"-amd64:"${VERSION}" \
+    "${IMAGE_REPO}"/"${IMAGE_NAME}"-ppc64le:"${VERSION}" \
+    "${IMAGE_REPO}"/"${IMAGE_NAME}"-s390x:"${VERSION}"
+echo "Creating the multi-arch image manifest for ${IMAGE_REPO}/${IMAGE_NAME}:latest..."
+${CONTAINER_CLI} manifest create "${IMAGE_REPO}"/"${IMAGE_NAME}":latest \
+    "${IMAGE_REPO}"/"${IMAGE_NAME}"-amd64:"${VERSION}" \
+    "${IMAGE_REPO}"/"${IMAGE_NAME}"-ppc64le:"${VERSION}" \
+    "${IMAGE_REPO}"/"${IMAGE_NAME}"-s390x:"${VERSION}"
+
+# push multi-arch manifest
+echo "Pushing the multi-arch image manifest for ${IMAGE_REPO}/${IMAGE_NAME}:${RELEASE_VERSION}..."
+${CONTAINER_CLI} manifest push "${IMAGE_REPO}"/"${IMAGE_NAME}":"${RELEASE_VERSION}"
+echo "Pushing the multi-arch image manifest for ${IMAGE_REPO}/${IMAGE_NAME}:latest..."
+${CONTAINER_CLI} manifest push "${IMAGE_REPO}"/"${IMAGE_NAME}":latest

--- a/config/default/overlays/dev/kustomization.yaml
+++ b/config/default/overlays/dev/kustomization.yaml
@@ -1,4 +1,4 @@
 bases:
-- ../crd
-- ../rbac
+- ../../../crd
+- ../../../rbac
 - ../../../manager/overlays/dev

--- a/config/manager/overlays/dev/kustomization.yaml
+++ b/config/manager/overlays/dev/kustomization.yaml
@@ -1,17 +1,17 @@
 resources:
-  - ../../bases
+- ../../bases
 generatorOptions:
   disableNameSuffixHash: true
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
-  - name: controller
-    newName: icr.io/cpopen/ibm-iam-operator
-    newTag: 4.5.0
+- name: controller
+  newName: icr.io/cpopen/ibm-iam-operator
+  newTag: 4.5.0
 patches:
-  - path: ./image_env_vars_patch.yaml
-    target:
-      group: apps
-      version: v1
-      kind: Deployment
-      name: ibm-iam-operator
+- path: ./image_env_vars_patch.yaml
+  target:
+    group: apps
+    kind: Deployment
+    name: ibm-iam-operator
+    version: v1

--- a/config/manifests/overlays/dev/kustomization.yaml
+++ b/config/manifests/overlays/dev/kustomization.yaml
@@ -1,7 +1,7 @@
 resources:
 - ../../bases
-- ../../../default/dev
-- ../../../samples/dev
+- ../../../default/overlays/dev
+- ../../../samples/overlays/dev
 - ../../../scorecard
 
 patches:


### PR DESCRIPTION
* Fix paths to overlays directories in various locations
* Remove unneeded copyright block
* Add go target for installing a pinned version of Go for building dependencies and the manager
* Replace previous manifest tool usage with script from ibm-common-service-operator used for creating multi-arch manifests
* Reorder Makefile targets to align them better with help section headings
* Remove unused Makefile targets
* Revert usage of go builder image to resume building using local go compiler (hence the aforementioned go target)
* Updated patch versions of dependencies
* Update clean target to remove both the manager binary as well as any dependencies that were downloaded and installed to the bin directory