### PR TITLE
[SC2] Enable Client controller watch of Client Secrets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,7 +180,7 @@ ifeq (,$(shell which go 2>/dev/null))
 		exit 1; \
 	}
 endif
-	test -s $(LOCALBIN)/go$(GO_VERSION) && $(LOCALBIN)/go$(GO_VERSION) version | grep -q $(GO_VERSION) || \
+	@test -s $(LOCALBIN)/go$(GO_VERSION) && $(LOCALBIN)/go$(GO_VERSION) version | grep -q $(GO_VERSION) || \
 	GOSUMDB=sum.golang.org GOBIN=$(LOCALBIN) go install golang.org/dl/go$(GO_VERSION)@latest && $(LOCALBIN)/go$(GO_VERSION) download
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
@@ -326,28 +326,35 @@ catalog-build: opm ## Build a catalog image.
 bundle-build: ## Build the bundle image.
 	docker build -f $(BUNDLE_DOCKERFILE) -t $(BUNDLE_IMG) .
 
-build-image-amd64: $(GO) $(CONFIG_DOCKER_TARGET) licenses-dir ## Build the Operator for Linux on amd64.
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GO) build -a -o build/_output/bin/manager main.go
-	DOCKER_BUILDKIT=1 DOCKER_DEFAULT_PLATFORM=linux/amd64 $(CONTAINER_CLI) build ${IMAGE_BUILD_OPTS} -t $(REGISTRY)/$(IMG)-amd64:$(GIT_COMMIT_ID) -f ./Dockerfile .
-	$(CONTAINER_CLI) inspect $(REGISTRY)/$(IMG)-amd64:$(GIT_COMMIT_ID)
-	@rm -f build/_output/bin/manager
-	@if [ $(BUILD_LOCALLY) -ne 1 ]; then $(CONTAINER_CLI) push $(REGISTRY)/$(IMG)-amd64:$(GIT_COMMIT_ID); fi
+TARGET_ARCH=$(LOCAL_ARCH)
 
-build-image-ppc64le: $(GO) $(CONFIG_DOCKER_TARGET) licenses-dir ## Build the Operator for Linux on ppc64le.
-	CGO_ENABLED=0 GOOS=linux GOARCH=ppc64le $(GO) build -a -o build/_output/bin/manager main.go
-	DOCKER_BUILDKIT=1 DOCKER_DEFAULT_PLATFORM=linux/ppc64le $(CONTAINER_CLI) build ${IMAGE_BUILD_OPTS} -t $(REGISTRY)/$(IMG)-ppc64le:$(GIT_COMMIT_ID) -f ./Dockerfile .
-	$(CONTAINER_CLI) inspect $(REGISTRY)/$(IMG)-ppc64le:$(GIT_COMMIT_ID)
-	@\rm -f build/_output/bin/manager
-	@if [ $(BUILD_LOCALLY) -ne 1 ]; then $(CONTAINER_CLI) push $(REGISTRY)/$(IMG)-ppc64le:$(GIT_COMMIT_ID); fi
+build-image: $(GO) $(CONFIG_DOCKER_TARGET) licenses-dir ## Build the Operator manager image
+	@echo "Building manager binary for linux/$(TARGET_ARCH)"
+	@CGO_ENABLED=0 GOOS=linux GOARCH=$(TARGET_ARCH) $(GO) build -a -o build/_output/bin/manager main.go
+	@echo "Building manager image for linux/$(TARGET_ARCH)"
+	@DOCKER_BUILDKIT=1 $(CONTAINER_CLI) build --platform=linux/$(TARGET_ARCH) ${IMAGE_BUILD_OPTS} -t $(REGISTRY)/$(IMG)-$(TARGET_ARCH):$(GIT_COMMIT_ID) -f ./Dockerfile .
+	@echo "Inspect built image $(REGISTRY)/$(IMG)-$(TARGET_ARCH):$(GIT_COMMIT_ID)"
+	$(CONTAINER_CLI) inspect $(REGISTRY)/$(IMG)-$(TARGET_ARCH):$(GIT_COMMIT_ID)
+	@echo "Clean up binary"
+	@if [ $(BUILD_LOCALLY) -ne 1 ]; then \
+		echo "Pushing $(REGISTRY)/$(IMG)-$(TARGET_ARCH):$(GIT_COMMIT_ID)"; \
+		$(CONTAINER_CLI) push $(REGISTRY)/$(IMG)-$(TARGET_ARCH):$(GIT_COMMIT_ID); \
+		echo "Done"; \
+	fi
 
-build-image-s390x: $(GO) $(CONFIG_DOCKER_TARGET) licenses-dir ## Build the Operator for Linux on s390x.
-	CGO_ENABLED=0 GOOS=linux GOARCH=s390x $(GO) build -a -o build/_output/bin/manager main.go
-	DOCKER_BUILDKIT=1 DOCKER_DEFAULT_PLATFORM=linux/s390x $(CONTAINER_CLI) build ${IMAGE_BUILD_OPTS} -t $(REGISTRY)/$(IMG)-s390x:$(GIT_COMMIT_ID) -f ./Dockerfile .
-	$(CONTAINER_CLI) inspect $(REGISTRY)/$(IMG)-s390x:$(GIT_COMMIT_ID)
-	@rm -f build/_output/bin/manager
-	@if [ $(BUILD_LOCALLY) -ne 1 ]; then $(CONTAINER_CLI) push $(REGISTRY)/$(IMG)-s390x:$(GIT_COMMIT_ID); fi
+build-image-amd64: TARGET_ARCH=amd64
+build-image-amd64: build-image
 
