### PR TITLE
ensure roks_url is correct

### DIFF
--- a/controllers/operator/configmap.go
+++ b/controllers/operator/configmap.go
@@ -374,6 +374,14 @@ func (r *AuthenticationReconciler) handleConfigMap(instance *operatorv1alpha1.Au
 					currentConfigMap.Data["IDENTITY_PROVIDER_URL"] = "https://platform-identity-provider:4300"
 					cmUpdateRequired = true
 				}
+				roksUrl, keyExists := currentConfigMap.Data["ROKS_URL"]
+				if keyExists {
+					desiredRoksUrl, err := readROKSURL(instance)
+					if err == nil && len(desiredRoksUrl) != 0 && roksUrl != desiredRoksUrl {
+						currentConfigMap.Data["ROKS_URL"] = desiredRoksUrl
+						cmUpdateRequired = true
+					}
+				}
 
 				cmUpdateRequired = true
 


### PR DESCRIPTION
post backup and restore, this ensures ROKS_URL in platform-auth-idp configmap is updated with right url incase post backup and restore ROKS_URL holds the old cluster url
Ref: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/62929