### PR TITLE
 Create unique ClusterRoleBindings

### DIFF
--- a/bundle/manifests/ibm-iam-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-iam-operator.clusterserviceversion.yaml
@@ -191,7 +191,7 @@ metadata:
     categories: Security
     certified: "false"
     containerImage: icr.io/cpopen/ibm-iam-operator:4.5.0
-    createdAt: "2024-03-07T14:22:15Z"
+    createdAt: "2024-03-29T06:13:00Z"
     description: The IAM operator provides a simple Kubernetes CRD-Based API to manage the lifecycle of IAM services. With this operator, you can simply deploy and upgrade the IAM services
     olm.skipRange: <4.5.0
     operators.operatorframework.io/builder: operator-sdk-v1.33.0

--- a/controllers/operator/authentication_controller.go
+++ b/controllers/operator/authentication_controller.go
@@ -803,7 +803,10 @@ func (r *AuthenticationReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	}
 	// create clusterrole and clusterrolebinding
 	r.createClusterRole(instance)
-	r.createClusterRoleBinding(instance)
+
+	if subResult, err := r.handleClusterRoleBinding(reconcileCtx, req); subreconciler.ShouldHaltOrRequeue(subResult, err) {
+		return subreconciler.Evaluate(subResult, err)
+	}
 
 	r.ReconcileRemoveIngresses(ctx, instance, &needToRequeue)
 	// updates redirecturi annotations to serviceaccount

--- a/controllers/operator/clusterrolebinding.go
+++ b/controllers/operator/clusterrolebinding.go
@@ -29,9 +29,8 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-// handleClusterRoleBinding creates the ibm-iam-operand-restricted ClusterRoleBinding that binds the
-// ibm-iam-operand-restricted ClusterRole to the ibm-iam-operand-restricted ServiceAccount in the services namespace for
-// this Authentication instance. If another ClusterRoleBinding already exists,
+// handleClusterRoleBinding creates a ClusterRoleBinding that binds the ibm-iam-operand-restricted ClusterRole to the
+// ibm-iam-operand-restricted ServiceAccount in the services namespace for this Authentication instance.
 func (r *AuthenticationReconciler) handleClusterRoleBinding(ctx context.Context, req ctrl.Request) (result *ctrl.Result, err error) {
 	reqLogger := logf.FromContext(ctx).WithValues("subreconciler", "handleClusterRoleBinding")
 	reqLogger.Info("Ensure that the ClusterRoleBinding is created")

--- a/controllers/operator/clusterrolebinding.go
+++ b/controllers/operator/clusterrolebinding.go
@@ -18,32 +18,52 @@ package operator
 
 import (
 	"context"
+	"fmt"
 
 	operatorv1alpha1 "github.com/IBM/ibm-iam-operator/apis/operator/v1alpha1"
+	"github.com/opdev/subreconciler"
 	rbacv1 "k8s.io/api/rbac/v1"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-func (r *AuthenticationReconciler) createClusterRoleBinding(instance *operatorv1alpha1.Authentication) {
-
-	reqLogger := log.WithValues("Instance.Namespace", instance.Namespace, "Instance.Name", instance.Name)
-	// Define a new ClusterRoleBinding
-	operandCRB := r.iamOperandCRB(instance)
-	reqLogger.Info("Creating ibm-iam-operand-restricted ClusterRoleBinding")
-	err := r.Client.Create(context.TODO(), operandCRB)
-	if err != nil {
-		reqLogger.Info("Failed to create ibm-iam-operand-restricted ClusterRoleBinding or its already present")
+// handleClusterRoleBinding creates the ibm-iam-operand-restricted ClusterRoleBinding that binds the
+// ibm-iam-operand-restricted ClusterRole to the ibm-iam-operand-restricted ServiceAccount in the services namespace for
+// this Authentication instance. If another ClusterRoleBinding already exists,
+func (r *AuthenticationReconciler) handleClusterRoleBinding(ctx context.Context, req ctrl.Request) (result *ctrl.Result, err error) {
+	reqLogger := logf.FromContext(ctx).WithValues("subreconciler", "handleClusterRoleBinding")
+	reqLogger.Info("Ensure that the ClusterRoleBinding is created")
+	authCR := &operatorv1alpha1.Authentication{}
+	if result, err = r.getLatestAuthentication(ctx, req, authCR); subreconciler.ShouldHaltOrRequeue(result, err) {
+		return
 	}
+	name := fmt.Sprintf("ibm-iam-operand-restricted-%s", authCR.Namespace)
 
+	crb := iamOperandCRB(authCR, name)
+
+	reqLogger = reqLogger.WithValues("ClusterRoleBinding.Name", name)
+	if err = r.Create(ctx, crb); k8sErrors.IsAlreadyExists(err) {
+		reqLogger.Info("ClusterRoleBinding already exists, continuing")
+		return subreconciler.ContinueReconciling()
+	} else if err != nil {
+		reqLogger.Error(err, "Failed to create ClusterRoleBinding")
+		return subreconciler.RequeueWithError(err)
+	}
+	reqLogger.Info("Created ClusterRoleBinding successfully")
+	return subreconciler.RequeueWithDelay(defaultLowerWait)
 }
-func (r *AuthenticationReconciler) iamOperandCRB(instance *operatorv1alpha1.Authentication) *rbacv1.ClusterRoleBinding {
 
-	// reqLogger := log.WithValues("Instance.Namespace", instance.Namespace, "Instance.Name", instance.Name)
+func iamOperandCRB(instance *operatorv1alpha1.Authentication, name string) *rbacv1.ClusterRoleBinding {
 	operandCRB := &rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "ibm-iam-operand-restricted",
-			Namespace: instance.Namespace,
-			Labels:    map[string]string{"app.kubernetes.io/instance": "ibm-iam-operator", "app.kubernetes.io/managed-by": "ibm-iam-operator", "app.kubernetes.io/name": "ibm-iam-operator"},
+			Name: name,
+			Labels: map[string]string{
+				"app.kubernetes.io/instance":   "ibm-iam-operator",
+				"app.kubernetes.io/managed-by": "ibm-iam-operator",
+				"app.kubernetes.io/name":       "ibm-iam-operator",
+			},
 		},
 		RoleRef: rbacv1.RoleRef{
 			APIGroup: rbacv1.GroupName,


### PR DESCRIPTION
Originating issue: [PrivateCloud-analytics/CPD-Quality#18726](https://github.ibm.com/PrivateCloud-analytics/CPD-Quality/issues/18726)

* Support multiple IM Operator instances by creating unique ClusterRoleBindings for each Authentication instance.