### PR TITLE
sleep introduce for init container

### DIFF
--- a/controllers/operator/containers.go
+++ b/controllers/operator/containers.go
@@ -37,7 +37,7 @@ func buildInitContainers(initImage string) []corev1.Container {
 			Command: []string{
 				"bash",
 				"-c",
-				"until </dev/tcp/$DATABASE_RW_ENDPOINT/$DATABASE_PORT ; do sleep 5; done;",
+				"until </dev/tcp/$DATABASE_RW_ENDPOINT/$DATABASE_PORT ; do sleep 5; done; sleep 30;",
 			},
 			Env: envVars,
 			SecurityContext: &corev1.SecurityContext{


### PR DESCRIPTION
introduce 30s delay once after init container check the basic TCP probe. This is to ensure add buffer time for liberty to connect with the running EDB instance.