### PR TITLE
Add MigrationsPerformed condition

### DIFF
--- a/apis/operator/v1alpha1/authentication_types.go
+++ b/apis/operator/v1alpha1/authentication_types.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"sync"
 
@@ -188,8 +189,44 @@ func (a *Authentication) SetService(ctx context.Context, service ServiceStatus, 
 
 // AuthenticationStatus defines the observed state of Authentication
 type AuthenticationStatus struct {
-	Nodes   []string      `json:"nodes"`
-	Service ServiceStatus `json:"service,omitempty"`
+	Nodes      []string           `json:"nodes"`
+	Service    ServiceStatus      `json:"service,omitempty"`
+	Conditions []metav1.Condition `json:"conditions,omitempty"`
+}
+
+const ConditionMigrated string = "MigrationsPerformed"
+const MessageMigrationSuccess string = "All migrations completed successfully"
+const MessageMigrationInProgress string = "Migrations are currently being performed; monitor progress in the IM Operator \"migration_worker\" logs"
+const ReasonMigrationSuccess string = "Complete"
+const ReasonMigrationInProgress string = "InProgress"
+const ReasonMigrationFailure string = "Failed"
+
+func NewMigrationSuccessCondition() *metav1.Condition {
+	return &metav1.Condition{
+		Type:    ConditionMigrated,
+		Status:  metav1.ConditionTrue,
+		Reason:  ReasonMigrationSuccess,
+		Message: MessageMigrationSuccess,
+	}
+}
+
+func NewMigrationInProgressCondition() *metav1.Condition {
+	return &metav1.Condition{
+		Type:    ConditionMigrated,
+		Status:  metav1.ConditionFalse,
+		Reason:  ReasonMigrationInProgress,
+		Message: MessageMigrationInProgress,
+	}
+}
+
+func NewMigrationFailureCondition(name string) *metav1.Condition {
+	message := fmt.Sprintf("Migration %q failed; review the IM Operator \"migration_worker\" logs for more information", name)
+	return &metav1.Condition{
+		Type:    ConditionMigrated,
+		Status:  metav1.ConditionFalse,
+		Reason:  ReasonMigrationFailure,
+		Message: message,
+	}
 }
 
 //+kubebuilder:object:root=true

--- a/controllers/operator/resourcestatus.go
+++ b/controllers/operator/resourcestatus.go
@@ -25,6 +25,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -265,6 +266,11 @@ func (r *AuthenticationReconciler) getCurrentServiceStatus(ctx context.Context, 
 		if managedResourceStatus.Status == ResourceNotReadyState {
 			return
 		}
+	}
+
+	// If planned migrations have not been completed, return Authentication as not ready
+	if meta.IsStatusConditionFalse(authentication.Status.Conditions, operatorv1alpha1.ConditionMigrated) {
+		return
 	}
 	status.Status = ResourceReadyState
 	return

--- a/migration/migration.go
+++ b/migration/migration.go
@@ -38,6 +38,14 @@ type Result struct {
 	Error error
 }
 
+func (r *Result) IsFailure() bool {
+	return r.Error != nil && len(r.Incomplete) > 0
+}
+
+func (r *Result) IsSuccess() bool {
+	return !r.IsFailure()
+}
+
 type DBConn interface {
 	Connect(context.Context) error
 	Configure(...DBOption) error


### PR DESCRIPTION
Originating issue: [IBMPrivateCloud/roadmap#62506](https://github.ibm.com/IBMPrivateCloud/roadmap/issues/62506)

* Add the MigrationsPerformed condition to the Authentication CR, which communicates whether all necessary migrations have been performed. This status factors into the `.status.service` that the Authentication reports - when one or more migrations are active or have failed, the Authentication is flagged as NotReady.