### PR TITLE
Check for Deployments before registering Clients

### DIFF
--- a/controllers/common/constants.go
+++ b/controllers/common/constants.go
@@ -27,3 +27,12 @@ const DatastoreEDBSecretName string = "im-datastore-edb-secret"
 
 // Name of CommonService created by IM Operator to provision EDB share
 const DatastoreEDBCSName string = "im-common-service"
+
+type DeploymentName string
+
+// The current names of Deployments managed by this Operator
+const (
+	PlatformIdentityProvider   DeploymentName = "platform-identity-provider"
+	PlatformIdentityManagement DeploymentName = "platform-identity-management"
+	PlatformAuthService        DeploymentName = "platform-auth-service"
+)


### PR DESCRIPTION
Originating issue: [IBMPrivateCloud/roadmap#62692](https://github.ibm.com/IBMPrivateCloud/roadmap/issues/62692)

* Check for `platform-identity-provider` Deployment availability before attempting OIDC registration
* Check for `platform-identity-management` Deployment availability before attempting Zen registration
* Cluster subreconciler definitions together and in order of execution