### PR TITLE
Update Non Zen User roles for isolated upgrade

### DIFF
--- a/migration/migration.go
+++ b/migration/migration.go
@@ -682,6 +682,12 @@ func insertUserRelatedRows(ctx context.Context, mongodb *MongoDB, postgres *Post
 			err = nil
 			continue
 		}
+		if _, err = setUserV3Role(ctx, mongodb, user); err != nil {
+			reqLogger.Error(err, "Failed to set role for user")
+			errCount++
+			err = nil
+			continue
+		}
 		var uid *uuid.UUID
 		if uid, err = insertUser(ctx, postgres, user); err != nil {
 			errCount++
@@ -840,6 +846,42 @@ func setClientSecretIfEmpty(ctx context.Context, mongodb *MongoDB, zenInstance *
 	zenInstance.ClientSecret = decodedSecret
 	set = true
 
+	return
+}
+
+func getHighestRoleForUserFromTeam(userID string, team *v1schema.Team) (role v1schema.Role) {
+	teamUser := team.Users.GetUser(userID)
+	if teamUser == nil {
+		return v1schema.Authenticated
+	}
+	return teamUser.Roles.GetHighestRole()
+}
+
+func setUserV3Role(ctx context.Context, mongodb *MongoDB, user *v1schema.User) (set bool, err error) {
+	if user.Role != "" {
+		return
+	}
+	dbName := "platform-db"
+	collectionName := "Team"
+	filter := bson.D{}
+	cursor, err := mongodb.Client.
+		Database(dbName).
+		Collection(collectionName).
+		Find(ctx, filter)
+
+	var highest v1schema.Role
+	for cursor.Next(ctx) {
+		team := &v1schema.Team{}
+		if err = cursor.Decode(&team); err != nil {
+			return
+		}
+
+		if current := getHighestRoleForUserFromTeam(user.UserID, team); current > highest {
+			highest = current
+		}
+	}
+	user.Role = highest.ToV3String()
+	set = true
 	return
 }
 

--- a/migration/schema/v1/tables.go
+++ b/migration/schema/v1/tables.go
@@ -1011,3 +1011,113 @@ func ConvertV2SamlToIdpConfig(samlMap map[string]any) (v3Config *IdpConfig, err 
 	v3Config.Enabled = true
 	return
 }
+
+type Role int
+
+const (
+	Authenticated Role = iota
+	Viewer
+	Auditor
+	Editor
+	Operator
+	Administrator
+	CloudPakAdmin
+	ClusterAdmin
+)
+
+// ToString returns an IAM-compatible role name as a string.
+func (r Role) ToString() (s string) {
+	switch r {
+	case ClusterAdmin:
+		return "ClusterAdministrator"
+	case CloudPakAdmin:
+		return "CloudPakAdministrator"
+	case Administrator:
+		return "Administrator"
+	case Operator:
+		return "Operator"
+	case Editor:
+		return "Editor"
+	case Viewer:
+		return "Viewer"
+	case Auditor:
+		return "Auditor"
+	default:
+		return
+	}
+}
+
+// GetRole takes a string role name and returns the corresponding Role. If the string is not a known name, it returns
+// the lowest role.
+func GetRole(s string) (r Role) {
+	switch s {
+	case "ClusterAdministrator":
+		return ClusterAdmin
+	case "CloudPakAdministrator":
+		return CloudPakAdmin
+	case "Administrator":
+		return Administrator
+	case "Operator":
+		return Operator
+	case "Editor":
+		return Editor
+	case "Viewer":
+		return Viewer
+	case "Auditor":
+		return Auditor
+	default:
+		return Authenticated
+	}
+}
+
+// ToV3String returns an IM-compatible role name as a string. In IM, there are only three valid roles - Administrator,
+// Viewer, and Authenticated.
+func (r Role) ToV3String() (s string) {
+	if r >= Administrator && r <= ClusterAdmin {
+		return Administrator.ToString()
+	} else if r >= Viewer && r < Administrator {
+		return Viewer.ToString()
+	} else {
+		return Authenticated.ToString()
+	}
+}
+
+type TeamRole struct {
+	ID string `bson:"id"`
+}
+
+type TeamRoles []*TeamRole
+
+func (t TeamRoles) GetHighestRole() (highest Role) {
+	crnPrefix := "crn:v1:icp:private:iam::::role:"
+	for _, r := range t {
+		if r == nil {
+			continue
+		}
+		if current := GetRole(strings.TrimPrefix(r.ID, crnPrefix)); current > highest {
+			highest = current
+		}
+	}
+	return
+}
+
+type TeamUser struct {
+	UserID string    `bson:"userId"`
+	Roles  TeamRoles `bson:"roles"`
+}
+
+type TeamUsers []*TeamUser
+
+func (t TeamUsers) GetUser(id string) (user *TeamUser) {
+	for _, user := range t {
+		if user.UserID == id {
+			return user
+		}
+	}
+	return nil
+}
+
+type Team struct {
+	ID    string    `bson:"_id"`
+	Users TeamUsers `bson:"users"`
+}


### PR DESCRIPTION
Originating issue: [IBMPrivateCloud/roadmap#62770](https://github.ibm.com/IBMPrivateCloud/roadmap/issues/62770)

* Query Team collection in MongoDB to determine initial role value for User rows