### PR TITLE
Add delays to Authentication requeues

### DIFF
--- a/controllers/operator/operandrequest.go
+++ b/controllers/operator/operandrequest.go
@@ -111,7 +111,7 @@ func (r *AuthenticationReconciler) handleOperandRequest(ctx context.Context, req
 			return subreconciler.RequeueWithError(err)
 		}
 		reqLogger.Info("Created OperandRequest", "OperandRequestName", opReqName)
-		return subreconciler.Requeue()
+		return subreconciler.RequeueWithDelay(opreqWait)
 	} else if err != nil {
 		reqLogger.Error(err, "Failed to get OperandRequest", "OperandRequestName", opReqName)
 		return subreconciler.RequeueWithError(err)
@@ -158,7 +158,7 @@ func (r *AuthenticationReconciler) handleOperandRequest(ctx context.Context, req
 			return subreconciler.RequeueWithError(err)
 		}
 		reqLogger.Info("Updated OperandRequest successfully", "OperandRequestName", opReqName)
-		return subreconciler.Requeue()
+		return subreconciler.RequeueWithDelay(defaultLowerWait)
 	}
 
 	reqLogger.Info("No changes to OperandRequest; continue", "OperandRequestName", opReqName)
@@ -307,5 +307,5 @@ func (r *AuthenticationReconciler) createEDBShareClaim(ctx context.Context, req 
 		return subreconciler.RequeueWithError(err)
 	}
 	reqLogger.Info("Created CommonService CR for shared EDB claim successfully")
-	return subreconciler.Requeue()
+	return subreconciler.RequeueWithDelay(defaultLowerWait)
 }


### PR DESCRIPTION
More requeues happening in the Operator's controllers leads to an increased propensity to hit exponential backoff. Given the Authentication controller only manages a single CR instance, the reconciliation logic can afford to provide more explicit, quick turnarounds for loops without having to worry too much about the impact on the overall rate limit.