### PR TITLE
63487 add env var AUTHSVC_KUBEDNS_NAME

### DIFF
--- a/controllers/operator/containers.go
+++ b/controllers/operator/containers.go
@@ -866,6 +866,10 @@ func buildIdentityManagerContainer(instance *operatorv1alpha1.Authentication, id
 			Value: "https://platform-identity-provider",
 		},
 		{
+			Name:  "AUTHSVC_KUBEDNS_NAME",
+			Value: "https://platform-auth-service",
+		},
+		{
 			Name:  "IAM_TOKEN_SERVICE_URL",
 			Value: "https://platform-auth-service:9443",
 		},


### PR DESCRIPTION
Adding env variable, AUTHSVC_KUBEDNS_NAME,  in platform-identity-management pod.
https://github.ibm.com/IBMPrivateCloud/roadmap/issues/63487