### PR TITLE
Skip migrating broken Zen documents

### DIFF
--- a/apis/operator/v1alpha1/authentication_types.go
+++ b/apis/operator/v1alpha1/authentication_types.go
@@ -296,3 +296,7 @@ func (a *Authentication) HasDBSchemaVersion() bool {
 func (a *Authentication) HasNoDBSchemaVersion() bool {
 	return !a.HasDBSchemaVersion()
 }
+
+func (a *Authentication) IsReady() bool {
+	return a.Status.Service.Status == "Ready"
+}

--- a/controllers/common/utils.go
+++ b/controllers/common/utils.go
@@ -213,12 +213,12 @@ func GetOperatorNamespace() (string, error) {
 
 // End k8sutil "ports"
 
-// GetServicesNamespace finds the namespace that contains the shared services by listing all Authentications in all
-// namespaces where the Operator has visibility. There should only ever be one Authentication CR for a given IM Operator
-// instance, so wherever that one Authentication CR is found is assumed to be where the other Operands are. If no or
-// more than one Authentication CR is found, an error is reported as this is an unsupported usage of the CR.
-func GetServicesNamespace(ctx context.Context, k8sClient *client.Client) (namespace string, err error) {
-	reqLogger := logf.FromContext(ctx)
+// GetAuthentication finds the Authentication for this install of the Cloud Pak Foundational Services. It does this by
+// listing all Authentications in all namespaces where the Operator has visibility. There should only ever be one
+// Authentication CR for a given IM Operator instance, so wherever that one Authentication CR is found is assumed to be
+// where the other Operands are. If no or more than one Authentication CR is found, an error is reported as this is an
+// unsupported usage of the CR.
+func GetAuthentication(ctx context.Context, k8sClient *client.Client) (authCR *operatorv1alpha1.Authentication, err error) {
 	authenticationList := &operatorv1alpha1.AuthenticationList{}
 	err = (*k8sClient).List(ctx, authenticationList)
 	if err != nil {
@@ -226,15 +226,19 @@ func GetServicesNamespace(ctx context.Context, k8sClient *client.Client) (namesp
 	}
 	if len(authenticationList.Items) != 1 {
 		err = fmt.Errorf("expected to find 1 Authentication but found %d", len(authenticationList.Items))
-		var namespacedNames []types.NamespacedName
-		for _, item := range authenticationList.Items {
-			nsn := types.NamespacedName{Name: item.Name, Namespace: item.Namespace}
-			namespacedNames = append(namespacedNames, nsn)
-		}
-		reqLogger.Error(err, "Error encountered while trying to determine shared services namespace", "AuthenticationList", namespacedNames)
 		return
 	}
-	return authenticationList.Items[0].Namespace, nil
+	return &authenticationList.Items[0], nil
+}
+
+// GetServicesNamespace finds the namespace that contains the shared services deriving from the Authentication CR for
+// this IM install. Returns an error when
+func GetServicesNamespace(ctx context.Context, k8sClient *client.Client) (namespace string, err error) {
+	authCR, err := GetAuthentication(ctx, k8sClient)
+	if err != nil {
+		return
+	}
+	return authCR.Namespace, nil
 }
 
 func MergeMap(in map[string]string, mergeMap map[string]string) map[string]string {

--- a/controllers/operator/routes.go
+++ b/controllers/operator/routes.go
@@ -275,7 +275,7 @@ func (r *AuthenticationReconciler) removeIdauth(ctx context.Context, instance *o
 		return
 	} else if err != nil {
 		reqLogger.Error(err, "Failed to get existing platform-id-auth route for reconciliation")
-		return 
+		return
 	}
 	err = r.Delete(ctx, observedRoute)
 	if err != nil {
@@ -283,7 +283,7 @@ func (r *AuthenticationReconciler) removeIdauth(ctx context.Context, instance *o
 		return
 	}
 	reqLogger.Info("Successfully deleted platform-id-auth Route")
-	return 
+	return
 }
 
 func (r *AuthenticationReconciler) reconcileRoute(ctx context.Context, instance *operatorv1alpha1.Authentication, fields *reconcileRouteFields, needToRequeue *bool) (err error) {


### PR DESCRIPTION
Originating issue: [IBMPrivateCloud/roadmap#64896](https://github.ibm.com/IBMPrivateCloud/roadmap/issues/64896)

When ZenInstance documents are broken, e.g. the OIDC clients referred to by them no longer exist, they break migration. Whenever this happens, instead skip these documents as well as ZenInstanceUser documents that refer to the skipped ZenInstance.

Additionally, introduce a subreconciler to the Client controller to wait for the Authentication CR to become ready before attempting to manage OIDC client registrations.