### PR TITLE
[CD] Enable Client controller watch of Client Secrets

### DIFF
--- a/controllers/oidc.security/client_controller.go
+++ b/controllers/oidc.security/client_controller.go
@@ -826,5 +826,6 @@ func (r *ClientReconciler) removeAnnotationFromSA(ctx context.Context, req ctrl.
 func (r *ClientReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&oidcsecurityv1.Client{}).
+		Owns(&corev1.Secret{}).
 		Complete(r)
 }

--- a/controllers/oidc.security/clientreg.go
+++ b/controllers/oidc.security/clientreg.go
@@ -63,15 +63,6 @@ type OidcClientResponse struct {
 	AllowRegexpRedirects    bool     `json:"allow_regexp_redirects"`
 }
 
-// ZenInstance represents the zen instance model (response from post, get)
-type ZenInstance struct {
-	ClientID       string `json:"clientId"`
-	InstanceId     string `json:"instanceId"`
-	ProductNameUrl string `json:"productNameUrl"`
-	Namespace      string `json:"namespace"`
-	ZenAuditUrl    string `json:"zenAuditUrl"`
-}
-
 // CreateClientRegistration registers a new OIDC Client on the OP using information provided in the provided Client CR;
 // it does so via a call to the IM Identity Provider service.
 func (r *ClientReconciler) createClientRegistration(ctx context.Context, client *oidcsecurityv1.Client, config *AuthenticationConfig) (response *http.Response, err error) {
@@ -203,7 +194,10 @@ func (r *ClientReconciler) invokeClientRegistrationAPI(ctx context.Context, clie
 		return
 	}
 
-	request, _ := http.NewRequest(requestType, requestURL, bytes.NewBuffer([]byte(payload)))
+	request, err := http.NewRequest(requestType, requestURL, bytes.NewBuffer([]byte(payload)))
+	if err != nil {
+		return
+	}
 	request.Header.Set("Content-Type", "application/json")
 	request.SetBasicAuth(oauthAdmin, clientRegistrationSecret)
 

--- a/controllers/oidc.security/zen_registration.go
+++ b/controllers/oidc.security/zen_registration.go
@@ -27,6 +27,15 @@ import (
 	oidcsecurityv1 "github.com/IBM/ibm-iam-operator/apis/oidc.security/v1"
 )
 
+// ZenInstance represents the zen instance model (response from post, get)
+type ZenInstance struct {
+	ClientID       string `json:"clientId"`
+	InstanceId     string `json:"instanceId"`
+	ProductNameUrl string `json:"productNameUrl"`
+	Namespace      string `json:"namespace"`
+	ZenAuditUrl    string `json:"zenAuditUrl"`
+}
+
 // getZenInstanceRegistration gets the requested Zen instance registration using the ID Management API.
 func (r *ClientReconciler) getZenInstanceRegistration(ctx context.Context, clientCR *oidcsecurityv1.Client, config *AuthenticationConfig) (zenInstance *ZenInstance, err error) {
 	//reqLogger := logf.FromContext(ctx).WithName("GetZenInstance")


### PR DESCRIPTION
Originating issue: [IBMPrivateCloud/roadmap#65093](https://github.ibm.com/IBMPrivateCloud/roadmap/issues/65093)

After the Operator SDK upgrade, watching the Client-owned Secrets was no longer enabled. This adds that behavior back in.

Additionally:

* Use common target for building platform images
* Add missing error handling