### PR TITLE
Ensure MigrationsPerformed is True when done migrating

### DIFF
--- a/controllers/operator/authentication_controller.go
+++ b/controllers/operator/authentication_controller.go
@@ -45,6 +45,7 @@ import (
 
 	operatorv1alpha1 "github.com/IBM/ibm-iam-operator/apis/operator/v1alpha1"
 	"github.com/opdev/subreconciler"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -338,6 +339,32 @@ func (r *AuthenticationReconciler) getMongoDB(ctx context.Context, req ctrl.Requ
 			secrets[mongoCACertName].Data["ca.crt"],
 			secrets[mongoClientCertName].Data["tls.crt"],
 			secrets[mongoClientCertName].Data["tls.key"]))
+}
+
+func (r *AuthenticationReconciler) setMigrationCompleteStatus(ctx context.Context, req ctrl.Request) (result *ctrl.Result, err error) {
+	reqLogger := logf.FromContext(ctx).WithValues("subreconciler", "setMigrationCompleteStatus")
+	reqLogger.Info("Set the migration success condition if it is not already set")
+	authCR := &operatorv1alpha1.Authentication{}
+	if result, err = r.getLatestAuthentication(ctx, req, authCR); subreconciler.ShouldHaltOrRequeue(result, err) {
+		return
+	}
+	if meta.IsStatusConditionPresentAndEqual(authCR.Status.Conditions, operatorv1alpha1.ConditionMigrated, metav1.ConditionTrue) {
+		reqLogger.Info("Migration success condition has already been set; continuing")
+		return subreconciler.ContinueReconciling()
+	}
+	if authCR.HasNotBeenMigrated() {
+		reqLogger.Info("Authentication still has pending migrations; requeueing")
+		return subreconciler.RequeueWithDelay(defaultLowerWait)
+	}
+	condition := operatorv1alpha1.NewMigrationSuccessCondition()
+	meta.SetStatusCondition(&authCR.Status.Conditions, *condition)
+	if err = r.Client.Status().Update(ctx, authCR); err != nil {
+		reqLogger.Info("Failed to set migration success condition on Authentication", "reason", err.Error())
+	} else {
+		reqLogger.Info("Set migration success condition on Authentication", "reason", err.Error())
+	}
+
+	return subreconciler.RequeueWithDelay(defaultLowerWait)
 }
 
 func (r *AuthenticationReconciler) handleMigrations(ctx context.Context, req ctrl.Request) (result *ctrl.Result, err error) {
@@ -898,6 +925,10 @@ func (r *AuthenticationReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 
 	// perform any migrations that may be needed before Deployments run
 	if subResult, err := r.handleMigrations(reconcileCtx, req); subreconciler.ShouldHaltOrRequeue(subResult, err) {
+		return subreconciler.Evaluate(subResult, err)
+	}
+
+	if subResult, err := r.setMigrationCompleteStatus(reconcileCtx, req); subreconciler.ShouldHaltOrRequeue(subResult, err) {
 		return subreconciler.Evaluate(subResult, err)
 	}
 


### PR DESCRIPTION
Originating issue: [IBMPrivateCloud/roadmap#64955](https://github.ibm.com/IBMPrivateCloud/roadmap/issues/64955)

When attempting to override whether the migration should be considered complete or not, e.g. setting `"authentication.operator.ibm.com/migration-complete"` to `"true"` when some migration failure has resulted in some non-essential data never reaching EDB, it could get the Authentication stuck in an InProgress state.

This adds a subreconciler that ensures that, upon exiting the migration subreconciler, the Authentication CR always has the MigrationsPerformed condition set to True.