### PR TITLE
Reconcile Routes and ZenExtension later

### DIFF
--- a/controllers/operator/authentication_controller.go
+++ b/controllers/operator/authentication_controller.go
@@ -826,14 +826,6 @@ func (r *AuthenticationReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	// updates redirecturi annotations to serviceaccount
 	r.handleServiceAccount(instance, &needToRequeue)
 
-	if result, err := r.handleZenExtension(reconcileCtx, req); subreconciler.ShouldHaltOrRequeue(result, err) {
-		return subreconciler.Evaluate(result, err)
-	}
-
-	if subResult, err := r.handleRoutes(ctx, req); subreconciler.ShouldHaltOrRequeue(subResult, err) {
-		return subreconciler.Evaluate(subResult, err)
-	}
-
 	if subResult, err := r.ensureDatastoreSecretAndCM(reconcileCtx, req); subreconciler.ShouldHaltOrRequeue(subResult, err) {
 		return subreconciler.Evaluate(subResult, err)
 	}
@@ -867,6 +859,14 @@ func (r *AuthenticationReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		if err != nil {
 			return
 		}
+	}
+
+	if result, err := r.handleZenExtension(reconcileCtx, req); subreconciler.ShouldHaltOrRequeue(result, err) {
+		return subreconciler.Evaluate(result, err)
+	}
+
+	if subResult, err := r.handleRoutes(ctx, req); subreconciler.ShouldHaltOrRequeue(subResult, err) {
+		return subreconciler.Evaluate(subResult, err)
 	}
 
 	return


### PR DESCRIPTION
Originating issue: [PrivateCloud-analytics/Zen#39543](https://github.ibm.com/PrivateCloud-analytics/Zen/issues/39543)

If Zen and IM were installed on the cluster at the same time, and the Zen front door was enabled on the Authentication CR, this would lead to IM waiting for the ZenExtension resource to be reconciled without standing up its Operands for Zen to register OIDC clients with.

This changes the order in which objects are reconciled so that Zen will be able to communicate with IM's Operands and create those OIDC clients, which will in turn allow the Zen Operator to handle the ZenExtensions that IM needs in order to expose its Operands to ingress traffic.