-images: $(CONFIG_DOCKER_TARGET) build-image-amd64 build-image-ppc64le build-image-s390x ## Build the multi-arch manifest.
+build-image-ppc64le: TARGET_ARCH=ppc64le
+build-image-ppc64le: build-image
+
+build-image-s390x: TARGET_ARCH=s390x
+build-image-s390x: build-image
+
+images: $(CONFIG_DOCKER_TARGET)  ## Build the multi-arch manifest.
+	@${MAKE} build-image-amd64
+	@${MAKE} build-image-ppc64le
+	@${MAKE} build-image-s390x
 	@DOCKER_BUILDKIT=1 MAX_PULLING_RETRY=20 RETRY_INTERVAL=30 common/scripts/multiarch_image.sh $(REGISTRY) $(IMG) $(GIT_COMMIT_ID) $(VERSION)
 
 ##@ Deployment
@@ -374,15 +381,6 @@ deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
 	- oc delete -f config/samples/bases/operator_v1alpha1_authentication.yaml -n ${NAMESPACE}
 	$(KUSTOMIZE) build config/default | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
-
-build-image: build ## Build image using local architecture.
-	@echo "Building ibm-iam-operator dev image for $(LOCAL_ARCH)"
-	$(CONTAINER_CLI) build ${IMAGE_BUILD_OPTS} -t $(REGISTRY)/$(IMG)-$(LOCAL_ARCH):$(VERSION) -f Dockerfile .
-	@if [ $(BUILD_LOCALLY) -ne 1 ]; then $(CONTAINER_CLI) push $(REGISTRY)/$(IMG)-$(LOCAL_ARCH):$(GIT_COMMIT_ID); fi
-
-.PHONY: bundle-push
-bundle-push: ## Push the bundle image.
-	$(MAKE) docker-push IMG=$(BUNDLE_IMG)
 
 # A comma-separated list of bundle images (e.g. make catalog-build BUNDLE_IMGS=example.com/operator-bundle:v0.1.0,example.com/operator-bundle:v0.2.0).
 # These images MUST exist in a registry and be pull-able.

--- a/controllers/oidc.security/client_controller.go
+++ b/controllers/oidc.security/client_controller.go
@@ -853,5 +853,6 @@ func (r *ClientReconciler) removeAnnotationFromSA(ctx context.Context, req ctrl.
 func (r *ClientReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&oidcsecurityv1.Client{}).
+		Owns(&corev1.Secret{}).
 		Complete(r)
 }

--- a/controllers/oidc.security/clientreg.go
+++ b/controllers/oidc.security/clientreg.go
@@ -63,15 +63,6 @@ type OidcClientResponse struct {
 	AllowRegexpRedirects    bool     `json:"allow_regexp_redirects"`
 }
 
-// ZenInstance represents the zen instance model (response from post, get)
-type ZenInstance struct {
-	ClientID       string `json:"clientId"`
-	InstanceId     string `json:"instanceId"`
-	ProductNameUrl string `json:"productNameUrl"`
-	Namespace      string `json:"namespace"`
-	ZenAuditUrl    string `json:"zenAuditUrl"`
-}
-
 // CreateClientRegistration registers a new OIDC Client on the OP using information provided in the provided Client CR;
 // it does so via a call to the IM Identity Provider service.
 func (r *ClientReconciler) createClientRegistration(ctx context.Context, client *oidcsecurityv1.Client, config *AuthenticationConfig) (response *http.Response, err error) {
@@ -203,7 +194,10 @@ func (r *ClientReconciler) invokeClientRegistrationAPI(ctx context.Context, clie
 		return
 	}
 
-	request, _ := http.NewRequest(requestType, requestURL, bytes.NewBuffer([]byte(payload)))
+	request, err := http.NewRequest(requestType, requestURL, bytes.NewBuffer([]byte(payload)))
+	if err != nil {
+		return
+	}
 	request.Header.Set("Content-Type", "application/json")
 	request.SetBasicAuth(oauthAdmin, clientRegistrationSecret)
 

--- a/controllers/oidc.security/zen_registration.go
+++ b/controllers/oidc.security/zen_registration.go
@@ -27,6 +27,15 @@ import (
 	oidcsecurityv1 "github.com/IBM/ibm-iam-operator/apis/oidc.security/v1"
 )
 
+// ZenInstance represents the zen instance model (response from post, get)
+type ZenInstance struct {
+	ClientID       string `json:"clientId"`
+	InstanceId     string `json:"instanceId"`
+	ProductNameUrl string `json:"productNameUrl"`
+	Namespace      string `json:"namespace"`
+	ZenAuditUrl    string `json:"zenAuditUrl"`
+}
+
 // getZenInstanceRegistration gets the requested Zen instance registration using the ID Management API.
 func (r *ClientReconciler) getZenInstanceRegistration(ctx context.Context, clientCR *oidcsecurityv1.Client, config *AuthenticationConfig) (zenInstance *ZenInstance, err error) {
 	//reqLogger := logf.FromContext(ctx).WithName("GetZenInstance")


### PR DESCRIPTION
Originating issue: [IBMPrivateCloud/roadmap#65093](https://github.ibm.com/IBMPrivateCloud/roadmap/issues/65093)

After the Operator SDK upgrade, watching the Client-owned Secrets was no longer enabled. This adds that behavior back in.

Additionally:

* Use common target for building platform images
* Add missing error handling

Signed-off-by: Rob Hundley <rwhundle@us.ibm.com>
(cherry picked from commit 7eace55e678a5825fe71b93c389de876c51bf974)