### PR TITLE
Updating go version from 1.21.8 to 1.21.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 #
 
 # Build the manager binary
-FROM golang:1.21.8-bullseye as builder
+FROM golang:1.22.2-bullseye as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 #
 
 # Build the manager binary
-FROM golang:1.22.2-bullseye as builder
+FROM golang:1.21.9-bullseye as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/Makefile
+++ b/Makefile
@@ -163,7 +163,7 @@ ENVTEST ?= $(LOCALBIN)/setup-envtest
 KUSTOMIZE_VERSION ?= v3.8.9
 CONTROLLER_TOOLS_VERSION ?= v0.11.4
 YQ_VERSION ?= v4.40.5
-GO_VERSION ?= 1.22.2
+GO_VERSION ?= 1.21.9
 
 # This pinned version of go has its version pinned to its name, so order of operations is inverted here.
 GO ?= $(LOCALBIN)/go$(GO_VERSION)

--- a/Makefile
+++ b/Makefile
@@ -163,7 +163,7 @@ ENVTEST ?= $(LOCALBIN)/setup-envtest
 KUSTOMIZE_VERSION ?= v3.8.9
 CONTROLLER_TOOLS_VERSION ?= v0.11.4
 YQ_VERSION ?= v4.40.5
-GO_VERSION ?= 1.21.8
+GO_VERSION ?= 1.22.2
 
 # This pinned version of go has its version pinned to its name, so order of operations is inverted here.
 GO ?= $(LOCALBIN)/go$(GO_VERSION)


### PR DESCRIPTION
Addressing Issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/64328