### PR TITLE
Clear redundant enpoint idauth

### DIFF
--- a/controllers/operator/ingress.go
+++ b/controllers/operator/ingress.go
@@ -34,8 +34,6 @@ var ingressList []string = []string{
 	"id-mgmt",
 	"idmgmt-v2-api",
 	"platform-auth",
-	"platform-id-auth-block",
-	"platform-id-auth",
 	"platform-id-provider",
 	"platform-login",
 	"platform-oidc-block",

--- a/controllers/operator/ingress.go
+++ b/controllers/operator/ingress.go
@@ -96,8 +96,6 @@ func (r *AuthenticationReconciler) handleIngress(instance *operatorv1alpha1.Auth
 		idMgmtIngress,
 		idmgmtV2ApiIngress,
 		platformAuthIngress,
-		platformIdAuthBlockIngress,
-		platformIdAuthIngress,
 		platformIdProviderIngress,
 		platformLoginIngress,
 		platformOidcBlockIngress,
@@ -327,112 +325,6 @@ func platformAuthIngress(instance *operatorv1alpha1.Authentication, scheme *runt
 											Name: "platform-identity-provider",
 											Port: netv1.ServiceBackendPort{
 												Number: 4300,
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-
-	// Set Authentication instance as the owner and controller of the Ingress
-	err := controllerutil.SetControllerReference(instance, newIngress, scheme)
-	if err != nil {
-		reqLogger.Error(err, "Failed to set owner for Ingress")
-		return nil
-	}
-	return newIngress
-
-}
-
-func platformIdAuthBlockIngress(instance *operatorv1alpha1.Authentication, scheme *runtime.Scheme) *netv1.Ingress {
-	pathType := netv1.PathType("ImplementationSpecific")
-	reqLogger := log.WithValues("Instance.Namespace", instance.Namespace, "Instance.Name", instance.Name)
-	newIngress := &netv1.Ingress{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "platform-id-auth-block",
-			Namespace: instance.Namespace,
-			Labels:    map[string]string{"app": "platform-auth-service"},
-			Annotations: map[string]string{
-				"kubernetes.io/ingress.class":              "ibm-icp-management",
-				"icp.management.ibm.com/location-modifier": "=",
-				"icp.management.ibm.com/configuration-snippet": `
-					add_header 'X-XSS-Protection' '1' always;
-					`,
-			},
-		},
-		Spec: netv1.IngressSpec{
-			Rules: []netv1.IngressRule{
-				{
-					IngressRuleValue: netv1.IngressRuleValue{
-						HTTP: &netv1.HTTPIngressRuleValue{
-							Paths: []netv1.HTTPIngressPath{
-								{
-									Path:     "/idauth/oidc/endpoint",
-									PathType: &pathType,
-									Backend: netv1.IngressBackend{
-										Service: &netv1.IngressServiceBackend{
-											Name: "default-http-backend",
-											Port: netv1.ServiceBackendPort{
-												Number: 80,
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-
-	// Set Authentication instance as the owner and controller of the Ingress
-	err := controllerutil.SetControllerReference(instance, newIngress, scheme)
-	if err != nil {
-		reqLogger.Error(err, "Failed to set owner for Ingress")
-		return nil
-	}
-	return newIngress
-
-}
-
-func platformIdAuthIngress(instance *operatorv1alpha1.Authentication, scheme *runtime.Scheme) *netv1.Ingress {
-	pathType := netv1.PathType("ImplementationSpecific")
-	reqLogger := log.WithValues("Instance.Namespace", instance.Namespace, "Instance.Name", instance.Name)
-	newIngress := &netv1.Ingress{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "platform-id-auth",
-			Namespace: instance.Namespace,
-			Labels:    map[string]string{"app": "platform-auth-service"},
-			Annotations: map[string]string{
-				"kubernetes.io/ingress.class":            "ibm-icp-management",
-				"icp.management.ibm.com/secure-backends": "true",
-				"icp.management.ibm.com/rewrite-target":  "/",
-				"icp.management.ibm.com/configuration-snippet": `
-					add_header 'X-Frame-Options' 'SAMEORIGIN' always;
-					add_header 'X-Content-Type-Options' 'nosniff';
-					`,
-			},
-		},
-		Spec: netv1.IngressSpec{
-			Rules: []netv1.IngressRule{
-				{
-					IngressRuleValue: netv1.IngressRuleValue{
-						HTTP: &netv1.HTTPIngressRuleValue{
-							Paths: []netv1.HTTPIngressPath{
-								{
-									Path:     "/idauth",
-									PathType: &pathType,
-									Backend: netv1.IngressBackend{
-										Service: &netv1.IngressServiceBackend{
-											Name: "platform-auth-service",
-											Port: netv1.ServiceBackendPort{
-												Number: 9443,
 											},
 										},
 									},

--- a/controllers/operator/resourcestatus.go
+++ b/controllers/operator/resourcestatus.go
@@ -230,7 +230,6 @@ func (r *AuthenticationReconciler) getCurrentServiceStatus(ctx context.Context, 
 		names: []string{
 			"id-mgmt",
 			"platform-auth",
-			"platform-id-auth",
 			"platform-id-provider",
 			"platform-login",
 			"platform-oidc",

--- a/controllers/operator/routes_test.go
+++ b/controllers/operator/routes_test.go
@@ -751,7 +751,7 @@ var _ = Describe("Route handling", func() {
 			}
 			err := r.List(ctx, routes, listOpts...)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(routes.Items).To(HaveLen(8))
+			Expect(routes.Items).To(HaveLen(7))
 		}
 
 		It("creates all Routes when zenFrontDoor is not enabled", func() {

--- a/controllers/operator/routes_test.go
+++ b/controllers/operator/routes_test.go
@@ -669,7 +669,7 @@ var _ = Describe("Route handling", func() {
 		})
 
 		hasAllValidRoutes := func(routes *routev1.RouteList) {
-			Expect(routes.Items).To(HaveLen(8))
+			Expect(routes.Items).To(HaveLen(7))
 			for _, route := range routes.Items {
 				Expect(route.Spec.Host).To(Equal(clusterInfoConfigMap.Data["cluster_address"]))
 				for k, v := range commonRouteAnnotations {
@@ -688,13 +688,6 @@ var _ = Describe("Route handling", func() {
 					Expect(route.Spec.To.Name).To(Equal(PlatformIdentityProviderServiceName))
 					Expect(route.Spec.TLS.DestinationCACertificate).To(Equal(string(identityProviderSecretSecret.Data["ca.crt"])))
 					Expect(route.Annotations).To(HaveKeyWithValue("haproxy.router.openshift.io/rewrite-target", "/v1/auth/"))
-				case "platform-id-auth":
-					Expect(route.Spec.Path).To(Equal("/idauth"))
-					Expect(route.Spec.Port).To(Equal(&routev1.RoutePort{TargetPort: intstr.FromInt(9443)}))
-					Expect(route.Spec.To.Name).To(Equal(PlatformAuthServiceName))
-					Expect(route.Spec.TLS.DestinationCACertificate).To(Equal(string(platformAuthSecretSecret.Data["ca.crt"])))
-					Expect(route.Annotations).To(HaveKeyWithValue("haproxy.router.openshift.io/balance", "source"))
-					Expect(route.Annotations).To(HaveKeyWithValue("haproxy.router.openshift.io/rewrite-target", "/"))
 				case "platform-id-provider":
 					Expect(route.Spec.Path).To(Equal("/idprovider/"))
 					Expect(route.Spec.Port).To(Equal(&routev1.RoutePort{TargetPort: intstr.FromInt(4300)}))
@@ -735,7 +728,6 @@ var _ = Describe("Route handling", func() {
 			names := []string{
 				"id-mgmt",
 				"platform-auth",
-				"platform-id-auth",
 				"platform-id-provider",
 				"platform-login",
 				"platform-oidc",

--- a/controllers/operator/zenextension.go
+++ b/controllers/operator/zenextension.go
@@ -56,14 +56,6 @@ location /v1/auth/ {
   proxy_pass https://platform-identity-provider.%[1]s.svc:4300;
   proxy_read_timeout 180s;
 }
-location /idauth {
-  proxy_set_header Host $host;
-  proxy_set_header Strict-Transport-Security "max-age=31536000; includeSubDomains";
-  proxy_pass https://platform-auth-service.%[1]s.svc:9443;
-  proxy_read_timeout 180s;
-  rewrite /idauth/(.*) /$1 break;
-  rewrite /idauth / break;
-}
 location /idprovider/ {
   proxy_set_header Host $host;
   proxy_set_header Strict-Transport-Security "max-age=31536000; includeSubDomains";


### PR DESCRIPTION
Issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/61141
Parent issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/60011

The redundant endpoint "\idauth" is not needed as it redirects to the next endpoint in the route. Therefore, causing an increase in number of security issues. 