### PR TITLE
Fetching "uid" of user based on "realm_id" OR "type" column

### DIFF
--- a/migration/schema/v1/tables.go
+++ b/migration/schema/v1/tables.go
@@ -1483,8 +1483,9 @@ func (g *Group) GetArgs() pgx.NamedArgs {
 
 func (m *Member) GetArgs() pgx.NamedArgs {
 	return pgx.NamedArgs{
-		"subject": m.Value,
+		"userId":  m.Value,
 		"realmId": "defaultSP",
+		"type":    "SAML",
 	}
 }
 
@@ -1503,7 +1504,7 @@ func (ug *UserGroup) GetInsertSQL() string {
 	return `
 		INSERT INTO platformdb.users_groups(user_uid, group_uid)
 		VALUES (
-			(SELECT uid from platformdb.users WHERE subject=@subject AND realm_id=@realmId),
+			(SELECT uid from platformdb.users WHERE user_id=@userId AND (realm_id=@realmId OR type=@type)),
 			(SELECT uid from platformdb.groups WHERE group_id=@groupId AND realm_id=@realmId)
 		) ON CONFLICT DO NOTHING;`
 }


### PR DESCRIPTION
Related to issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/62845

Summary of changes:

- Fetching "uid" of user based on "realm_id" OR "type" column for users_groups mapping during migration of scim-jit data