### PR TITLE
[SC2] Remove idauth route

### DIFF
--- a/controllers/operator/ingress.go
+++ b/controllers/operator/ingress.go
@@ -34,8 +34,6 @@ var ingressList []string = []string{
 	"id-mgmt",
 	"idmgmt-v2-api",
 	"platform-auth",
-	"platform-id-auth-block",
-	"platform-id-auth",
 	"platform-id-provider",
 	"platform-login",
 	"platform-oidc-block",
@@ -96,8 +94,6 @@ func (r *AuthenticationReconciler) handleIngress(instance *operatorv1alpha1.Auth
 		idMgmtIngress,
 		idmgmtV2ApiIngress,
 		platformAuthIngress,
-		platformIdAuthBlockIngress,
-		platformIdAuthIngress,
 		platformIdProviderIngress,
 		platformLoginIngress,
 		platformOidcBlockIngress,
@@ -327,112 +323,6 @@ func platformAuthIngress(instance *operatorv1alpha1.Authentication, scheme *runt
 											Name: "platform-identity-provider",
 											Port: netv1.ServiceBackendPort{
 												Number: 4300,
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-
-	// Set Authentication instance as the owner and controller of the Ingress
-	err := controllerutil.SetControllerReference(instance, newIngress, scheme)
-	if err != nil {
-		reqLogger.Error(err, "Failed to set owner for Ingress")
-		return nil
-	}
-	return newIngress
-
-}
-
-func platformIdAuthBlockIngress(instance *operatorv1alpha1.Authentication, scheme *runtime.Scheme) *netv1.Ingress {
-	pathType := netv1.PathType("ImplementationSpecific")
-	reqLogger := log.WithValues("Instance.Namespace", instance.Namespace, "Instance.Name", instance.Name)
-	newIngress := &netv1.Ingress{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "platform-id-auth-block",
-			Namespace: instance.Namespace,
-			Labels:    map[string]string{"app": "platform-auth-service"},
-			Annotations: map[string]string{
-				"kubernetes.io/ingress.class":              "ibm-icp-management",
-				"icp.management.ibm.com/location-modifier": "=",
-				"icp.management.ibm.com/configuration-snippet": `
-					add_header 'X-XSS-Protection' '1' always;
-					`,
-			},
-		},
-		Spec: netv1.IngressSpec{
-			Rules: []netv1.IngressRule{
-				{
-					IngressRuleValue: netv1.IngressRuleValue{
-						HTTP: &netv1.HTTPIngressRuleValue{
-							Paths: []netv1.HTTPIngressPath{
-								{
-									Path:     "/idauth/oidc/endpoint",
-									PathType: &pathType,
-									Backend: netv1.IngressBackend{
-										Service: &netv1.IngressServiceBackend{
-											Name: "default-http-backend",
-											Port: netv1.ServiceBackendPort{
-												Number: 80,
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-
-	// Set Authentication instance as the owner and controller of the Ingress
-	err := controllerutil.SetControllerReference(instance, newIngress, scheme)
-	if err != nil {
-		reqLogger.Error(err, "Failed to set owner for Ingress")
-		return nil
-	}
-	return newIngress
-
-}
-
-func platformIdAuthIngress(instance *operatorv1alpha1.Authentication, scheme *runtime.Scheme) *netv1.Ingress {
-	pathType := netv1.PathType("ImplementationSpecific")
-	reqLogger := log.WithValues("Instance.Namespace", instance.Namespace, "Instance.Name", instance.Name)
-	newIngress := &netv1.Ingress{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "platform-id-auth",
-			Namespace: instance.Namespace,
-			Labels:    map[string]string{"app": "platform-auth-service"},
-			Annotations: map[string]string{
-				"kubernetes.io/ingress.class":            "ibm-icp-management",
-				"icp.management.ibm.com/secure-backends": "true",
-				"icp.management.ibm.com/rewrite-target":  "/",
-				"icp.management.ibm.com/configuration-snippet": `
-					add_header 'X-Frame-Options' 'SAMEORIGIN' always;
-					add_header 'X-Content-Type-Options' 'nosniff';
-					`,
-			},
-		},
-		Spec: netv1.IngressSpec{
-			Rules: []netv1.IngressRule{
-				{
-					IngressRuleValue: netv1.IngressRuleValue{
-						HTTP: &netv1.HTTPIngressRuleValue{
-							Paths: []netv1.HTTPIngressPath{
-								{
-									Path:     "/idauth",
-									PathType: &pathType,
-									Backend: netv1.IngressBackend{
-										Service: &netv1.IngressServiceBackend{
-											Name: "platform-auth-service",
-											Port: netv1.ServiceBackendPort{
-												Number: 9443,
 											},
 										},
 									},

--- a/controllers/operator/resourcestatus.go
+++ b/controllers/operator/resourcestatus.go
@@ -230,7 +230,6 @@ func (r *AuthenticationReconciler) getCurrentServiceStatus(ctx context.Context, 
 		names: []string{
 			"id-mgmt",
 			"platform-auth",
-			"platform-id-auth",
 			"platform-id-provider",
 			"platform-login",
 			"platform-oidc",

--- a/controllers/operator/routes.go
+++ b/controllers/operator/routes.go
@@ -294,6 +294,10 @@ func (r *AuthenticationReconciler) reconcileRoute(ctx context.Context, instance 
 	reqLogger.Info("Reconciling route", "annotations", fields.Annotations, "routeHost", fields.RouteHost, "routePath", fields.RoutePath)
 
 	err = r.removeIdauth(ctx, instance)
+	if err != nil {
+		reqLogger.Error(err, "Error deleting platform-id-auth Route")
+		return
+	}
 
 	calculatedRoute, err := r.newRoute(instance, fields)
 	if err != nil {

--- a/controllers/operator/routes.go
+++ b/controllers/operator/routes.go
@@ -21,13 +21,17 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/opdev/subreconciler"
 	routev1 "github.com/openshift/api/route/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	operatorv1alpha1 "github.com/IBM/ibm-iam-operator/apis/operator/v1alpha1"
 	"github.com/IBM/ibm-iam-operator/controllers/common"
@@ -184,18 +188,6 @@ func (r *AuthenticationReconciler) handleRoutes(ctx context.Context, instance *o
 			DestinationCAcert: platformIdentityProviderCert,
 			ServiceName:       PlatformIdentityProviderServiceName,
 		},
-		"platform-id-auth": {
-			Annotations: map[string]string{
-				"haproxy.router.openshift.io/balance":        "source",
-				"haproxy.router.openshift.io/rewrite-target": "/",
-			},
-			Name:              "platform-id-auth",
-			RouteHost:         routeHost,
-			RoutePath:         "/idauth",
-			RoutePort:         9443,
-			DestinationCAcert: platformAuthCert,
-			ServiceName:       PlatformAuthServiceName,
-		},
 		"platform-id-provider": {
 			Annotations: map[string]string{
 				"haproxy.router.openshift.io/rewrite-target": "/",
@@ -277,12 +269,35 @@ func (r *AuthenticationReconciler) handleRoutes(ctx context.Context, instance *o
 	return
 }
 
+
+func (r *AuthenticationReconciler) removeIdauth(ctx context.Context, authCR *operatorv1alpha1.Authentication) (result *ctrl.Result, err error) {
+	reqLogger := logf.FromContext(ctx)
+	reqLogger.Info("Determined platform-id-auth Route should not exist; removing if present")
+	observedRoute := &routev1.Route{}
+	err = r.Get(ctx, types.NamespacedName{Name: "platform-id-auth", Namespace: authCR.Namespace}, observedRoute)
+	if k8sErrors.IsNotFound(err) {
+		return subreconciler.ContinueReconciling()
+	} else if err != nil {
+		reqLogger.Error(err, "Failed to get existing platform-id-auth route for reconciliation")
+		return subreconciler.RequeueWithError(err)
+	}
+	err = r.Delete(ctx, observedRoute)
+	if err != nil {
+		reqLogger.Error(err, "Failed to delete platform-id-auth Route")
+		return subreconciler.RequeueWithError(err)
+	}
+	reqLogger.Info("Successfully deleted platform-id-auth Route")
+	return subreconciler.RequeueWithDelay(defaultLowerWait)
+}
+
 func (r *AuthenticationReconciler) reconcileRoute(ctx context.Context, instance *operatorv1alpha1.Authentication, fields *reconcileRouteFields, needToRequeue *bool) (err error) {
 
 	namespace := instance.Namespace
 	reqLogger := log.WithValues("func", "ReconcileRoute", "name", fields.Name, "namespace", namespace)
 
 	reqLogger.Info("Reconciling route", "annotations", fields.Annotations, "routeHost", fields.RouteHost, "routePath", fields.RoutePath)
+
+	result, err := r.removeIdauth(ctx, instance)
 
 	calculatedRoute, err := r.newRoute(instance, fields)
 	if err != nil {


### PR DESCRIPTION
Issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/61141
Parent issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/60011

The redundant endpoint "\idauth" is not needed as it redirects to the next endpoint in the route. Therefore, causing an increase in number of security issues. 