### PR TITLE
Remove redundant endpoint - idauth

### DIFF
--- a/bundle/manifests/ibm-iam-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-iam-operator.clusterserviceversion.yaml
@@ -74,7 +74,7 @@ metadata:
               "installType": "fresh",
               "isOpenshiftEnv": true,
               "nonceEnabled": true,
-              "oidcIssuerURL": "https://127.0.0.1:443/idauth/oidc/endpoint/OP",
+              "oidcIssuerURL": "https://127.0.0.1:443/oidc/endpoint/OP",
               "openshiftPort": 443,
               "preferredLogin": "",
               "providerIssuerURL": "",

--- a/config/samples/bases/operator_v1alpha1_authentication.yaml
+++ b/config/samples/bases/operator_v1alpha1_authentication.yaml
@@ -64,7 +64,7 @@ spec:
     claimsMap: name="givenName" family_name="givenName" given_name="givenName" preferred_username="displayName"
       display_name="displayName"
     scopeClaim: profile="name,family_name,display_name,given_name,preferred_username"
-    oidcIssuerURL: https://127.0.0.1:443/idauth/oidc/endpoint/OP
+    oidcIssuerURL: https://127.0.0.1:443/oidc/endpoint/OP
     openshiftPort: 443
     roksEnabled: true
     roksURL: https://roks.domain.name:443

--- a/controllers/operator/constants.go
+++ b/controllers/operator/constants.go
@@ -92,7 +92,7 @@ var registrationJson string = `{
   "introspect_tokens": true,
   "functional_user_groupIds": ["Administrator"],
   "trusted_uri_prefixes": ["https://{{.ICPConsoleURL}}"],
-  "redirect_uris": [{{ range $_, $url := .ICPRegistrationConsoleURIs}}{{printf "%q" $url}}{{", "}}{{end}}"https://127.0.0.1:443/idauth/oidc/endpoint/OP"]
+  "redirect_uris": [{{ range $_, $url := .ICPRegistrationConsoleURIs}}{{printf "%q" $url}}{{", "}}{{end}}"https://127.0.0.1:443/oidc/endpoint/OP"]
 }`
 
 var scimLdapAttributesMapping string = `{

--- a/controllers/operator/ingress.go
+++ b/controllers/operator/ingress.go
@@ -97,7 +97,6 @@ func (r *AuthenticationReconciler) handleIngress(instance *operatorv1alpha1.Auth
 		idmgmtV2ApiIngress,
 		platformAuthIngress,
 		platformIdAuthBlockIngress,
-		platformIdAuthIngress,
 		platformIdProviderIngress,
 		platformLoginIngress,
 		platformOidcBlockIngress,
@@ -372,67 +371,13 @@ func platformIdAuthBlockIngress(instance *operatorv1alpha1.Authentication, schem
 						HTTP: &netv1.HTTPIngressRuleValue{
 							Paths: []netv1.HTTPIngressPath{
 								{
-									Path:     "/idauth/oidc/endpoint",
+									Path:     "/oidc/endpoint",
 									PathType: &pathType,
 									Backend: netv1.IngressBackend{
 										Service: &netv1.IngressServiceBackend{
 											Name: "default-http-backend",
 											Port: netv1.ServiceBackendPort{
 												Number: 80,
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-
-	// Set Authentication instance as the owner and controller of the Ingress
-	err := controllerutil.SetControllerReference(instance, newIngress, scheme)
-	if err != nil {
-		reqLogger.Error(err, "Failed to set owner for Ingress")
-		return nil
-	}
-	return newIngress
-
-}
-
-func platformIdAuthIngress(instance *operatorv1alpha1.Authentication, scheme *runtime.Scheme) *netv1.Ingress {
-	pathType := netv1.PathType("ImplementationSpecific")
-	reqLogger := log.WithValues("Instance.Namespace", instance.Namespace, "Instance.Name", instance.Name)
-	newIngress := &netv1.Ingress{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "platform-id-auth",
-			Namespace: instance.Namespace,
-			Labels:    map[string]string{"app": "platform-auth-service"},
-			Annotations: map[string]string{
-				"kubernetes.io/ingress.class":            "ibm-icp-management",
-				"icp.management.ibm.com/secure-backends": "true",
-				"icp.management.ibm.com/rewrite-target":  "/",
-				"icp.management.ibm.com/configuration-snippet": `
-					add_header 'X-Frame-Options' 'SAMEORIGIN' always;
-					add_header 'X-Content-Type-Options' 'nosniff';
-					`,
-			},
-		},
-		Spec: netv1.IngressSpec{
-			Rules: []netv1.IngressRule{
-				{
-					IngressRuleValue: netv1.IngressRuleValue{
-						HTTP: &netv1.HTTPIngressRuleValue{
-							Paths: []netv1.HTTPIngressPath{
-								{
-									Path:     "/idauth",
-									PathType: &pathType,
-									Backend: netv1.IngressBackend{
-										Service: &netv1.IngressServiceBackend{
-											Name: "platform-auth-service",
-											Port: netv1.ServiceBackendPort{
-												Number: 9443,
 											},
 										},
 									},

--- a/controllers/operator/routes.go
+++ b/controllers/operator/routes.go
@@ -184,18 +184,6 @@ func (r *AuthenticationReconciler) handleRoutes(ctx context.Context, instance *o
 			DestinationCAcert: platformIdentityProviderCert,
 			ServiceName:       PlatformIdentityProviderServiceName,
 		},
-		"platform-id-auth": {
-			Annotations: map[string]string{
-				"haproxy.router.openshift.io/balance":        "source",
-				"haproxy.router.openshift.io/rewrite-target": "/",
-			},
-			Name:              "platform-id-auth",
-			RouteHost:         routeHost,
-			RoutePath:         "/idauth",
-			RoutePort:         9443,
-			DestinationCAcert: platformAuthCert,
-			ServiceName:       PlatformAuthServiceName,
-		},
 		"platform-id-provider": {
 			Annotations: map[string]string{
 				"haproxy.router.openshift.io/rewrite-target": "/",


### PR DESCRIPTION
The redundant endpoint "idauth" used to originally redirect to itself. Thus, seeing an increase in number of security vulnerabilities and observe the need to remove it.
Parent issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/60011

