### PR TITLE
assign directory's _id to uid

### DIFF
--- a/migration/schema/v1/tables.go
+++ b/migration/schema/v1/tables.go
@@ -773,9 +773,9 @@ func ConvertV2DirectoryToV3IdpConfig(dirMap map[string]any) (v3Config *IdpConfig
 	v3Config = &IdpConfig{}
 	idpConfig := make(map[string]any)
 
-	if uid, ok := dirMap["id"]; ok {
+	if uid, ok := dirMap["_id"]; ok {
 		if v3Config.UID, ok = uid.(string); !ok {
-			return nil, fmt.Errorf("id of Directory is not a string")
+			return nil, fmt.Errorf("_id of Directory is not a string")
 		}
 	}
 	if id, ok := dirMap["LDAP_ID"]; ok {

--- a/migration/schema/v1/tables_test.go
+++ b/migration/schema/v1/tables_test.go
@@ -64,7 +64,7 @@ var _ = Describe("IdpConfig", func() {
 		Context("When Directory map is valid", func() {
 			It("produces a valid pointer to an IdpConfig struct", func() {
 				dirMap = map[string]any{
-					"id":                    "someidentifier",
+					"_id":                   "someidentifier",
 					"LDAP_ID":               "openLDAP",
 					"LDAP_REALM":            "openLDAPRealm",
 					"LDAP_HOST":             "100.100.100.100",
@@ -111,7 +111,7 @@ var _ = Describe("IdpConfig", func() {
 		Context("When Directory map has CP3MIGRATED", func() {
 			It("returns a valid pointer to a IdpConfig when it is set to \"true\"", func() {
 				dirMap = map[string]any{
-					"id":                    "someidentifier",
+					"_id":                   "someidentifier",
 					"LDAP_ID":               "openLDAP",
 					"LDAP_REALM":            "openLDAPRealm",
 					"LDAP_HOST":             "100.100.100.100",
@@ -157,7 +157,7 @@ var _ = Describe("IdpConfig", func() {
 			})
 			It("returns a valid pointer to a IdpConfig when it is not set to \"true\"", func() {
 				dirMap = map[string]any{
-					"id":                    "someidentifier",
+					"_id":                   "someidentifier",
 					"LDAP_ID":               "openLDAP",
 					"LDAP_REALM":            "openLDAPRealm",
 					"LDAP_HOST":             "100.100.100.100",
@@ -203,7 +203,7 @@ var _ = Describe("IdpConfig", func() {
 			})
 			It("returns a valid point to a IdpConfig when it is not set to \"true\"", func() {
 				dirMap = map[string]any{
-					"id":                    "someidentifier",
+					"_id":                   "someidentifier",
 					"LDAP_ID":               "openLDAP",
 					"LDAP_REALM":            "openLDAPRealm",
 					"LDAP_HOST":             "100.100.100.100",
@@ -251,7 +251,7 @@ var _ = Describe("IdpConfig", func() {
 		Context("When Directory map is invalid", func() {
 			It("returns nil", func() {
 				dirMap = map[string]any{
-					"id":                    "someidentifier",
+					"_id":                   "someidentifier",
 					"LDAP_ID":               123,
 					"LDAP_REALM":            "openLDAPRealm",
 					"LDAP_HOST":             "100.100.100.100",


### PR DESCRIPTION
https://github.ibm.com/IBMPrivateCloud/roadmap/issues/62716
Background on the issue: Initially we thought that `id` field from Directory need to considered as uid. but this seems to be wrong. so when a directory is onboarded, the get call returns below response which has `_id` and this has to be considered as uid
```
{
	"_id" : "64257460-e65c-11ee-bc9f-afdf81dc128f",
	"LDAP_ID" : "sert-openldap",
	"LDAP_REALM" : "REALM",
	"LDAP_HOST" : "XXXXXXXXXX",
	"LDAP_PORT" : "389",
	"LDAP_IGNORECASE" : "false",
	"LDAP_BASEDN" : "BASEDNVALUE",
	"LDAP_BINDDN" : "BINDDNVALUE",
	"LDAP_BINDPASSWORD" : "PASSWORD",
	"LDAP_TYPE" : "Custom",
	"LDAP_USERFILTER" : "(&(uid=%v)(objectclass=person))",
	"LDAP_GROUPFILTER" : "(&(cn=%v)(objectclass=groupOfUniqueNames))",
	"LDAP_USERIDMAP" : "*:uid",
	"LDAP_GROUPIDMAP" : "*:cn",
	"LDAP_GROUPMEMBERIDMAP" : "groupOfUniqueNames:uniqueMember",
	"LDAP_URL" : "ldap://XXXXXXXX:389",
	"LDAP_PROTOCOL" : "ldap",
	"LDAP_NESTEDSEARCH" : "false",
	"LDAP_PAGINGSEARCH" : "false"
}
```