### PR TITLE
Always update ROKS_URL in platform-auth-idp

### DIFF
--- a/apis/operator/v1alpha1/authentication_types.go
+++ b/apis/operator/v1alpha1/authentication_types.go
@@ -137,7 +137,7 @@ type ConfigSpec struct {
 	NONCEEnabled                bool   `json:"nonceEnabled"`
 	XFrameDomain                string `json:"xframeDomain,omitempty"`
 	PreferredLogin              string `json:"preferredLogin,omitempty"`
-	DefaultLogin              string `json:"defaultLogin,omitempty"`
+	DefaultLogin                string `json:"defaultLogin,omitempty"`
 	ROKSURL                     string `json:"roksURL"`
 	ROKSUserPrefix              string `json:"roksUserPrefix"`
 	EnableImpersonation         bool   `json:"enableImpersonation"`

--- a/controllers/common/constants.go
+++ b/controllers/common/constants.go
@@ -19,6 +19,9 @@ package common
 const GlobalConfigMapName string = "ibm-cpp-config"
 const CommonServiceName string = "common-service"
 
+// Name of ConfigMap that configures IBM Cloud cluster information
+const IBMCloudClusterInfoCMName string = "ibmcloud-cluster-info"
+
 // Name of ConfigMap that configures external or embedded EDB for IM
 const DatastoreEDBCMName string = "im-datastore-edb-cm"
 

--- a/controllers/operator/authentication_controller.go
+++ b/controllers/operator/authentication_controller.go
@@ -802,11 +802,8 @@ func (r *AuthenticationReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		return
 	}
 
-	//Check if this ConfigMap already exists and create it if it doesn't
-	currentConfigMap := &corev1.ConfigMap{}
-	err = r.handleConfigMap(instance, wlpClientID, wlpClientSecret, currentConfigMap, &needToRequeue)
-	if err != nil {
-		return
+	if subResult, err := r.handleConfigMaps(ctx, req); subreconciler.ShouldHaltOrRequeue(subResult, err) {
+		return subreconciler.Evaluate(subResult, err)
 	}
 
 	// Check if this Job already exists and create it if it doesn't

--- a/controllers/operator/configmap.go
+++ b/controllers/operator/configmap.go
@@ -23,7 +23,6 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"reflect"
@@ -32,457 +31,389 @@ import (
 	"text/template"
 
 	operatorv1alpha1 "github.com/IBM/ibm-iam-operator/apis/operator/v1alpha1"
-	ctrlCommon "github.com/IBM/ibm-iam-operator/controllers/common"
+	ctrlcommon "github.com/IBM/ibm-iam-operator/controllers/common"
+	"github.com/opdev/subreconciler"
 	osconfigv1 "github.com/openshift/api/config/v1"
 	"gopkg.in/yaml.v2"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/client-go/discovery"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-func (r *AuthenticationReconciler) handleConfigMap(instance *operatorv1alpha1.Authentication, wlpClientID string, wlpClientSecret string, currentConfigMap *corev1.ConfigMap, needToRequeue *bool) (err error) {
-
-	var isOSEnv bool
-	var domainName string
-	var newConfigMap *corev1.ConfigMap
-
-	configMapList := []string{"platform-auth-idp", "registration-script", "oauth-client-map", "registration-json"}
-	functionList := []func(*operatorv1alpha1.Authentication, *runtime.Scheme) *corev1.ConfigMap{r.authIdpConfigMap, registrationScriptConfigMap}
-
-	reqLogger := log.WithValues("Instance.Namespace", instance.Namespace, "Instance.Name", instance.Name)
-
-	// Check cluster type if CNCF or OCP
-	globalConfigMapName := ctrlCommon.GlobalConfigMapName
-	globalConfigMap := &corev1.ConfigMap{}
-	reqLogger.Info("Query global cm", "Configmap.Namespace", instance.Namespace, "ConfigMap.Name", globalConfigMapName)
-	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: globalConfigMapName, Namespace: instance.Namespace}, globalConfigMap)
+// getCNCFDomain returns the CNCF domain name set in the global ConfigMap, if
+// present. Returns an error when the ConfigMap is not found and returns an
+// empty string whenever the ConfigMap is found but the CNCF domain name is not
+// set.
+func getCNCFDomain(ctx context.Context, cl client.Client, authCR *operatorv1alpha1.Authentication) (domainName string, err error) {
+	logger := logf.FromContext(ctx)
+	cmName := ctrlcommon.GlobalConfigMapName
+	cmNs := authCR.Namespace
+	cm := &corev1.ConfigMap{}
+	err = cl.Get(ctx, types.NamespacedName{Name: cmName, Namespace: cmNs}, cm)
 	if err != nil {
-		if errors.IsNotFound(err) {
-			reqLogger.Error(err, "The configmap ", globalConfigMapName, " is not created yet")
-			return
-		}
-		reqLogger.Error(err, "Failed to get ConfigMap", globalConfigMapName)
+		logger.Error(err, "Failed to get ConfigMap")
 		return
 	}
+	logger.Info("Found ConfigMap", "name", cm.Name, "namespace", cm.Namespace)
 
-	ctrlCommon.GetClusterType(context.Background(), &r.Client, ctrlCommon.GlobalConfigMapName)
-
-	if !ctrlCommon.ClusterHasRouteGroupVersion(&r.DiscoveryClient) && !ctrlCommon.ClusterHasOpenShiftConfigGroupVerison(&r.DiscoveryClient) {
-		isOSEnv = false
-		reqLogger.Info("Checked cluster type", "Configmap.Namespace", instance.Namespace, "ConfigMap.Name", globalConfigMapName, "clusterType", r.clusterType)
-		domainName = globalConfigMap.Data["domain_name"]
-		reqLogger.Info("Reading domainName from global cm", "Configmap.Namespace", instance.Namespace, "ConfigMap.Name", globalConfigMapName, "domainName", domainName)
+	if !strings.EqualFold(cm.Data["kubernetes_cluster_type"], "cncf") {
+		return "", nil
+	} else if cm.Data["domain_name"] == "" {
+		return "", fmt.Errorf("domain name not configured")
 	}
 
-	// Reconcile ibmcloud-cluster-info configmap if not created already
-	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: "ibmcloud-cluster-info", Namespace: instance.Namespace}, currentConfigMap)
-	if err != nil {
-		if errors.IsNotFound(err) {
-			reqLogger.Info("Configmap is not found ", "Configmap.Namespace", instance.Namespace, "ConfigMap.Name", "ibmcloud-cluster-info")
-			reqLogger.Info("Going to create new ConfigMap", "ConfigMap.Namespace", instance.Namespace, "ConfigMap.Name", "ibmcloud-cluster-info")
-			newConfigMap = r.ibmcloudClusterInfoConfigMap(r.Client, instance, r.RunningOnOpenShiftCluster(), domainName, r.Scheme)
-			err = r.Client.Create(context.TODO(), newConfigMap)
-			if err != nil {
-				reqLogger.Error(err, "Failed to create new ConfigMap", "ConfigMap.Namespace", instance.Namespace, "ConfigMap.Name", "ibmcloud-cluster-info")
-				return
-			} else {
-				reqLogger.Info("Successfully created ConfigMap", "ConfigMap.Namespace", instance.Namespace, "ConfigMap.Name", "ibmcloud-cluster-info")
-			}
-		} else {
-			reqLogger.Error(err, "Failed to get the ConfigMap", "ConfigMap.Namespace", instance.Namespace, "ConfigMap.Name", "ibmcloud-cluster-info")
+	return cm.Data["domain_name"], nil
+}
+
+// handleIBMCloudClusterInfo creates the ibmcloud-cluster-info configmap if not created already
+func (r *AuthenticationReconciler) handleIBMCloudClusterInfo(ctx context.Context, authCR *operatorv1alpha1.Authentication, observed *corev1.ConfigMap) (result *ctrl.Result, err error) {
+	reqLogger := logf.FromContext(ctx).WithValues("ConfigMap.Namespace", authCR.Namespace, "ConfigMap.Name", ctrlcommon.IBMCloudClusterInfoCMName)
+	generated := &corev1.ConfigMap{}
+	if err = r.generateIBMCloudClusterInfoConfigMap(ctx, authCR, generated); err != nil {
+		return subreconciler.RequeueWithError(err)
+	}
+	cmKey := types.NamespacedName{Name: ctrlcommon.IBMCloudClusterInfoCMName, Namespace: authCR.Namespace}
+	if err = r.Client.Get(ctx, cmKey, observed); k8sErrors.IsNotFound(err) {
+		reqLogger.Info("Create new ConfigMap")
+		if err = r.Client.Create(ctx, generated); err != nil {
+			reqLogger.Error(err, "Failed to create new ConfigMap")
+			return subreconciler.RequeueWithDelay(defaultLowerWait)
 		}
+		reqLogger.Info("Successfully created ConfigMap")
+		return subreconciler.RequeueWithDelay(defaultLowerWait)
+	} else if err != nil {
+		reqLogger.Error(err, "Failed to get the ConfigMap")
+		return subreconciler.RequeueWithDelay(defaultLowerWait)
+	}
+
+	updated := false
+	controllerKind := ctrlcommon.GetControllerKind(observed)
+	if controllerKind == "ManagementIngress" {
+		reqLogger.Info("Configmap is already created by managementingress, IM installation may not proceed further until the configmap is removed")
+		return subreconciler.RequeueWithDelay(defaultLowerWait)
+	} else if controllerKind != "Authentication" {
+		reqLogger.Info("ConfigMap is not owned by the current Authentication or a ManagementIngress; will attempt to become controller")
+		if err = controllerutil.SetControllerReference(authCR, observed, r.Client.Scheme()); err != nil {
+			reqLogger.Error(err, "Could not become the controller of the ConfigMap; it may need to be removed")
+			return subreconciler.RequeueWithError(err)
+		}
+		updated = true
+	}
+
+	if observed.Labels == nil {
+		observed.Labels = map[string]string{"app": "auth-idp"}
+		updated = true
+	} else if observed.Labels["app"] != "auth-idp" {
+		observed.Labels["app"] = "auth-idp"
+		updated = true
 	} else {
-		labels := currentConfigMap.Labels
-
-		if labels != nil {
-			value, ok := labels["app"]
-			if ok && value == "auth-idp" && ctrlCommon.IsControllerOf(instance, currentConfigMap) {
-				reqLogger.Info("ibmcloud-cluster-info Configmap is already created by IM operator", "Configmap.Namespace", currentConfigMap.Namespace, "ConfigMap.Name", "ibmcloud-cluster-info")
-			} else if ok && value == "management-ingress" && ctrlCommon.GetControllerKind(currentConfigMap) == "ManagementIngress" {
-				reqLogger.Info("Configmap is already created by managementingress , IM installation may not proceed further until the configmap is removed", "Configmap.Namespace", currentConfigMap.Namespace, "ConfigMap.Name", "ibmcloud-cluster-info")
-				*needToRequeue = true
-				return
-			} else {
-				reqLogger.Info("ConfigMap is not owned by the current Authentication or a ManagementIngress; will attempt to become controller", "Configmap.Namespace", currentConfigMap.Namespace, "ConfigMap.Name", "ibmcloud-cluster-info")
-				if err = controllerutil.SetControllerReference(instance, currentConfigMap, r.Client.Scheme()); err != nil {
-					reqLogger.Error(err, "Could not become the controller of the ConfigMap; it may need to be removed", "Configmap.Namespace", currentConfigMap.Namespace, "ConfigMap.Name", "ibmcloud-cluster-info")
-					return
-				}
-				currentConfigMap.Labels["app"] = "auth-idp"
-				reqLogger.Info("Became controller and labeled to indicate association with IM; attempting update", "Configmap.Namespace", currentConfigMap.Namespace, "ConfigMap.Name", "ibmcloud-cluster-info")
-				err = r.Client.Update(context.TODO(), currentConfigMap)
-				if err != nil {
-					reqLogger.Error(err, "Failed to update ConfigMap", "Configmap.Namespace", currentConfigMap.Namespace, "ConfigMap.Name", "ibmcloud-cluster-info")
-					return
-				}
-				reqLogger.Info("Successfully updated ConfigMap; requeueing reconcile", "Configmap.Namespace", currentConfigMap.Namespace, "ConfigMap.Name", "ibmcloud-cluster-info")
-				*needToRequeue = true
-				return
-			}
-		}
+		reqLogger.Info("ibmcloud-cluster-info Configmap is already created by IM operator")
 	}
 
-	// Public Cloud to be checked from ibmcloud-cluster-info
-	isPublicCloud := isPublicCloud(r.Client, instance.Namespace, "ibmcloud-cluster-info")
+	if !updated {
+		return subreconciler.ContinueReconciling()
+	}
 
-	//icpConsoleURL , icpProxyURL to be fetched from ibmcloud-cluster-info
-	proxyConfigMapName := "ibmcloud-cluster-info"
-	proxyConfigMap := &corev1.ConfigMap{}
-	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: proxyConfigMapName, Namespace: instance.Namespace}, proxyConfigMap)
-	if err != nil {
-		if errors.IsNotFound(err) {
-			reqLogger.Error(err, "The configmap ", proxyConfigMapName, " is not created yet")
+	reqLogger.Info("Became controller and labeled to indicate association with IM; attempting update")
+	if err = r.Update(ctx, observed); err != nil {
+		reqLogger.Error(err, "Failed to update ConfigMap")
+		return subreconciler.RequeueWithError(err)
+	}
+	reqLogger.Info("Successfully updated ConfigMap; requeueing reconcile")
+
+	return subreconciler.RequeueWithDelay(defaultLowerWait)
+}
+
+func (r *AuthenticationReconciler) handleConfigMaps(ctx context.Context, req ctrl.Request) (result *ctrl.Result, err error) {
+	//reqLogger := logf.FromContext(ctx)
+
+	authCR := &operatorv1alpha1.Authentication{}
+	if result, err = r.getLatestAuthentication(ctx, req, authCR); subreconciler.ShouldHaltOrRequeue(result, err) {
+		return
+	}
+
+	// Ensure that the ibmcloud-cluster-info configmap is created
+	ibmCloudClusterInfoCM := &corev1.ConfigMap{}
+
+	var subresult *ctrl.Result
+	subresult, err = r.handleIBMCloudClusterInfo(ctx, authCR, ibmCloudClusterInfoCM)
+	if subreconciler.ShouldHaltOrRequeue(subresult, err) {
+		return subreconciler.RequeueWithDelay(defaultLowerWait)
+	}
+
+	cmUpdaters := []*cmUpdater{
+		{
+			Name:     "platform-auth-idp",
+			generate: generateAuthIdpConfigMap,
+			update:   updatePlatformAuthIDP,
+		},
+		{
+			Name:     "registration-json",
+			generate: generateRegistrationJsonConfigMap,
+			update:   updateRegistrationJSON,
+			onChange: replaceOIDCClientRegistrationJob,
+		},
+		{
+			Name:     "oauth-client-map",
+			generate: generateOAuthClientConfigMap,
+		},
+		{
+			Name:     "registration-script",
+			generate: generateRegistrationScriptConfigMap,
+		},
+	}
+
+	subresults := []*ctrl.Result{}
+	errs := []error{}
+	for _, updater := range cmUpdaters {
+		subresult, err = updater.CreateOrUpdate(ctx, r.Client, authCR, ibmCloudClusterInfoCM)
+		subresults = append(subresults, subresult)
+		errs = append(errs, err)
+	}
+
+	return ctrlcommon.ReduceSubreconcilerResultsAndErrors(subresults, errs)
+}
+
+func updateFields(observed, updates *corev1.ConfigMap, keys ...string) (updated bool) {
+	for _, key := range keys {
+		if value, ok := updates.Data[key]; ok && observed.Data[key] != value {
+			observed.Data[key] = value
+			updated = true
+		}
+	}
+	return
+}
+
+type matcherFunc func(*corev1.ConfigMap) bool
+
+func observedKeySet(key string) matcherFunc {
+	return func(observed *corev1.ConfigMap) bool {
+		_, ok := observed.Data[key]
+		return ok
+	}
+}
+
+func observedKeyValueSetTo(key, value string) matcherFunc {
+	return func(observed *corev1.ConfigMap) bool {
+		observedValue, ok := observed.Data[key]
+		if ok && value == observedValue {
+			return true
+		}
+		return false
+	}
+}
+
+func not(matches matcherFunc) matcherFunc {
+	return func(observed *corev1.ConfigMap) bool {
+		return !matches(observed)
+	}
+}
+
+func observedKeyValueContains(key, value string) matcherFunc {
+	return func(observed *corev1.ConfigMap) bool {
+		observedValue, ok := observed.Data[key]
+		if ok && strings.Contains(observedValue, value) {
+			return true
+		}
+		return false
+	}
+}
+
+func updatesValuesWhen(matches matcherFunc, keys ...string) (fn func(*corev1.ConfigMap, *corev1.ConfigMap) bool) {
+	return func(observed, updates *corev1.ConfigMap) bool {
+		if matches(observed) {
+			return updateFields(observed, updates, keys...)
+		}
+		return false
+	}
+}
+
+func replaceOIDCClientRegistrationJob(ctx context.Context, cl client.Client, authCR *operatorv1alpha1.Authentication) (err error) {
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "oidc-client-registration",
+			Namespace: authCR.Namespace,
+		},
+	}
+	if err = cl.Delete(ctx, job); k8sErrors.IsNotFound(err) {
+		return nil
+	}
+	return
+}
+
+func updateRegistrationJSON(observed, generated *corev1.ConfigMap) (updated bool, err error) {
+	observedJSON := &registrationJSONData{}
+	if err = json.Unmarshal([]byte(observed.Data["platform-oidc-registration.json"]), observedJSON); err != nil {
+		return
+	}
+	generatedJSON := &registrationJSONData{}
+	if err = json.Unmarshal([]byte(generated.Data["platform-oidc-registration.json"]), generatedJSON); err != nil {
+		return
+	}
+	if !reflect.DeepEqual(generatedJSON, observedJSON) {
+		var newJSON []byte
+		if newJSON, err = json.MarshalIndent(generatedJSON, "", "  "); err != nil {
 			return
 		}
-		reqLogger.Error(err, "Failed to get ConfigMap", proxyConfigMapName)
-		*needToRequeue = true
-		err = nil
-		return
+
+		observed.Data["platform-oidc-registration.json"] = string(newJSON[:])
+		updated = true
 	}
-	icpProxyURL, ok := proxyConfigMap.Data["proxy_address"]
-	if !ok {
-		reqLogger.Error(nil, "The configmap", proxyConfigMapName, "doesn't contain proxy address")
-		*needToRequeue = true
-		return
+	if !reflect.DeepEqual(generated.GetOwnerReferences(), observed.GetOwnerReferences()) {
+		observed.OwnerReferences = generated.GetOwnerReferences()
+		updated = true
 	}
-	icpConsoleURL, ok := proxyConfigMap.Data["cluster_address"]
+	return
+}
 
-	if !ok {
-		reqLogger.Error(nil, "The configmap", proxyConfigMapName, "doesn't contain cluster_address address")
-		*needToRequeue = true
-		return
+type cmUpdater struct {
+	Name     string
+	generate func(context.Context, client.Client, *operatorv1alpha1.Authentication, *corev1.ConfigMap, *corev1.ConfigMap) error
+	update   func(*corev1.ConfigMap, *corev1.ConfigMap) (bool, error)
+	onChange func(context.Context, client.Client, *operatorv1alpha1.Authentication) error
+}
+
+func (u *cmUpdater) CreateOrUpdate(ctx context.Context, cl client.Client, authCR *operatorv1alpha1.Authentication, ibmcloudClusterInfo *corev1.ConfigMap) (result *ctrl.Result, err error) {
+	reqLogger := logf.FromContext(ctx).WithValues("ConfigMap.Namespace", authCR.Namespace, "ConfigMap.Name", u.Name)
+	observed := &corev1.ConfigMap{}
+	generated := &corev1.ConfigMap{}
+	if err = u.generate(ctx, cl, authCR, ibmcloudClusterInfo, generated); err != nil {
+		return subreconciler.RequeueWithError(err)
 	}
-
-	// Creation the default configmaps
-	for index, configMap := range configMapList {
-		err = r.Client.Get(context.TODO(), types.NamespacedName{Name: configMap, Namespace: instance.Namespace}, currentConfigMap)
-		if err != nil {
-			if errors.IsNotFound(err) {
-				// Define a new ConfigMap
-				if configMapList[index] == "registration-json" {
-					newConfigMap = registrationJsonConfigMap(instance, wlpClientID, wlpClientSecret, icpConsoleURL, r.Scheme)
-					if newConfigMap == nil {
-						err = fmt.Errorf("an error occurred during registration-json generation")
-						return err
-					}
-				} else if configMapList[index] == "oauth-client-map" {
-					newConfigMap = oauthClientConfigMap(instance, icpConsoleURL, icpProxyURL, r.Scheme)
-				} else {
-					newConfigMap = functionList[index](instance, r.Scheme)
-					if configMapList[index] == "platform-auth-idp" {
-						if instance.Spec.Config.ROKSEnabled && instance.Spec.Config.ROKSURL == "https://roks.domain.name:443" { //we enable it by default
-							reqLogger.Info("Create platform-auth-idp Configmap roks settings", "Configmap.Namespace", currentConfigMap.Namespace, "ConfigMap.Name", currentConfigMap.Name)
-							issuer, err := readROKSURL(instance)
-							if err != nil {
-								reqLogger.Error(err, "Failed to get issuer URL", "ConfigMap.Namespace", instance.Namespace, "ConfigMap.Name", configMap)
-								return err
-							}
-							newConfigMap.Data["ROKS_ENABLED"] = "true"
-							newConfigMap.Data["ROKS_URL"] = issuer
-							if instance.Spec.Config.ROKSUserPrefix == "changeme" { //we change it to empty prefix, that's the new default in 3.5
-								if isPublicCloud {
-									newConfigMap.Data["ROKS_USER_PREFIX"] = "IAM#"
-								} else {
-									newConfigMap.Data["ROKS_USER_PREFIX"] = ""
-								}
-							} else { // user specifies prefix but does not specify roksEnabled and roksURL we take the user provided prefix
-								newConfigMap.Data["ROKS_USER_PREFIX"] = instance.Spec.Config.ROKSUserPrefix
-							}
-						} else {
-							reqLogger.Info("Honor end user's setting", "Configmap.Namespace", currentConfigMap.Namespace, "ConfigMap.Name", currentConfigMap.Name)
-							//if user does not specify the prefix, we set it to IAM# to be consistent with previous release
-							if instance.Spec.Config.ROKSEnabled && instance.Spec.Config.ROKSURL != "https://roks.domain.name:443" && instance.Spec.Config.ROKSUserPrefix == "changeme" {
-								newConfigMap.Data["ROKS_USER_PREFIX"] = "IAM#"
-							}
-						}
-						reqLogger.Info("Adding new variable to configmap", "Configmap.Namespace", currentConfigMap.Namespace, "isOSEnv", isOSEnv)
-						// Detect cluster type - cncf or openshift
-						// if global cm, ignore CR, and populate auth-idp with value from global
-						// if no global cm, take value from CR - NOT REQD.
-						newConfigMap.Data["IS_OPENSHIFT_ENV"] = strconv.FormatBool(r.RunningOnOpenShiftCluster())
-
-					} else {
-						//user specifies roksEnabled and roksURL, but not roksPrefix, then we set prefix to IAM# (consistent with previous release behavior)
-						if instance.Spec.Config.ROKSEnabled && instance.Spec.Config.ROKSURL != "https://roks.domain.name:443" && instance.Spec.Config.ROKSUserPrefix == "changeme" {
-							newConfigMap.Data["ROKS_USER_PREFIX"] = "IAM#"
-						}
-					}
-				}
-				reqLogger.Info("Creating a new ConfigMap", "ConfigMap.Namespace", instance.Namespace, "ConfigMap.Name", configMap)
-				err = r.Client.Create(context.TODO(), newConfigMap)
-				if err != nil {
-					reqLogger.Error(err, "Failed to create new ConfigMap", "ConfigMap.Namespace", instance.Namespace, "ConfigMap.Name", configMap)
-					return
-				}
-				// ConfigMap created successfully - return and requeue
-				*needToRequeue = true
-			} else {
-				reqLogger.Error(err, "Failed to get ConfigMap", "ConfigMap.Namespace", instance.Namespace, "ConfigMap.Name", configMap)
-				return
-			}
-		} else {
-			// @posriniv - find a more efficient solution
-			if configMapList[index] == "platform-auth-idp" {
-				cmUpdateRequired := false
-				if _, keyExists := currentConfigMap.Data["LDAP_RECURSIVE_SEARCH"]; !keyExists {
-					reqLogger.Info("Updating an existing Configmap", "Configmap.Namespace", currentConfigMap.Namespace, "ConfigMap.Name", currentConfigMap.Name)
-					newConfigMap = functionList[index](instance, r.Scheme)
-					currentConfigMap.Data["LDAP_RECURSIVE_SEARCH"] = newConfigMap.Data["LDAP_RECURSIVE_SEARCH"]
-					cmUpdateRequired = true
-				}
-				if _, keyExists := currentConfigMap.Data["CLAIMS_SUPPORTED"]; !keyExists {
-					reqLogger.Info("Updating an existing Configmap", "Configmap.Namespace", currentConfigMap.Namespace, "ConfigMap.Name", currentConfigMap.Name)
-					newConfigMap = functionList[index](instance, r.Scheme)
-					currentConfigMap.Data["CLAIMS_SUPPORTED"] = newConfigMap.Data["CLAIMS_SUPPORTED"]
-					currentConfigMap.Data["CLAIMS_MAP"] = newConfigMap.Data["CLAIMS_MAP"]
-					currentConfigMap.Data["SCOPE_CLAIM"] = newConfigMap.Data["SCOPE_CLAIM"]
-					currentConfigMap.Data["BOOTSTRAP_USERID"] = newConfigMap.Data["BOOTSTRAP_USERID"]
-					cmUpdateRequired = true
-				}
-				if _, keyExists := currentConfigMap.Data["PROVIDER_ISSUER_URL"]; !keyExists {
-					reqLogger.Info("Updating an existing Configmap", "Configmap.Namespace", currentConfigMap.Namespace, "ConfigMap.Name", currentConfigMap.Name)
-					newConfigMap = functionList[index](instance, r.Scheme)
-					currentConfigMap.Data["PROVIDER_ISSUER_URL"] = newConfigMap.Data["PROVIDER_ISSUER_URL"]
-					cmUpdateRequired = true
-				}
-				if _, keyExists := currentConfigMap.Data["PREFERRED_LOGIN"]; !keyExists {
-					reqLogger.Info("Updating an existing Configmap", "Configmap.Namespace", currentConfigMap.Namespace, "ConfigMap.Name", currentConfigMap.Name)
-					newConfigMap = functionList[index](instance, r.Scheme)
-					currentConfigMap.Data["PREFERRED_LOGIN"] = newConfigMap.Data["PREFERRED_LOGIN"]
-					cmUpdateRequired = true
-				}
-				if _, keyExists := currentConfigMap.Data["DEFAULT_LOGIN"]; !keyExists {
-					reqLogger.Info("Updating an existing Configmap", "Configmap.Namespace", currentConfigMap.Namespace, "ConfigMap.Name", currentConfigMap.Name)
-					newConfigMap = functionList[index](instance, r.Scheme)
-					currentConfigMap.Data["DEFAULT_LOGIN"] = newConfigMap.Data["DEFAULT_LOGIN"]
-					cmUpdateRequired = true
-				}
-				if _, keyExists := currentConfigMap.Data["DB_CONNECT_TIMEOUT"]; !keyExists {
-					reqLogger.Info("Updating an existing Configmap with connection pooling information", "Configmap.Namespace", currentConfigMap.Namespace, "ConfigMap.Name", currentConfigMap.Name)
-					newConfigMap = functionList[index](instance, r.Scheme)
-					currentConfigMap.Data["DB_CONNECT_TIMEOUT"] = newConfigMap.Data["DB_CONNECT_TIMEOUT"]
-					currentConfigMap.Data["DB_IDLE_TIMEOUT"] = newConfigMap.Data["DB_IDLE_TIMEOUT"]
-					currentConfigMap.Data["DB_CONNECT_MAX_RETRIES"] = newConfigMap.Data["DB_CONNECT_MAX_RETRIES"]
-					currentConfigMap.Data["DB_POOL_MIN_SIZE"] = newConfigMap.Data["DB_POOL_MIN_SIZE"]
-					currentConfigMap.Data["DB_POOL_MAX_SIZE"] = newConfigMap.Data["DB_POOL_MAX_SIZE"]
-					currentConfigMap.Data["SEQL_LOGGING"] = newConfigMap.Data["SEQL_LOGGING"]
-					cmUpdateRequired = true
-				}
-				if _, keyExists := currentConfigMap.Data["DB_SSL_MODE"]; !keyExists {
-					reqLogger.Info("Updating an existing Configmap with db ssl mode information", "Configmap.Namespace", currentConfigMap.Namespace, "ConfigMap.Name", currentConfigMap.Name)
-					newConfigMap = functionList[index](instance, r.Scheme)
-					currentConfigMap.Data["DB_SSL_MODE"] = newConfigMap.Data["DB_SSL_MODE"]
-					cmUpdateRequired = true
-				}
-				if _, keyExists := currentConfigMap.Data["OS_TOKEN_LENGTH"]; keyExists {
-					if currentConfigMap.Data["OS_TOKEN_LENGTH"] == "45" {
-						newConfigMap = functionList[index](instance, r.Scheme)
-						reqLogger.Info("Updating an existing Configmap", "Configmap.Namespace", currentConfigMap.Namespace, "ConfigMap.Name", currentConfigMap.Name)
-						reqLogger.Info("Updating OS token length", "New length is ", newConfigMap.Data["OS_TOKEN_LENGTH"])
-						currentConfigMap.Data["OS_TOKEN_LENGTH"] = newConfigMap.Data["OS_TOKEN_LENGTH"]
-						cmUpdateRequired = true
-					}
-				}
-				if _, keyExists := currentConfigMap.Data["SCIM_LDAP_ATTRIBUTES_MAPPING"]; !keyExists {
-					reqLogger.Info("Updating an existing Configmap to add new SCIM variables", "Configmap.Namespace", currentConfigMap.Namespace, "ConfigMap.Name", currentConfigMap.Name)
-					newConfigMap = functionList[index](instance, r.Scheme)
-					currentConfigMap.Data["SCIM_LDAP_ATTRIBUTES_MAPPING"] = newConfigMap.Data["SCIM_LDAP_ATTRIBUTES_MAPPING"]
-					currentConfigMap.Data["SCIM_LDAP_SEARCH_SIZE_LIMIT"] = newConfigMap.Data["SCIM_LDAP_SEARCH_SIZE_LIMIT"]
-					currentConfigMap.Data["SCIM_LDAP_SEARCH_TIME_LIMIT"] = newConfigMap.Data["SCIM_LDAP_SEARCH_TIME_LIMIT"]
-					currentConfigMap.Data["SCIM_ASYNC_PARALLEL_LIMIT"] = newConfigMap.Data["SCIM_ASYNC_PARALLEL_LIMIT"]
-					currentConfigMap.Data["SCIM_GET_DISPLAY_FOR_GROUP_USERS"] = newConfigMap.Data["SCIM_GET_DISPLAY_FOR_GROUP_USERS"]
-					cmUpdateRequired = true
-				}
-				if _, keyExists := currentConfigMap.Data["SCIM_AUTH_CACHE_MAX_SIZE"]; !keyExists {
-					reqLogger.Info("Updating an existing Configmap to add new SCIM variables", "Configmap.Namespace", currentConfigMap.Namespace, "ConfigMap.Name", currentConfigMap.Name)
-					newConfigMap = functionList[index](instance, r.Scheme)
-					currentConfigMap.Data["SCIM_AUTH_CACHE_MAX_SIZE"] = newConfigMap.Data["SCIM_AUTH_CACHE_MAX_SIZE"]
-					cmUpdateRequired = true
-				}
-				if _, keyExists := currentConfigMap.Data["SCIM_AUTH_CACHE_TTL_VALUE"]; !keyExists {
-					reqLogger.Info("Updating an existing Configmap to add new SCIM variables", "Configmap.Namespace", currentConfigMap.Namespace, "ConfigMap.Name", currentConfigMap.Name)
-					newConfigMap = functionList[index](instance, r.Scheme)
-					currentConfigMap.Data["SCIM_AUTH_CACHE_TTL_VALUE"] = newConfigMap.Data["SCIM_AUTH_CACHE_TTL_VALUE"]
-					cmUpdateRequired = true
-				}
-				if _, keyExists := currentConfigMap.Data["AUTH_SVC_LDAP_CONFIG_TIMEOUT"]; !keyExists {
-					reqLogger.Info("Updating an existing Configmap to add new variable for auth-service LDAP configuration timeout", "Configmap.Namespace", currentConfigMap.Namespace, "ConfigMap.Name", currentConfigMap.Name)
-					newConfigMap = functionList[index](instance, r.Scheme)
-					currentConfigMap.Data["AUTH_SVC_LDAP_CONFIG_TIMEOUT"] = newConfigMap.Data["AUTH_SVC_LDAP_CONFIG_TIMEOUT"]
-					cmUpdateRequired = true
-				}
-				if _, keyExists := currentConfigMap.Data["IBM_CLOUD_SAAS"]; !keyExists {
-					reqLogger.Info("Updating an existing Configmap", "Configmap.Namespace", currentConfigMap.Namespace, "ConfigMap.Name", currentConfigMap.Name)
-					newConfigMap = functionList[index](instance, r.Scheme)
-					currentConfigMap.Data["IBM_CLOUD_SAAS"] = newConfigMap.Data["IBM_CLOUD_SAAS"]
-					currentConfigMap.Data["SAAS_CLIENT_REDIRECT_URL"] = newConfigMap.Data["SAAS_CLIENT_REDIRECT_URL"]
-					cmUpdateRequired = true
-				}
-				if _, keyExists := currentConfigMap.Data["ATTR_MAPPING_FROM_CONFIG"]; !keyExists {
-					reqLogger.Info("Updating an existing Configmap to add new variable for attribute mapping resource", "Configmap.Namespace", currentConfigMap.Namespace, "ConfigMap.Name", currentConfigMap.Name)
-					newConfigMap = functionList[index](instance, r.Scheme)
-					currentConfigMap.Data["ATTR_MAPPING_FROM_CONFIG"] = newConfigMap.Data["ATTR_MAPPING_FROM_CONFIG"]
-					cmUpdateRequired = true
-				}
-				if _, keyExists := currentConfigMap.Data["LDAP_CTX_POOL_INITSIZE"]; !keyExists {
-					reqLogger.Info("Updating an existing Configmap to add context pool for ldap configuration", "Configmap.Namespace", currentConfigMap.Namespace, "ConfigMap.Name", currentConfigMap.Name)
-					newConfigMap = functionList[index](instance, r.Scheme)
-					currentConfigMap.Data["LDAP_CTX_POOL_INITSIZE"] = newConfigMap.Data["LDAP_CTX_POOL_INITSIZE"]
-					currentConfigMap.Data["LDAP_CTX_POOL_MAXSIZE"] = newConfigMap.Data["LDAP_CTX_POOL_MAXSIZE"]
-					currentConfigMap.Data["LDAP_CTX_POOL_TIMEOUT"] = newConfigMap.Data["LDAP_CTX_POOL_TIMEOUT"]
-					currentConfigMap.Data["LDAP_CTX_POOL_WAITTIME"] = newConfigMap.Data["LDAP_CTX_POOL_WAITTIME"]
-					currentConfigMap.Data["LDAP_CTX_POOL_PREFERREDSIZE"] = newConfigMap.Data["LDAP_CTX_POOL_PREFERREDSIZE"]
-					cmUpdateRequired = true
-				}
-				_, keyExists := currentConfigMap.Data["IS_OPENSHIFT_ENV"]
-				if keyExists {
-					reqLogger.Info("Current configmap", "Current Value", currentConfigMap.Data["IS_OPENSHIFT_ENV"])
-					if currentConfigMap.Data["IS_OPENSHIFT_ENV"] != strconv.FormatBool(r.RunningOnOpenShiftCluster()) {
-						currentConfigMap.Data["IS_OPENSHIFT_ENV"] = strconv.FormatBool(r.RunningOnOpenShiftCluster())
-					}
-				} else {
-					currentConfigMap.Data["IS_OPENSHIFT_ENV"] = strconv.FormatBool(r.RunningOnOpenShiftCluster())
-				}
-
-				// This code would take care updating cp2 specific values into cp3 format
-				idmgmtSVC, keyExists := currentConfigMap.Data["IDENTITY_MGMT_URL"]
-				if keyExists && strings.Contains(idmgmtSVC, "127.0.0.1") {
-					reqLogger.Info("Upgrade check : IDENTITY_MGMT_URL entry would be upgraded to CP3 format ", "Configmap.Namespace", currentConfigMap.Namespace, "ConfigMap.Name", currentConfigMap.Name)
-					currentConfigMap.Data["IDENTITY_MGMT_URL"] = "https://platform-identity-management:4500"
-					cmUpdateRequired = true
-				}
-
-				authSVC, keyExists := currentConfigMap.Data["BASE_OIDC_URL"]
-				if keyExists && strings.Contains(authSVC, "127.0.0.1") {
-					reqLogger.Info("Upgrade check : BASE_OIDC_URL entry would be upgraded to CP3 format ", "Configmap.Namespace", currentConfigMap.Namespace, "ConfigMap.Name", currentConfigMap.Name)
-					currentConfigMap.Data["BASE_OIDC_URL"] = "https://platform-auth-service:9443/oidc/endpoint/OP"
-					cmUpdateRequired = true
-				}
-
-				authdirSVC, keyExists := currentConfigMap.Data["IDENTITY_AUTH_DIRECTORY_URL"]
-				if keyExists && strings.Contains(authdirSVC, "127.0.0.1") {
-					reqLogger.Info("Upgrade check : IDENTITY_AUTH_DIRECTORY_URL entry would be upgraded to CP3 format ", "Configmap.Namespace", currentConfigMap.Namespace, "ConfigMap.Name", currentConfigMap.Name)
-					currentConfigMap.Data["IDENTITY_AUTH_DIRECTORY_URL"] = "https://platform-auth-service:3100"
-					cmUpdateRequired = true
-				}
-
-				idproviderSVC, keyExists := currentConfigMap.Data["IDENTITY_PROVIDER_URL"]
-				if keyExists && strings.Contains(idproviderSVC, "127.0.0.1") {
-					reqLogger.Info("Upgrade check : IDENTITY_PROVIDER_URL entry would be upgraded to CP3 format ", "Configmap.Namespace", currentConfigMap.Namespace, "ConfigMap.Name", currentConfigMap.Name)
-					currentConfigMap.Data["IDENTITY_PROVIDER_URL"] = "https://platform-identity-provider:4300"
-					cmUpdateRequired = true
-				}
-				roksUrl, keyExists := currentConfigMap.Data["ROKS_URL"]
-				if keyExists {
-					desiredRoksUrl, err := readROKSURL(instance)
-					if err == nil && len(desiredRoksUrl) != 0 && roksUrl != desiredRoksUrl {
-						currentConfigMap.Data["ROKS_URL"] = desiredRoksUrl
-						cmUpdateRequired = true
-					}
-				}
-
-				cmUpdateRequired = true
-
-				if cmUpdateRequired {
-					err = r.Client.Update(context.TODO(), currentConfigMap)
-					if err != nil {
-						reqLogger.Error(err, "Failed to update an existing Configmap", "Configmap.Namespace", currentConfigMap.Namespace, "Configmap.Name", currentConfigMap.Name)
-						return
-					}
-				}
-			} else if configMapList[index] == "registration-json" {
-				platformOIDCCredentials := &corev1.Secret{}
-				var servicesNamespace string
-				servicesNamespace, err = ctrlCommon.GetServicesNamespace(context.Background(), &r.Client)
-				if err != nil {
-					reqLogger.Error(err, "Failed to get services namespace")
-					return
-				}
-				objectKey := types.NamespacedName{Name: "platform-oidc-credentials", Namespace: servicesNamespace}
-				err = r.Client.Get(context.Background(), objectKey, platformOIDCCredentials)
-				if err != nil {
-					reqLogger.Error(err, "Failed to get Secret for registration-json update")
-					return
-				}
-				latestWLPClientID := platformOIDCCredentials.Data["WLP_CLIENT_ID"]
-				latestWLPClientSecret := platformOIDCCredentials.Data["WLP_CLIENT_SECRET"]
-				newConfigMap = registrationJsonConfigMap(instance, string(latestWLPClientID[:]), string(latestWLPClientSecret[:]), icpConsoleURL, r.Scheme)
-				if newConfigMap == nil {
-					err = fmt.Errorf("an error occurred during registration-json generation")
-					return err
-				}
-				reqLogger.Info("Calculated new platform-oidc-registration.json")
-				var currentRegistrationJSON, newRegistrationJSON *registrationJSONData
-				newRegistrationJSON = &registrationJSONData{}
-				currentRegistrationJSON = &registrationJSONData{}
-				if err = json.Unmarshal([]byte(newConfigMap.Data["platform-oidc-registration.json"]), newRegistrationJSON); err != nil {
-					reqLogger.Error(err, "Failed to unmarshal calculated ConfigMap")
-					return
-				}
-				if err = json.Unmarshal([]byte(currentConfigMap.Data["platform-oidc-registration.json"]), currentRegistrationJSON); err != nil {
-					reqLogger.Error(err, "Failed to unmarshal observed ConfigMap")
-					return
-				}
-				var updatedJSON, updatedOwnerRefs bool
-				if !reflect.DeepEqual(newRegistrationJSON, currentRegistrationJSON) {
-					reqLogger.Info("Difference found in observed vs calculated platform-oidc-registration.json")
-					var newJSON []byte
-					if newJSON, err = json.MarshalIndent(newRegistrationJSON, "", "  "); err != nil {
-						reqLogger.Error(err, "Failed to marshal JSON for registration-json update")
-						return
-					}
-					currentConfigMap.Data["platform-oidc-registration.json"] = string(newJSON[:])
-					updatedJSON = true
-				}
-				if !reflect.DeepEqual(newConfigMap.GetOwnerReferences(), currentConfigMap.GetOwnerReferences()) {
-					reqLogger.Info("Difference found in observed vs calculated OwnerReferences")
-					currentConfigMap.OwnerReferences = newConfigMap.GetOwnerReferences()
-					updatedOwnerRefs = true
-				}
-				if updatedJSON || updatedOwnerRefs {
-					reqLogger.Info("Updating ConfigMap")
-					if err = r.Client.Update(context.Background(), currentConfigMap); err != nil {
-						reqLogger.Error(err, "Failed to update ConfigMap", "Name", "registration-json", "Namespace", instance.Namespace)
-						return
-					}
-					reqLogger.Info("ConfigMap successfully updated")
-					if updatedJSON {
-						reqLogger.Info("Deleting Job to re-run with upated ConfigMap", "Job.Name", "oidc-client-registration")
-
-						job := &batchv1.Job{
-							ObjectMeta: metav1.ObjectMeta{
-								Name:      "oidc-client-registration",
-								Namespace: instance.Namespace,
-							},
-						}
-						if err = r.Client.Delete(context.TODO(), job); err != nil {
-							if errors.IsNotFound(err) {
-								reqLogger.Info("Job not found on cluster; continuing", "Job.Name", "oidc-client-registration")
-								return nil
-							}
-							reqLogger.Error(err, "Could not delete job", "Job.Name", "oidc-client-registration")
-							return
-						}
-						reqLogger.Info("Deleted Job", "Job.Name", "oidc-client-registration")
-						return
-					}
-				} else {
-					reqLogger.Info("No ConfigMap update required")
-				}
-			}
+	cmKey := types.NamespacedName{Name: u.Name, Namespace: authCR.Namespace}
+	if err = cl.Get(ctx, cmKey, observed); k8sErrors.IsNotFound(err) {
+		if err := cl.Create(ctx, generated); k8sErrors.IsAlreadyExists(err) {
+			reqLogger.Info("ConfigMap was found while creating")
+			return subreconciler.RequeueWithDelay(defaultLowerWait)
+		} else if err != nil {
+			reqLogger.Info("ConfigMap could not be created for an unexpected reason", "msg", err.Error())
+			return subreconciler.RequeueWithDelay(defaultLowerWait)
 		}
+		reqLogger.Info("ConfigMap created")
+		if u.onChange == nil {
+			return subreconciler.RequeueWithDelay(defaultLowerWait)
+		}
+
+		if err = u.onChange(ctx, cl, authCR); err != nil {
+			reqLogger.Info("Error occurred while performing post-update work", "reason", err.Error())
+		}
+		return subreconciler.RequeueWithDelay(defaultLowerWait)
 	}
 
-	return nil
+	if u.update == nil {
+		return subreconciler.ContinueReconciling()
+	}
+	updated := false
+	updated, err = u.update(observed, generated)
+	if err != nil {
+		return subreconciler.RequeueWithError(err)
+	} else if !updated {
+		return subreconciler.ContinueReconciling()
+	}
+
+	if err = cl.Update(ctx, observed); err != nil {
+		reqLogger.Info("Failed to update Configmap", "msg", err.Error())
+		return subreconciler.RequeueWithDelay(defaultLowerWait)
+	}
+
+	reqLogger.Info("ConfigMap updated successfully")
+	if u.onChange == nil {
+		return subreconciler.RequeueWithDelay(defaultLowerWait)
+	}
+
+	if err = u.onChange(ctx, cl, authCR); err != nil {
+		reqLogger.Info("Error occurred while performing post-update work", "reason", err.Error())
+	}
+
+	return subreconciler.RequeueWithDelay(defaultLowerWait)
+}
+
+func updatePlatformAuthIDP(observed, generated *corev1.ConfigMap) (updated bool, err error) {
+	updateFns := []func(*corev1.ConfigMap, *corev1.ConfigMap) bool{
+		updatesValuesWhen(observedKeyValueSetTo("OS_TOKEN_LENGTH", "45"),
+			"OS_TOKEN_LENGTH"),
+		updatesValuesWhen(observedKeyValueContains("IDENTITY_MGMT_URL", "127.0.0.1"),
+			"IDENTITY_MGMT_URL"),
+		updatesValuesWhen(
+			observedKeyValueContains("BASE_OIDC_URL", "127.0.0.1"),
+			"BASE_OIDC_URL"),
+		updatesValuesWhen(
+			observedKeyValueContains("IDENTITY_AUTH_DIRECTORY_URL", "127.0.0.1"),
+			"IDENTITY_AUTH_DIRECTORY_URL"),
+		updatesValuesWhen(
+			observedKeyValueContains("IDENTITY_PROVIDER_URL", "127.0.0.1"),
+			"IDENTITY_PROVIDER_URL"),
+		updatesValuesWhen(not(observedKeySet("LDAP_RECURSIVE_SEARCH")),
+			"LDAP_RECURSIVE_SEARCH"),
+		updatesValuesWhen(not(observedKeySet("CLAIMS_SUPPORTED")),
+			"CLAIMS_SUPPORTED",
+			"CLAIMS_MAP",
+			"SCOPE_CLAIM",
+			"BOOTSTRAP_USERID"),
+		updatesValuesWhen(not(observedKeySet("PROVIDER_ISSUER_URL")),
+			"PROVIDER_ISSUER_URL"),
+		updatesValuesWhen(not(observedKeySet("PREFERRED_LOGIN")),
+			"PREFERRED_LOGIN"),
+		updatesValuesWhen(not(observedKeySet("DEFAULT_LOGIN")),
+			"DEFAULT_LOGIN"),
+		updatesValuesWhen(not(observedKeySet("DB_CONNECT_TIMEOUT")),
+			"DB_CONNECT_TIMEOUT",
+			"DB_IDLE_TIMEOUT",
+			"DB_CONNECT_MAX_RETRIES",
+			"DB_POOL_MIN_SIZE",
+			"DB_POOL_MAX_SIZE",
+			"SEQL_LOGGING"),
+		updatesValuesWhen(not(observedKeySet("DB_SSL_MODE")),
+			"DB_SSL_MODE"),
+		updatesValuesWhen(not(observedKeySet("SCIM_LDAP_ATTRIBUTES_MAPPING")),
+			"SCIM_LDAP_ATTRIBUTES_MAPPING",
+			"SCIM_LDAP_SEARCH_SIZE_LIMIT",
+			"SCIM_LDAP_SEARCH_TIME_LIMIT",
+			"SCIM_ASYNC_PARALLEL_LIMIT",
+			"SCIM_GET_DISPLAY_FOR_GROUP_USERS"),
+		updatesValuesWhen(not(observedKeySet("SCIM_AUTH_CACHE_MAX_SIZE")),
+			"SCIM_AUTH_CACHE_MAX_SIZE"),
+		updatesValuesWhen(not(observedKeySet("SCIM_AUTH_CACHE_TTL_VALUE")),
+			"SCIM_AUTH_CACHE_TTL_VALUE"),
+		updatesValuesWhen(not(observedKeySet("AUTH_SVC_LDAP_CONFIG_TIMEOUT")),
+			"AUTH_SVC_LDAP_CONFIG_TIMEOUT"),
+		updatesValuesWhen(not(observedKeySet("IBM_CLOUD_SAAS")),
+			"IBM_CLOUD_SAAS",
+			"SAAS_CLIENT_REDIRECT_URL"),
+		updatesValuesWhen(not(observedKeySet("ATTR_MAPPING_FROM_CONFIG")),
+			"ATTR_MAPPING_FROM_CONFIG"),
+		updatesValuesWhen(not(observedKeySet("LDAP_CTX_POOL_INITSIZE")),
+			"LDAP_CTX_POOL_INITSIZE",
+			"LDAP_CTX_POOL_MAXSIZE",
+			"LDAP_CTX_POOL_TIMEOUT",
+			"LDAP_CTX_POOL_WAITTIME",
+			"LDAP_CTX_POOL_PREFERREDSIZE"),
+	}
+
+	if v, ok := generated.Data["ROKS_URL"]; ok {
+		updateFns = append(updateFns, updatesValuesWhen(
+			not(observedKeyValueSetTo("ROKS_URL", v)), "ROKS_URL"))
+	}
+	if v, ok := generated.Data["IS_OPENSHIFT_ENV"]; ok {
+		updateFns = append(updateFns, updatesValuesWhen(
+			not(observedKeyValueSetTo("IS_OPENSHIFT_ENV", v)), "IS_OPENSHIFT_ENV"))
+	}
+
+	for _, update := range updateFns {
+		updated = update(observed, generated) || updated
+	}
+
+	return
 }
 
 type registrationJSONData struct {
@@ -502,32 +433,55 @@ type registrationJSONData struct {
 	RedirectURIs            []string `json:"redirect_uris"`
 }
 
-func (r *AuthenticationReconciler) authIdpConfigMap(instance *operatorv1alpha1.Authentication, scheme *runtime.Scheme) *corev1.ConfigMap {
-	reqLogger := log.WithValues("Instance.Namespace", instance.Namespace, "Instance.Name", instance.Name)
-	isPublicCloud := isPublicCloud(r.Client, instance.Namespace, "ibmcloud-cluster-info")
-	bootStrapUserId := instance.Spec.Config.BootstrapUserId
-	roksUserPrefix := instance.Spec.Config.ROKSUserPrefix
-	if len(bootStrapUserId) > 0 && strings.EqualFold(bootStrapUserId, "kubeadmin") && isPublicCloud {
+func generateAuthIdpConfigMap(ctx context.Context, cl client.Client, authCR *operatorv1alpha1.Authentication, ibmcloudClusterInfo, generated *corev1.ConfigMap) (err error) {
+	reqLogger := logf.FromContext(ctx)
+	onIBMCloud, _ := isHostedOnIBMCloud(ctx, cl, authCR.Namespace)
+
+	bootStrapUserId := authCR.Spec.Config.BootstrapUserId
+	if len(bootStrapUserId) > 0 && strings.EqualFold(bootStrapUserId, "kubeadmin") && onIBMCloud {
 		bootStrapUserId = ""
 	}
-	if isPublicCloud {
+
+	roksUserPrefix := authCR.Spec.Config.ROKSUserPrefix
+	if onIBMCloud || (authCR.Spec.Config.ROKSEnabled && roksUserPrefix == "changeme") {
 		roksUserPrefix = "IAM#"
 	}
-	newConfigMap := &corev1.ConfigMap{
+
+	var desiredRoksUrl string
+	if authCR.Spec.Config.ROKSEnabled {
+		if desiredRoksUrl, err = readROKSURL(ctx); err != nil {
+			reqLogger.Error(err, "Failed to get issuer URL")
+			return
+		} else if len(desiredRoksUrl) == 0 {
+			reqLogger.Error(err, "Failed to get issuer URL")
+			err = fmt.Errorf("issuer URL is empty")
+			return
+		}
+	}
+
+	var isOSEnv bool
+	if domainName, err := getCNCFDomain(ctx, cl, authCR); err != nil {
+		reqLogger.Info("Could not retrieve cluster configuration; requeueing", "reason", err.Error())
+		return err
+	} else {
+		isOSEnv = domainName == ""
+	}
+
+	*generated = corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "platform-auth-idp",
-			Namespace: instance.Namespace,
+			Namespace: authCR.Namespace,
 			Labels:    map[string]string{"app": "platform-auth-service"},
 		},
 		Data: map[string]string{
 			"BASE_AUTH_URL":                      "/v1",
 			"BASE_OIDC_URL":                      "https://platform-auth-service:9443/oidc/endpoint/OP",
-			"CLUSTER_NAME":                       instance.Spec.Config.ClusterName,
+			"CLUSTER_NAME":                       authCR.Spec.Config.ClusterName,
 			"HTTP_ONLY":                          "false",
 			"IDENTITY_AUTH_DIRECTORY_URL":        "https://platform-auth-service:3100",
 			"IDENTITY_PROVIDER_URL":              "https://platform-identity-provider:4300",
 			"IDENTITY_MGMT_URL":                  "https://platform-identity-management:4500",
-			"MASTER_HOST":                        instance.Spec.Config.ClusterCADomain,
+			"MASTER_HOST":                        authCR.Spec.Config.ClusterCADomain,
 			"NODE_ENV":                           "production",
 			"AUDIT_ENABLED_IDPROVIDER":           "false",
 			"AUDIT_ENABLED_IDMGMT":               "false",
@@ -538,23 +492,23 @@ func (r *AuthenticationReconciler) authIdpConfigMap(instance *operatorv1alpha1.A
 			"LOG_LEVEL_MW":                       "info",
 			"IDTOKEN_LIFETIME":                   "12h",
 			"SESSION_TIMEOUT":                    "43200",
-			"OIDC_ISSUER_URL":                    instance.Spec.Config.OIDCIssuerURL,
+			"OIDC_ISSUER_URL":                    authCR.Spec.Config.OIDCIssuerURL,
 			"PDP_REDIS_CACHE_DEFAULT_TTL":        "600",
-			"FIPS_ENABLED":                       strconv.FormatBool(instance.Spec.Config.FIPSEnabled),
-			"NONCE_ENABLED":                      strconv.FormatBool(instance.Spec.Config.NONCEEnabled),
-			"ROKS_ENABLED":                       strconv.FormatBool(instance.Spec.Config.ROKSEnabled),
-			"IBM_CLOUD_SAAS":                     strconv.FormatBool(instance.Spec.Config.IBMCloudSaas),
-			"ATTR_MAPPING_FROM_CONFIG":           strconv.FormatBool(instance.Spec.Config.AttrMappingFromConfig),
-			"SAAS_CLIENT_REDIRECT_URL":           instance.Spec.Config.SaasClientRedirectUrl,
-			"ROKS_URL":                           instance.Spec.Config.ROKSURL,
+			"FIPS_ENABLED":                       strconv.FormatBool(authCR.Spec.Config.FIPSEnabled),
+			"NONCE_ENABLED":                      strconv.FormatBool(authCR.Spec.Config.NONCEEnabled),
+			"ROKS_ENABLED":                       strconv.FormatBool(authCR.Spec.Config.ROKSEnabled),
+			"IBM_CLOUD_SAAS":                     strconv.FormatBool(authCR.Spec.Config.IBMCloudSaas),
+			"ATTR_MAPPING_FROM_CONFIG":           strconv.FormatBool(authCR.Spec.Config.AttrMappingFromConfig),
+			"SAAS_CLIENT_REDIRECT_URL":           authCR.Spec.Config.SaasClientRedirectUrl,
+			"ROKS_URL":                           desiredRoksUrl,
 			"ROKS_USER_PREFIX":                   roksUserPrefix,
-			"CLAIMS_SUPPORTED":                   instance.Spec.Config.ClaimsSupported,
-			"CLAIMS_MAP":                         instance.Spec.Config.ClaimsMap,
-			"SCOPE_CLAIM":                        instance.Spec.Config.ScopeClaim,
+			"CLAIMS_SUPPORTED":                   authCR.Spec.Config.ClaimsSupported,
+			"CLAIMS_MAP":                         authCR.Spec.Config.ClaimsMap,
+			"SCOPE_CLAIM":                        authCR.Spec.Config.ScopeClaim,
 			"BOOTSTRAP_USERID":                   bootStrapUserId,
-			"PROVIDER_ISSUER_URL":                instance.Spec.Config.ProviderIssuerURL,
-			"PREFERRED_LOGIN":                    instance.Spec.Config.PreferredLogin,
-			"DEFAULT_LOGIN":                      instance.Spec.Config.DefaultLogin,
+			"PROVIDER_ISSUER_URL":                authCR.Spec.Config.ProviderIssuerURL,
+			"PREFERRED_LOGIN":                    authCR.Spec.Config.PreferredLogin,
+			"DEFAULT_LOGIN":                      authCR.Spec.Config.DefaultLogin,
 			"LIBERTY_TOKEN_LENGTH":               "1024",
 			"OS_TOKEN_LENGTH":                    "51",
 			"LIBERTY_DEBUG_ENABLED":              "false",
@@ -600,24 +554,26 @@ func (r *AuthenticationReconciler) authIdpConfigMap(instance *operatorv1alpha1.A
 			"SCIM_AUTH_CACHE_MAX_SIZE":           "1000",
 			"SCIM_AUTH_CACHE_TTL_VALUE":          "60",
 			"SCIM_LDAP_ATTRIBUTES_MAPPING":       scimLdapAttributesMapping,
+			"IS_OPENSHIFT_ENV":                   strconv.FormatBool(isOSEnv),
 		},
 	}
 
-	// Set Authentication instance as the owner and controller of the ConfigMap
-	err := controllerutil.SetControllerReference(instance, newConfigMap, scheme)
-	if err != nil {
+	// Set Authentication authCR as the owner and controller of the ConfigMap
+	if err = controllerutil.SetControllerReference(authCR, generated, cl.Scheme()); err != nil {
 		reqLogger.Error(err, "Failed to set owner for ConfigMap")
-		return nil
+		return
 	}
-	return newConfigMap
+
+	return
 }
 
-func registrationJsonConfigMap(instance *operatorv1alpha1.Authentication, wlpClientID string, wlpClientSecret string, icpConsoleURL string, scheme *runtime.Scheme) *corev1.ConfigMap {
-	reqLogger := log.WithValues("Instance.Namespace", instance.Namespace, "Instance.Name", instance.Name)
+func generateRegistrationJsonConfigMap(ctx context.Context, cl client.Client, authCR *operatorv1alpha1.Authentication, ibmcloudClusterInfo, generated *corev1.ConfigMap) (err error) {
+	reqLogger := logf.FromContext(ctx)
 
 	// Calculate the ICP Registration Console URI(s)
 	icpRegistrationConsoleURIs := []string{}
 	const apiRegistrationPath = "/auth/liberty/callback"
+	icpConsoleURL := ibmcloudClusterInfo.Data["cluster_address"]
 	icpRegistrationConsoleURIs = append(icpRegistrationConsoleURIs, strings.Join([]string{"https://", icpConsoleURL, apiRegistrationPath}, ""))
 	parseConsoleURL := strings.Split(icpConsoleURL, ":")
 	// If the console URI is using port 443, a copy of the URI without the port number needs to be included as well
@@ -626,27 +582,37 @@ func registrationJsonConfigMap(instance *operatorv1alpha1.Authentication, wlpCli
 		icpRegistrationConsoleURIs = append(icpRegistrationConsoleURIs, strings.Join([]string{"https://", parseConsoleURL[0], apiRegistrationPath}, ""))
 	}
 
+	platformOIDCCredentials := &corev1.Secret{}
+	objectKey := types.NamespacedName{Name: "platform-oidc-credentials", Namespace: authCR.Namespace}
+	if err = cl.Get(ctx, objectKey, platformOIDCCredentials); err != nil {
+		reqLogger.Error(err, "Failed to get Secret for registration-json update")
+		return
+	}
+
+	observedWLPClientID := string(platformOIDCCredentials.Data["WLP_CLIENT_ID"][:])
+	observedWLPClientSecret := string(platformOIDCCredentials.Data["WLP_CLIENT_SECRET"][:])
+
 	type tmpRegistrationJsonVals struct {
 		WLPClientID, WLPClientSecret, ICPConsoleURL string
 		ICPRegistrationConsoleURIs                  []string
 	}
 	vals := tmpRegistrationJsonVals{
-		wlpClientID,
-		wlpClientSecret,
-		icpConsoleURL,
-		icpRegistrationConsoleURIs,
+		WLPClientID:                observedWLPClientID,
+		WLPClientSecret:            observedWLPClientSecret,
+		ICPConsoleURL:              icpConsoleURL,
+		ICPRegistrationConsoleURIs: icpRegistrationConsoleURIs,
 	}
 	registrationJsonTpl := template.Must(template.New("registrationJson").Parse(registrationJson))
 	var registrationJsonBytes bytes.Buffer
-	if err := registrationJsonTpl.Execute(&registrationJsonBytes, vals); err != nil {
+	if err = registrationJsonTpl.Execute(&registrationJsonBytes, vals); err != nil {
 		reqLogger.Error(err, "Failed to execute registrationJson template")
-		return nil
+		return
 	}
 
-	newConfigMap := &corev1.ConfigMap{
+	*generated = corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "registration-json",
-			Namespace: instance.Namespace,
+			Namespace: authCR.Namespace,
 			Labels:    map[string]string{"app": "platform-auth-service"},
 		},
 		Data: map[string]string{
@@ -654,22 +620,19 @@ func registrationJsonConfigMap(instance *operatorv1alpha1.Authentication, wlpCli
 		},
 	}
 
-	// Set Authentication instance as the owner and controller of the ConfigMap
-	err := controllerutil.SetControllerReference(instance, newConfigMap, scheme)
-	if err != nil {
+	// Set Authentication authCR as the owner and controller of the ConfigMap
+	if err = controllerutil.SetControllerReference(authCR, generated, cl.Scheme()); err != nil {
 		reqLogger.Error(err, "Failed to set owner for ConfigMap")
-		return nil
 	}
-	return newConfigMap
+	return
 }
 
-func registrationScriptConfigMap(instance *operatorv1alpha1.Authentication, scheme *runtime.Scheme) *corev1.ConfigMap {
-
-	reqLogger := log.WithValues("Instance.Namespace", instance.Namespace, "Instance.Name", instance.Name)
-	newConfigMap := &corev1.ConfigMap{
+func generateRegistrationScriptConfigMap(ctx context.Context, cl client.Client, authCR *operatorv1alpha1.Authentication, ibmcloudClusterInfo, generated *corev1.ConfigMap) (err error) {
+	reqLogger := logf.FromContext(ctx).WithValues("ConfigMap.Namespace", authCR.Namespace, "ConfigMap.Name", "registration-script")
+	*generated = corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "registration-script",
-			Namespace: instance.Namespace,
+			Namespace: authCR.Namespace,
 			Labels:    map[string]string{"app": "platform-auth-service"},
 		},
 		Data: map[string]string{
@@ -677,45 +640,46 @@ func registrationScriptConfigMap(instance *operatorv1alpha1.Authentication, sche
 		},
 	}
 
-	// Set Authentication instance as the owner and controller of the ConfigMap
-	err := controllerutil.SetControllerReference(instance, newConfigMap, scheme)
-	if err != nil {
+	// Set Authentication authCR as the owner and controller of the ConfigMap
+	if err = controllerutil.SetControllerReference(authCR, generated, cl.Scheme()); err != nil {
 		reqLogger.Error(err, "Failed to set owner for ConfigMap")
-		return nil
 	}
-	return newConfigMap
+	return
 
 }
 
-func oauthClientConfigMap(instance *operatorv1alpha1.Authentication, icpConsoleURL string, icpProxyURL string, scheme *runtime.Scheme) *corev1.ConfigMap {
-
-	reqLogger := log.WithValues("Instance.Namespace", instance.Namespace, "Instance.Name", instance.Name)
-	newConfigMap := &corev1.ConfigMap{
+func generateOAuthClientConfigMap(ctx context.Context, cl client.Client, authCR *operatorv1alpha1.Authentication, ibmcloudClusterInfo, generated *corev1.ConfigMap) (err error) {
+	reqLogger := logf.FromContext(ctx).WithValues("ConfigMap.Namespace", authCR.Namespace, "ConfigMap.Name", "oauth-client-map")
+	icpConsoleURL := ibmcloudClusterInfo.Data["cluster_address"]
+	icpProxyURL := ibmcloudClusterInfo.Data["proxy_address"]
+	*generated = corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "oauth-client-map",
-			Namespace: instance.Namespace,
+			Namespace: authCR.Namespace,
 			Labels:    map[string]string{"app": "platform-auth-service"},
 		},
 		Data: map[string]string{
 			"MASTER_IP":         icpConsoleURL,
 			"PROXY_IP":          icpProxyURL,
 			"CLUSTER_CA_DOMAIN": icpConsoleURL,
-			"CLUSTER_NAME":      instance.Spec.Config.ClusterName,
+			"CLUSTER_NAME":      authCR.Spec.Config.ClusterName,
 		},
 	}
 
-	// Set Authentication instance as the owner and controller of the ConfigMap
-	err := controllerutil.SetControllerReference(instance, newConfigMap, scheme)
-	if err != nil {
+	// Set Authentication authCR as the owner and controller of the ConfigMap
+	if err = controllerutil.SetControllerReference(authCR, generated, cl.Scheme()); err != nil {
 		reqLogger.Error(err, "Failed to set owner for ConfigMap")
-		return nil
 	}
-	return newConfigMap
-
+	return
 }
-func (r *AuthenticationReconciler) ibmcloudClusterInfoConfigMap(client client.Client, instance *operatorv1alpha1.Authentication, isOSEnv bool, domainName string, scheme *runtime.Scheme) *corev1.ConfigMap {
 
-	reqLogger := log.WithValues("Instance.Namespace", instance.Namespace, "Instance.Name", instance.Name)
+func (r *AuthenticationReconciler) generateIBMCloudClusterInfoConfigMap(ctx context.Context, authCR *operatorv1alpha1.Authentication, generated *corev1.ConfigMap) (err error) {
+	reqLogger := log.WithValues("authCR.Namespace", authCR.Namespace, "authCR.Name", authCR.Name)
+	var domainName string
+	if domainName, err = getCNCFDomain(ctx, r.Client, authCR); err != nil {
+		reqLogger.Info("Could not retrieve cluster configuration; requeueing", "reason", err.Error())
+		return
+	}
 
 	rhttpPort := os.Getenv("ROUTE_HTTP_PORT")
 	if rhttpPort == "" {
@@ -730,16 +694,16 @@ func (r *AuthenticationReconciler) ibmcloudClusterInfoConfigMap(client client.Cl
 		cname = ClusterNameValue
 	}
 	// if the env identified as CNCF
-	if !isOSEnv {
+	if domainName != "" {
 		reqLogger.Info("Env type is CNCF")
 
-		ClusterAddress := strings.Join([]string{strings.Join([]string{"cp-console", instance.Namespace}, "-"), domainName}, ".")
+		ClusterAddress := strings.Join([]string{strings.Join([]string{"cp-console", authCR.Namespace}, "-"), domainName}, ".")
 		ep := "https://" + ClusterAddress
 
-		newConfigMap := &corev1.ConfigMap{
+		*generated = corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "ibmcloud-cluster-info",
-				Namespace: instance.Namespace,
+				Name:      ctrlcommon.IBMCloudClusterInfoCMName,
+				Namespace: authCR.Namespace,
 				Labels:    map[string]string{"app": "auth-idp"},
 			},
 			Data: map[string]string{
@@ -749,136 +713,113 @@ func (r *AuthenticationReconciler) ibmcloudClusterInfoConfigMap(client client.Cl
 				RouteHTTPSPort: rhttpsPort,
 				ClusterName:    cname,
 				ProxyAddress:   ClusterAddress,
-				ProviderSVC:    "https://platform-identity-provider" + "." + instance.Namespace + ".svc:4300",
-				IDMgmtSVC:      "https://platform-identity-management" + "." + instance.Namespace + ".svc:4500",
+				ProviderSVC:    fmt.Sprintf("https://platform-identity-provider.%s.svc:4300", authCR.Namespace),
+				IDMgmtSVC:      fmt.Sprintf("https://platform-identity-management.%s.svc:4500", authCR.Namespace),
 			},
 		}
 
-		// Set Authentication instance as the owner and controller of the ConfigMap
-		err := controllerutil.SetControllerReference(instance, newConfigMap, scheme)
+		// Set Authentication authCR as the owner and controller of the ConfigMap
+		err = controllerutil.SetControllerReference(authCR, generated, r.Client.Scheme())
 		if err != nil {
 			reqLogger.Error(err, "Failed to set owner for ConfigMap")
-			return nil
 		}
-		return newConfigMap
-
-	} else if isOSEnv { // if the env identified as OCP
-
-		reqLogger.Info("Env Type is OCP")
-		// get domain name from ingresses.config/cluster from openshift-ingress-operator ns
-		var DomainName string
-		var ProxyDomainName string
-		ingressConfigName := "cluster"
-		ingressConfig := &osconfigv1.Ingress{}
-		clusterClient, err := createOrGetClusterClient(&r.DiscoveryClient)
-
-		if err != nil {
-			reqLogger.Error(err, "Failure creating or getting cluster client")
-		}
-
-		reqLogger.Info("Going to READ openshift ingress cluster config")
-		errGet := clusterClient.Get(context.TODO(), types.NamespacedName{Name: ingressConfigName}, ingressConfig)
-
-		if errGet == nil {
-			reqLogger.Info("Successfully READ openshift ingress cluster config")
-			appsDomain := ingressConfig.Spec.AppsDomain
-			if len(appsDomain) > 0 {
-				reqLogger.Info("appsDomain has been configured", "appsDomain.value", appsDomain)
-
-				if instance.Spec.Config.OnPremMultipleDeploy {
-					multipleInstanceRouteName := strings.Join([]string{"cp-console", instance.Namespace}, "-")
-					DomainName = strings.Join([]string{multipleInstanceRouteName, appsDomain}, ".")
-					multipleInstanceProxyRouteName := strings.Join([]string{"cp-proxy", instance.Namespace}, "-")
-					ProxyDomainName = strings.Join([]string{multipleInstanceProxyRouteName, appsDomain}, ".")
-				} else {
-					DomainName = strings.Join([]string{"cp-console", appsDomain}, ".")
-					ProxyDomainName = strings.Join([]string{"cp-proxy", appsDomain}, ".")
-				}
-			} else {
-				ingressDomain := ingressConfig.Spec.Domain
-				reqLogger.Info("appsDomain is not configured , going to fetch default domain", "ingressDomain.value", ingressDomain)
-				if instance.Spec.Config.OnPremMultipleDeploy {
-					multipleInstanceRouteName := strings.Join([]string{"cp-console", instance.Namespace}, "-")
-					DomainName = strings.Join([]string{multipleInstanceRouteName, ingressDomain}, ".")
-					multipleInstanceProxyRouteName := strings.Join([]string{"cp-proxy", instance.Namespace}, "-")
-					ProxyDomainName = strings.Join([]string{multipleInstanceProxyRouteName, ingressDomain}, ".")
-				} else {
-					DomainName = strings.Join([]string{"cp-console", ingressDomain}, ".")
-					ProxyDomainName = strings.Join([]string{"cp-proxy", ingressDomain}, ".")
-				}
-			}
-		} else {
-			if !errors.IsNotFound(errGet) {
-				reqLogger.Error(errGet, "Failed to READ openshift ingress cluster config")
-			}
-		}
-
-		// get clusterApiServer Details cm console-config from openshift-console ns
-		OSconsoleConfigMap := &corev1.ConfigMap{}
-
-		err = clusterClient.Get(context.TODO(), types.NamespacedName{Name: "console-config", Namespace: "openshift-console"}, OSconsoleConfigMap)
-
-		if err != nil {
-			reqLogger.Error(err, "Failed to get console-config configmap from openshift-console namespace")
-			return nil
-		}
-
-		var result map[interface{}]interface{}
-		var apiaddr string
-		if err := yaml.Unmarshal([]byte(OSconsoleConfigMap.Data["console-config.yaml"]), &result); err != nil {
-			reqLogger.Error(err, "Failed to read console-config.yaml from console-config configmap")
-			return nil
-		}
-
-		for k, v := range result {
-			if k.(string) == "clusterInfo" {
-				cinfo := v.(map[interface{}]interface{})
-				for k1, v1 := range cinfo {
-					if k1.(string) == "masterPublicURL" {
-						apiaddr = v1.(string)
-						apiaddr = strings.TrimPrefix(apiaddr, "https://")
-						break
-					}
-				}
-				break
-			}
-		}
-
-		pos := strings.LastIndex(apiaddr, ":")
-
-		newConfigMap := &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "ibmcloud-cluster-info",
-				Namespace: instance.Namespace,
-				Labels:    map[string]string{"app": "auth-idp"},
-			},
-			Data: map[string]string{
-				ClusterAddr:          DomainName,
-				ClusterEP:            "https://" + DomainName,
-				RouteHTTPPort:        rhttpPort,
-				RouteHTTPSPort:       rhttpsPort,
-				ClusterName:          cname,
-				ClusterAPIServerHost: apiaddr[0:pos],
-				ClusterAPIServerPort: apiaddr[pos+1:],
-				ProxyAddress:         ProxyDomainName,
-				ProviderSVC:          "https://platform-identity-provider" + "." + instance.Namespace + ".svc:4300",
-				IDMgmtSVC:            "https://platform-identity-management" + "." + instance.Namespace + ".svc:4500",
-			},
-		}
-
-		// Set Authentication instance as the owner and controller of the ConfigMap
-		errset := controllerutil.SetControllerReference(instance, newConfigMap, scheme)
-
-		if errset != nil {
-			reqLogger.Error(err, "Failed to set owner for ConfigMap")
-			return nil
-		}
-		return newConfigMap
+		return
 	}
 
-	reqLogger.Info("Failed to create ibmcloudClusterInfoConfigMap , can't determine the env type")
-	return nil
+	reqLogger.Info("Env Type is OCP")
+	// get domain name from ingresses.config/cluster from openshift-ingress-operator ns
+	var DomainName string
+	var ProxyDomainName string
+	ingressConfigName := "cluster"
+	ingressConfig := &osconfigv1.Ingress{}
 
+	clusterClient, err := r.createOrGetClusterClient()
+	if err != nil {
+		reqLogger.Error(err, "Failure creating or getting cluster client")
+		return
+	}
+
+	reqLogger.Info("Going to READ openshift ingress cluster config")
+	if err = clusterClient.Get(ctx, types.NamespacedName{Name: ingressConfigName}, ingressConfig); err != nil {
+		reqLogger.Error(err, "Failed to READ openshift ingress cluster config")
+		return
+	}
+
+	reqLogger.Info("Successfully READ openshift ingress cluster config")
+
+	var baseDomain string
+	multipleauthCRRouteName := strings.Join([]string{"cp-console", authCR.Namespace}, "-")
+	multipleauthCRProxyRouteName := strings.Join([]string{"cp-proxy", authCR.Namespace}, "-")
+	if len(ingressConfig.Spec.AppsDomain) > 0 {
+		baseDomain = ingressConfig.Spec.AppsDomain
+	} else {
+		baseDomain = ingressConfig.Spec.Domain
+	}
+	if authCR.Spec.Config.OnPremMultipleDeploy {
+		DomainName = strings.Join([]string{multipleauthCRRouteName, baseDomain}, ".")
+		ProxyDomainName = strings.Join([]string{multipleauthCRProxyRouteName, baseDomain}, ".")
+	} else {
+		DomainName = strings.Join([]string{"cp-console", baseDomain}, ".")
+		ProxyDomainName = strings.Join([]string{"cp-proxy", baseDomain}, ".")
+	}
+
+	// get clusterApiServer Details cm console-config from openshift-console ns
+	OSconsoleConfigMap := &corev1.ConfigMap{}
+	OSConsoleCMKey := types.NamespacedName{Name: "console-config", Namespace: "openshift-console"}
+	if err = clusterClient.Get(ctx, OSConsoleCMKey, OSconsoleConfigMap); err != nil {
+		reqLogger.Error(err, "Failed to get console-config configmap from openshift-console namespace")
+		return nil
+	}
+
+	var result map[interface{}]interface{}
+	var apiaddr string
+	if err := yaml.Unmarshal([]byte(OSconsoleConfigMap.Data["console-config.yaml"]), &result); err != nil {
+		reqLogger.Error(err, "Failed to read console-config.yaml from console-config configmap")
+		return nil
+	}
+
+	for k, v := range result {
+		if k.(string) == "clusterInfo" {
+			cinfo := v.(map[interface{}]interface{})
+			for k1, v1 := range cinfo {
+				if k1.(string) == "masterPublicURL" {
+					apiaddr = v1.(string)
+					apiaddr = strings.TrimPrefix(apiaddr, "https://")
+					break
+				}
+			}
+			break
+		}
+	}
+
+	pos := strings.LastIndex(apiaddr, ":")
+
+	*generated = corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ctrlcommon.IBMCloudClusterInfoCMName,
+			Namespace: authCR.Namespace,
+			Labels:    map[string]string{"app": "auth-idp"},
+		},
+		Data: map[string]string{
+			ClusterAddr:          DomainName,
+			ClusterEP:            "https://" + DomainName,
+			RouteHTTPPort:        rhttpPort,
+			RouteHTTPSPort:       rhttpsPort,
+			ClusterName:          cname,
+			ClusterAPIServerHost: apiaddr[0:pos],
+			ClusterAPIServerPort: apiaddr[pos+1:],
+			ProxyAddress:         ProxyDomainName,
+			ProviderSVC:          fmt.Sprintf("https://platform-identity-provider.%s.svc:4300", authCR.Namespace),
+			IDMgmtSVC:            fmt.Sprintf("https://platform-identity-management.%s.svc:4500", authCR.Namespace),
+		},
+	}
+
+	// Set Authentication authCR as the owner and controller of the ConfigMap
+	if err = controllerutil.SetControllerReference(authCR, generated, r.Scheme); err != nil {
+		reqLogger.Error(err, "Failed to set owner for ConfigMap")
+	}
+
+	return
 }
 
 var (
@@ -888,7 +829,7 @@ var (
 	ConfigSchemeGroupVersion    = schema.GroupVersion{Group: "config.openshift.io", Version: "v1"}
 )
 
-func createOrGetClusterClient(dc *discovery.DiscoveryClient) (client.Client, error) {
+func (r *AuthenticationReconciler) createOrGetClusterClient() (client.Client, error) {
 	// return if cluster client already exists
 	if clusterClient != nil {
 		return clusterClient, nil
@@ -899,7 +840,7 @@ func createOrGetClusterClient(dc *discovery.DiscoveryClient) (client.Client, err
 		return nil, err
 	}
 
-	if ctrlCommon.ClusterHasRouteGroupVersion(dc) {
+	if ctrlcommon.ClusterHasRouteGroupVersion(&r.DiscoveryClient) {
 		utilruntime.Must(osconfigv1.AddToScheme(OpenShiftConfigScheme))
 	}
 	utilruntime.Must(corev1.AddToScheme(OpenShiftConfigScheme))
@@ -912,69 +853,66 @@ func createOrGetClusterClient(dc *discovery.DiscoveryClient) (client.Client, err
 	return clusterClient, nil
 }
 
-// Check if hosted on IBM Cloud
-func isPublicCloud(client client.Client, namespace string, configMap string) bool {
-	currentConfigMap := &corev1.ConfigMap{}
-	err := client.Get(context.TODO(), types.NamespacedName{Name: configMap, Namespace: namespace}, currentConfigMap)
-	if err != nil {
-		log.Info("Error getting configmap", configMap)
-		return false
-	} else if err == nil {
-		host := currentConfigMap.Data["cluster_kube_apiserver_host"]
-		return strings.HasSuffix(host, "cloud.ibm.com")
+// isHostedOnIBMCloud checks the
+func isHostedOnIBMCloud(ctx context.Context, cl client.Client, namespace string) (isPublicCloud bool, err error) {
+	reqLogger := logf.FromContext(ctx).V(1)
+	cmName := ctrlcommon.IBMCloudClusterInfoCMName
+	cm := &corev1.ConfigMap{}
+	if err = cl.Get(ctx, types.NamespacedName{Name: cmName, Namespace: namespace}, cm); err != nil {
+		reqLogger.Info("Error getting ConfigMap", "ConfigMap.Name", cmName, "ConfigMap.Namespace", namespace, "msg", err.Error())
+		return
 	}
-	return false
+	host := cm.Data["cluster_kube_apiserver_host"]
+	return strings.HasSuffix(host, "cloud.ibm.com"), nil
 }
 
-func readROKSURL(instance *operatorv1alpha1.Authentication) (string, error) {
-	reqLogger := log.WithValues("Instance.Namespace", instance.Namespace, "Instance.Name", instance.Name)
+func readROKSURL(ctx context.Context) (issuer string, err error) {
+	reqLogger := logf.FromContext(ctx).V(1)
+
 	wellknownURL := "https://kubernetes.default:443/.well-known/oauth-authorization-server"
 	tokenFile := "/var/run/secrets/kubernetes.io/serviceaccount/token"
-	caCert, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt")
-	if err != nil {
-		reqLogger.Error(err, "Failed to read ca cert", "ConfigMap.Namespace", instance.Namespace, "ConfigMap.Name")
+	var caCert []byte
+	if caCert, err = os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"); err != nil {
+		reqLogger.Error(err, "Failed to read ca cert")
 		return "", err
 	}
+
 	caCertPool := x509.NewCertPool()
 	caCertPool.AppendCertsFromPEM(caCert)
-	content, err := ioutil.ReadFile(tokenFile)
-	if err != nil {
-		reqLogger.Error(err, "Failed to read default token", "ConfigMap.Namespace", instance.Namespace, "ConfigMap.Name")
-		return "", err
+	var content []byte
+	if content, err = os.ReadFile(tokenFile); err != nil {
+		reqLogger.Info("Failed to read default token", "msg", err.Error())
+		return
 	}
+
 	token := string(content)
 	transport := &http.Transport{TLSClientConfig: &tls.Config{RootCAs: caCertPool}}
-	req, err := http.NewRequest("GET", wellknownURL, nil)
-	if err != nil {
-		reqLogger.Error(err, "Failed to get well known URL", "ConfigMap.Namespace", instance.Namespace, "ConfigMap.Name")
-		return "", err
+	var req *http.Request
+	if req, err = http.NewRequest("GET", wellknownURL, nil); err != nil {
+		reqLogger.Info("Failed to get well known URL", "msg", err.Error())
+		return
 	}
+
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
 	client := &http.Client{Transport: transport}
-	response, err := client.Do(req)
+	var response *http.Response
+	if response, err = client.Do(req); err != nil {
+		reqLogger.Info("Failed to get OpenShift server URL", err.Error())
+		return
+	}
 
-	if err != nil {
-		reqLogger.Error(err, "Failed to get OpenShift server URL", "ConfigMap.Namespace", instance.Namespace, "ConfigMap.Name")
-		return "", err
+	if response.Status != "200 OK" {
+		reqLogger.Info("Response status is not ok", "status", response.Status)
+		return "", fmt.Errorf("response status is not 200 OK")
 	}
-	var issuer string
-	if response.Status == "200 OK" {
-		defer response.Body.Close()
-		body, err1 := ioutil.ReadAll(response.Body)
-		if err1 != nil {
-			reqLogger.Error(err, "Failed to readAll", "ConfigMap.Namespace", instance.Namespace, "ConfigMap.Name")
-			return "", err1
-		}
-		var result map[string]interface{}
-		err = json.Unmarshal(body, &result)
-		if err != nil {
-			reqLogger.Error(err, "Failed to unmarshal", "ConfigMap.Namespace", instance.Namespace, "ConfigMap.Name")
-			return "", err
-		}
-		issuer = result["issuer"].(string)
-	} else {
-		reqLogger.Error(err, "Response status is not ok:"+response.Status, "ConfigMap.Namespace", instance.Namespace, "ConfigMap.Name")
-		return "", err
+
+	defer response.Body.Close()
+	var result map[string]interface{}
+	if err = json.NewDecoder(response.Body).Decode(&result); err != nil {
+		reqLogger.Error(err, "Failed to read body from response")
+		return
 	}
+	issuer = result["issuer"].(string)
+
 	return issuer, nil
 }

--- a/controllers/operator/configmap_test.go
+++ b/controllers/operator/configmap_test.go
@@ -1,0 +1,777 @@
+package operator
+
+import (
+	"context"
+	"strconv"
+
+	operatorv1alpha1 "github.com/IBM/ibm-iam-operator/apis/operator/v1alpha1"
+	testutil "github.com/IBM/ibm-iam-operator/testing"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/discovery"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var _ = Describe("ConfigMap handling", func() {
+
+	Describe("how controller determines whether it is configured for CNCF", func() {
+		var r *AuthenticationReconciler
+		var authCR *operatorv1alpha1.Authentication
+		var cb fakeclient.ClientBuilder
+		var cl client.WithWatch
+		var scheme *runtime.Scheme
+		var ctx context.Context
+		var globalConfigMap *corev1.ConfigMap
+		BeforeEach(func() {
+			authCR = &operatorv1alpha1.Authentication{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "operator.ibm.com/v1alpha1",
+					Kind:       "Authentication",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "example-authentication",
+					Namespace:       "data-ns",
+					ResourceVersion: trackerAddResourceVersion,
+				},
+			}
+			globalConfigMap = &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ibm-cpp-config",
+					Namespace: "data-ns",
+				},
+				Data: map[string]string{
+					"kubernetes_cluster_type": "cncf",
+					"domain_name":             "example.ibm.com",
+				},
+			}
+			scheme = runtime.NewScheme()
+			Expect(corev1.AddToScheme(scheme)).To(Succeed())
+			Expect(operatorv1alpha1.AddToScheme(scheme)).To(Succeed())
+			cb = *fakeclient.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(globalConfigMap, authCR)
+			cl = cb.Build()
+			dc, err := discovery.NewDiscoveryClientForConfig(cfg)
+			Expect(err).NotTo(HaveOccurred())
+
+			r = &AuthenticationReconciler{
+				Client:          cl,
+				DiscoveryClient: *dc,
+			}
+			ctx = context.Background()
+		})
+		It("retrieves the domain name when configured for CNCF", func() {
+			dn, err := getCNCFDomain(ctx, r.Client, authCR)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(dn).To(Equal("example.ibm.com"))
+		})
+		It("retrieves nothing when not configured for CNCF", func() {
+			globalConfigMap.Data["kubernetes_cluster_type"] = "other"
+			r.Update(ctx, globalConfigMap)
+			dn, err := getCNCFDomain(ctx, r.Client, authCR)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(dn).To(Equal(""))
+		})
+		It("produces an error when ibm-cpp-config does not have domain_name set", func() {
+			delete(globalConfigMap.Data, "domain_name")
+			r.Update(ctx, globalConfigMap)
+			dn, err := getCNCFDomain(ctx, r.Client, authCR)
+			Expect(err).To(HaveOccurred())
+			Expect(dn).To(Equal(""))
+			Expect(err.Error()).To(Equal("domain name not configured"))
+		})
+		It("produces an error when ibm-cpp-config isn't found", func() {
+			r.Delete(ctx, globalConfigMap)
+			dn, err := getCNCFDomain(ctx, r.Client, authCR)
+			Expect(dn).To(Equal(""))
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Describe("ibmcloud-cluster-info handling", func() {
+		var r *AuthenticationReconciler
+		var authCR *operatorv1alpha1.Authentication
+		var cb fakeclient.ClientBuilder
+		var cl client.WithWatch
+		var scheme *runtime.Scheme
+		var ctx context.Context
+		var globalConfigMap *corev1.ConfigMap
+		var ibmcloudClusterInfo *corev1.ConfigMap
+		BeforeEach(func() {
+			authCR = &operatorv1alpha1.Authentication{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "operator.ibm.com/v1alpha1",
+					Kind:       "Authentication",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "example-authentication",
+					Namespace:       "data-ns",
+					ResourceVersion: trackerAddResourceVersion,
+				},
+			}
+			globalConfigMap = &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ibm-cpp-config",
+					Namespace: "data-ns",
+				},
+				Data: map[string]string{
+					"kubernetes_cluster_type": "cncf",
+					"domain_name":             "example.ibm.com",
+				},
+			}
+			scheme = runtime.NewScheme()
+			Expect(corev1.AddToScheme(scheme)).To(Succeed())
+			Expect(operatorv1alpha1.AddToScheme(scheme)).To(Succeed())
+			cb = *fakeclient.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(globalConfigMap, authCR)
+			cl = cb.Build()
+			dc, err := discovery.NewDiscoveryClientForConfig(cfg)
+			Expect(err).NotTo(HaveOccurred())
+
+			r = &AuthenticationReconciler{
+				Client:          cl,
+				DiscoveryClient: *dc,
+			}
+			ctx = context.Background()
+			ibmcloudClusterInfo = &corev1.ConfigMap{}
+		})
+		It("creates ibmcloud-cluster-info when it is not already present in services namespace", func() {
+			result, err := r.handleIBMCloudClusterInfo(ctx, authCR, ibmcloudClusterInfo)
+			cmKey := types.NamespacedName{Name: "ibmcloud-cluster-info", Namespace: "data-ns"}
+			testutil.ConfirmThatItRequeuesWithDelay(result, err, defaultLowerWait)
+			observed := &corev1.ConfigMap{}
+			err = r.Get(ctx, cmKey, observed)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(observed).ToNot(BeNil())
+		})
+		It("does not require a requeue or perform updates when observed state is the same as calculated state", func() {
+			ibmcloudClusterInfo = &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ibmcloud-cluster-info",
+					Namespace: "data-ns",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion:         "operator.ibm.com/v1alpha1",
+							Kind:               "Authentication",
+							Name:               "example-authentication",
+							Controller:         ptr.To[bool](true),
+							BlockOwnerDeletion: ptr.To[bool](true),
+						},
+					},
+					Labels: map[string]string{
+						"app": "auth-idp",
+					},
+				},
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "ConfigMap",
+					APIVersion: "v1",
+				},
+				Data: map[string]string{
+					"im_idprovider_endpoint":    "https://platform-identity-provider.data-ns.svc:4300",
+					"proxy_address":             "cp-console-data-ns.example.ibm.com",
+					"cluster_address":           "cp-console-data-ns.example.ibm.com",
+					"cluster_endpoint":          "https://cp-console-data-ns.example.ibm.com",
+					"cluster_name":              "mycluster",
+					"cluster_router_http_port":  "80",
+					"cluster_router_https_port": "443",
+					"im_idmgmt_endpoint":        "https://platform-identity-management.data-ns.svc:4500",
+				},
+			}
+			Expect(r.Create(ctx, ibmcloudClusterInfo)).To(Succeed())
+			result, err := r.handleIBMCloudClusterInfo(ctx, authCR, ibmcloudClusterInfo)
+			cmKey := types.NamespacedName{Name: "ibmcloud-cluster-info", Namespace: "data-ns"}
+			testutil.ConfirmThatItContinuesReconciling(result, err)
+			observed := &corev1.ConfigMap{}
+			err = r.Get(ctx, cmKey, observed)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ibmcloudClusterInfo.Data).ToNot(BeNil())
+		})
+		It("produces an error when ibm-cpp-config does not have domain_name set", func() {
+			ibmcloudClusterInfo = &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ibmcloud-cluster-info",
+					Namespace: "data-ns",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion:         "operator.ibm.com/v1alpha1",
+							Kind:               "Authentication",
+							Name:               "example-authentication",
+							Controller:         ptr.To[bool](true),
+							BlockOwnerDeletion: ptr.To[bool](true),
+						},
+					},
+					Labels: map[string]string{
+						"app": "auth-idp",
+					},
+				},
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "ConfigMap",
+					APIVersion: "v1",
+				},
+				Data: map[string]string{
+					"im_idprovider_endpoint":    "https://platform-identity-provider.data-ns.svc:4300",
+					"proxy_address":             "cp-console-data-ns.example.ibm.com",
+					"cluster_address":           "cp-console-data-ns.example.ibm.com",
+					"cluster_endpoint":          "https://cp-console-data-ns.example.ibm.com",
+					"cluster_name":              "mycluster",
+					"cluster_router_http_port":  "80",
+					"cluster_router_https_port": "443",
+					"im_idmgmt_endpoint":        "https://platform-identity-management.data-ns.svc:4500",
+				},
+			}
+			Expect(r.Create(ctx, ibmcloudClusterInfo)).To(Succeed())
+			result, err := r.handleIBMCloudClusterInfo(ctx, authCR, ibmcloudClusterInfo)
+			cmKey := types.NamespacedName{Name: "ibmcloud-cluster-info", Namespace: "data-ns"}
+			testutil.ConfirmThatItContinuesReconciling(result, err)
+			observed := &corev1.ConfigMap{}
+			err = r.Get(ctx, cmKey, observed)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ibmcloudClusterInfo.Data).ToNot(BeNil())
+		})
+		It("only updates ibmcloud-cluster-info when ownership and labels do not match expected values", func() {
+			globalConfigMap.Data["domain_name"] = "example1.ibm.com"
+			Expect(r.Update(ctx, globalConfigMap)).To(Succeed())
+			ibmcloudClusterInfo = &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ibmcloud-cluster-info",
+					Namespace: "data-ns",
+				},
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "ConfigMap",
+					APIVersion: "v1",
+				},
+				Data: map[string]string{
+					"im_idprovider_endpoint":    "https://platform-identity-provider.different-ns.svc:4300",
+					"proxy_address":             "cp-console-different-ns.example.ibm.com",
+					"cluster_address":           "cp-console-different-ns.example.ibm.com",
+					"cluster_endpoint":          "https://cp-console-different-ns.example.ibm.com",
+					"cluster_name":              "mycluster",
+					"cluster_router_http_port":  "80",
+					"cluster_router_https_port": "443",
+					"im_idmgmt_endpoint":        "https://platform-identity-management.different-ns.svc:4500",
+				},
+			}
+			Expect(r.Create(ctx, ibmcloudClusterInfo)).To(Succeed())
+			result, err := r.handleIBMCloudClusterInfo(ctx, authCR, ibmcloudClusterInfo)
+			cmKey := types.NamespacedName{Name: "ibmcloud-cluster-info", Namespace: "data-ns"}
+			testutil.ConfirmThatItRequeuesWithDelay(result, err, defaultLowerWait)
+			observed := &corev1.ConfigMap{}
+			err = r.Get(ctx, cmKey, observed)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(observed.Data).ToNot(BeNil())
+			Expect(observed.Labels).ToNot(BeNil())
+			Expect(observed.Labels["app"]).To(Equal("auth-idp"))
+			Expect(observed.OwnerReferences).ToNot(BeEmpty())
+			Expect(*observed.OwnerReferences[0].Controller).To(BeTrue())
+		})
+	})
+
+	Describe("platform-auth-idp handling", func() {
+		var r *AuthenticationReconciler
+		var authCR *operatorv1alpha1.Authentication
+		var cb fakeclient.ClientBuilder
+		var cl client.WithWatch
+		var scheme *runtime.Scheme
+		var ctx context.Context
+		var globalConfigMap *corev1.ConfigMap
+		var ibmcloudClusterInfo *corev1.ConfigMap
+		var updated bool
+		BeforeEach(func() {
+			authCR = &operatorv1alpha1.Authentication{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "operator.ibm.com/v1alpha1",
+					Kind:       "Authentication",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "example-authentication",
+					Namespace:       "data-ns",
+					ResourceVersion: trackerAddResourceVersion,
+				},
+				Spec: operatorv1alpha1.AuthenticationSpec{
+					Config: operatorv1alpha1.ConfigSpec{
+						ClusterName:           "mycluster",
+						ClusterCADomain:       "domain.example.com",
+						DefaultAdminUser:      "myadmin",
+						ZenFrontDoor:          true,
+						PreferredLogin:        "ldap",
+						ProviderIssuerURL:     "example.com",
+						ROKSURL:               "",
+						ROKSEnabled:           false,
+						FIPSEnabled:           true,
+						NONCEEnabled:          true,
+						OIDCIssuerURL:         "oidc.example.com",
+						SaasClientRedirectUrl: "saasclient.example.com",
+						ClaimsMap:             "someclaims",
+						ScopeClaim:            "scopeclaimexample",
+						IsOpenshiftEnv:        false,
+					},
+				},
+			}
+			globalConfigMap = &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ibm-cpp-config",
+					Namespace: "data-ns",
+				},
+				Data: map[string]string{
+					"kubernetes_cluster_type": "cncf",
+					"domain_name":             "example.ibm.com",
+				},
+			}
+			ibmcloudClusterInfo = &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ibmcloud-cluster-info",
+					Namespace: "data-ns",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion:         "operator.ibm.com/v1alpha1",
+							Kind:               "Authentication",
+							Name:               "example-authentication",
+							Controller:         ptr.To[bool](true),
+							BlockOwnerDeletion: ptr.To[bool](true),
+						},
+					},
+					Labels: map[string]string{
+						"app": "auth-idp",
+					},
+				},
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "ConfigMap",
+					APIVersion: "v1",
+				},
+				Data: map[string]string{
+					"im_idprovider_endpoint":    "https://platform-identity-provider.data-ns.svc:4300",
+					"proxy_address":             "cp-console-data-ns.example.ibm.com",
+					"cluster_address":           "cp-console-data-ns.example.ibm.com",
+					"cluster_endpoint":          "https://cp-console-data-ns.example.ibm.com",
+					"cluster_name":              "mycluster",
+					"cluster_router_http_port":  "80",
+					"cluster_router_https_port": "443",
+					"im_idmgmt_endpoint":        "https://platform-identity-management.data-ns.svc:4500",
+				},
+			}
+			scheme = runtime.NewScheme()
+			Expect(corev1.AddToScheme(scheme)).To(Succeed())
+			Expect(operatorv1alpha1.AddToScheme(scheme)).To(Succeed())
+			cb = *fakeclient.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(globalConfigMap, ibmcloudClusterInfo, authCR)
+			cl = cb.Build()
+			dc, err := discovery.NewDiscoveryClientForConfig(cfg)
+			Expect(err).NotTo(HaveOccurred())
+
+			r = &AuthenticationReconciler{
+				Client:          cl,
+				DiscoveryClient: *dc,
+			}
+			ctx = context.Background()
+		})
+
+		getObserved := func() *corev1.ConfigMap {
+			return &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "platform-auth-idp",
+					Namespace: "data-ns",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion:         "operator.ibm.com/v1alpha1",
+							Kind:               "Authentication",
+							Name:               "example-authentication",
+							Controller:         ptr.To[bool](true),
+							BlockOwnerDeletion: ptr.To[bool](true),
+						},
+					},
+					Labels: map[string]string{
+						"app": "auth-idp",
+					},
+				},
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "ConfigMap",
+					APIVersion: "v1",
+				},
+				Data: map[string]string{
+					// primary keys that affect updates of other keys
+					"DB_SSL_MODE":                  "require",
+					"SCIM_LDAP_ATTRIBUTES_MAPPING": scimLdapAttributesMapping,
+					"SCIM_AUTH_CACHE_MAX_SIZE":     "1000",
+					"SCIM_AUTH_CACHE_TTL_VALUE":    "60",
+					"AUTH_SVC_LDAP_CONFIG_TIMEOUT": "25",
+					"IBM_CLOUD_SAAS":               "false",
+					"ATTR_MAPPING_FROM_CONFIG":     "false",
+					"LDAP_CTX_POOL_INITSIZE":       "10",
+					"DB_CONNECT_TIMEOUT":           "60000",
+					"PREFERRED_LOGIN":              "ldap",
+					"PROVIDER_ISSUER_URL":          "example.com",
+					"CLAIMS_SUPPORTED":             "false",
+					"LDAP_RECURSIVE_SEARCH":        "true",
+					// the rest
+					"BASE_AUTH_URL":                      "/v1",
+					"BASE_OIDC_URL":                      "https://platform-auth-service:9443/oidc/endpoint/OP",
+					"CLUSTER_NAME":                       authCR.Spec.Config.ClusterName,
+					"HTTP_ONLY":                          "false",
+					"IDENTITY_AUTH_DIRECTORY_URL":        "https://platform-auth-service:3100",
+					"IDENTITY_PROVIDER_URL":              "https://platform-identity-provider:4300",
+					"IDENTITY_MGMT_URL":                  "https://platform-identity-management:4500",
+					"MASTER_HOST":                        authCR.Spec.Config.ClusterCADomain,
+					"NODE_ENV":                           "production",
+					"AUDIT_ENABLED_IDPROVIDER":           "false",
+					"AUDIT_ENABLED_IDMGMT":               "false",
+					"AUDIT_DETAIL":                       "false",
+					"LOG_LEVEL_IDPROVIDER":               "info",
+					"LOG_LEVEL_AUTHSVC":                  "info",
+					"LOG_LEVEL_IDMGMT":                   "info",
+					"LOG_LEVEL_MW":                       "info",
+					"IDTOKEN_LIFETIME":                   "12h",
+					"SESSION_TIMEOUT":                    "43200",
+					"OIDC_ISSUER_URL":                    authCR.Spec.Config.OIDCIssuerURL,
+					"PDP_REDIS_CACHE_DEFAULT_TTL":        "600",
+					"FIPS_ENABLED":                       strconv.FormatBool(authCR.Spec.Config.FIPSEnabled),
+					"NONCE_ENABLED":                      strconv.FormatBool(authCR.Spec.Config.NONCEEnabled),
+					"ROKS_ENABLED":                       strconv.FormatBool(authCR.Spec.Config.ROKSEnabled),
+					"SAAS_CLIENT_REDIRECT_URL":           authCR.Spec.Config.SaasClientRedirectUrl,
+					"ROKS_URL":                           "",
+					"ROKS_USER_PREFIX":                   "changeme",
+					"CLAIMS_MAP":                         authCR.Spec.Config.ClaimsMap,
+					"SCOPE_CLAIM":                        authCR.Spec.Config.ScopeClaim,
+					"BOOTSTRAP_USERID":                   "kubeadmin",
+					"LIBERTY_TOKEN_LENGTH":               "1024",
+					"OS_TOKEN_LENGTH":                    "51",
+					"LIBERTY_DEBUG_ENABLED":              "false",
+					"LOGJAM_DHKEYSIZE_2048_BITS_ENABLED": "true",
+					"LDAP_ATTR_CACHE_SIZE":               "2000",
+					"LDAP_ATTR_CACHE_TIMEOUT":            "1200s",
+					"LDAP_ATTR_CACHE_ENABLED":            "true",
+					"LDAP_ATTR_CACHE_SIZELIMIT":          "2000",
+					"LDAP_SEARCH_CACHE_SIZE":             "2000",
+					"LDAP_SEARCH_CACHE_TIMEOUT":          "1200s",
+					"LDAP_SEARCH_CACHE_ENABLED":          "true",
+					"LDAP_SEARCH_CACHE_SIZELIMIT":        "2000",
+					"IGNORE_LDAP_FILTERS_VALIDATION":     "false",
+					"LDAP_SEARCH_EXCLUDE_WILDCARD_CHARS": "false",
+					"LDAP_SEARCH_SIZE_LIMIT":             "50",
+					"LDAP_SEARCH_TIME_LIMIT":             "10",
+					"LDAP_SEARCH_CN_ATTR_ONLY":           "false",
+					"LDAP_SEARCH_ID_ATTR_ONLY":           "false",
+					"LDAP_CTX_POOL_MAXSIZE":              "50",
+					"LDAP_CTX_POOL_TIMEOUT":              "30s",
+					"LDAP_CTX_POOL_WAITTIME":             "60s",
+					"LDAP_CTX_POOL_PREFERREDSIZE":        "10",
+					"IBMID_CLIENT_ID":                    "d3c8d1cf59a77cf73df35b073dfc1dc8",
+					"IBMID_CLIENT_ISSUER":                "idaas.iam.ibm.com",
+					"IBMID_PROFILE_URL":                  "https://w3-dev.api.ibm.com/profilemgmt/test/ibmidprofileait/v2/users",
+					"IBMID_PROFILE_CLIENT_ID":            "1c36586c-cf48-4bce-9b9b-1a0480cc798b",
+					"IBMID_PROFILE_FIELDS":               "displayName,name,emails",
+					"SAML_NAMEID_FORMAT":                 "unspecified",
+					"DB_IDLE_TIMEOUT":                    "20000",
+					"DB_CONNECT_MAX_RETRIES":             "5",
+					"DB_POOL_MIN_SIZE":                   "5",
+					"DB_POOL_MAX_SIZE":                   "15",
+					"SEQL_LOGGING":                       "false",
+					"SCIM_LDAP_SEARCH_SIZE_LIMIT":        "4500",
+					"SCIM_LDAP_SEARCH_TIME_LIMIT":        "10",
+					"SCIM_ASYNC_PARALLEL_LIMIT":          "100",
+					"SCIM_GET_DISPLAY_FOR_GROUP_USERS":   "true",
+					"IS_OPENSHIFT_ENV":                   "false",
+				},
+			}
+		}
+
+		It("sets certain values when other values are not set", func() {
+			// Value used to confirm that certain values are overwritten
+
+			updateOnNotSetKeys := []struct {
+				primaryKey string
+				keys       []string
+			}{
+				{
+					"LDAP_RECURSIVE_SEARCH",
+					[]string{"LDAP_RECURSIVE_SEARCH"},
+				},
+				{
+					"CLAIMS_SUPPORTED",
+					[]string{
+						"CLAIMS_SUPPORTED",
+						"CLAIMS_MAP",
+						"SCOPE_CLAIM",
+						"BOOTSTRAP_USERID",
+					},
+				},
+				{
+					"PROVIDER_ISSUER_URL",
+					[]string{
+						"PROVIDER_ISSUER_URL",
+					},
+				},
+				{
+					"PREFERRED_LOGIN",
+					[]string{
+						"PREFERRED_LOGIN",
+					},
+				},
+				{
+					"DB_CONNECT_TIMEOUT",
+					[]string{
+						"DB_CONNECT_TIMEOUT",
+						"DB_IDLE_TIMEOUT",
+						"DB_CONNECT_MAX_RETRIES",
+						"DB_POOL_MIN_SIZE",
+						"DB_POOL_MAX_SIZE",
+						"SEQL_LOGGING",
+					},
+				},
+				{
+					"DB_SSL_MODE",
+					[]string{
+						"DB_SSL_MODE",
+					},
+				},
+				{
+					"SCIM_LDAP_ATTRIBUTES_MAPPING",
+					[]string{
+						"SCIM_LDAP_ATTRIBUTES_MAPPING",
+						"SCIM_LDAP_SEARCH_SIZE_LIMIT",
+						"SCIM_LDAP_SEARCH_TIME_LIMIT",
+						"SCIM_ASYNC_PARALLEL_LIMIT",
+						"SCIM_GET_DISPLAY_FOR_GROUP_USERS",
+					},
+				},
+				{
+					"SCIM_AUTH_CACHE_MAX_SIZE",
+					[]string{
+						"SCIM_AUTH_CACHE_MAX_SIZE",
+					},
+				},
+				{
+					"SCIM_AUTH_CACHE_TTL_VALUE",
+					[]string{
+						"SCIM_AUTH_CACHE_TTL_VALUE",
+					},
+				},
+				{
+					"AUTH_SVC_LDAP_CONFIG_TIMEOUT",
+					[]string{
+						"AUTH_SVC_LDAP_CONFIG_TIMEOUT",
+					},
+				},
+				{
+					"IBM_CLOUD_SAAS",
+					[]string{
+						"IBM_CLOUD_SAAS",
+						"SAAS_CLIENT_REDIRECT_URL",
+					},
+				},
+				{
+					"ATTR_MAPPING_FROM_CONFIG",
+					[]string{
+						"ATTR_MAPPING_FROM_CONFIG",
+					},
+				},
+				{
+					"LDAP_CTX_POOL_INITSIZE",
+					[]string{
+						"LDAP_CTX_POOL_INITSIZE",
+						"LDAP_CTX_POOL_MAXSIZE",
+						"LDAP_CTX_POOL_TIMEOUT",
+						"LDAP_CTX_POOL_WAITTIME",
+						"LDAP_CTX_POOL_PREFERREDSIZE",
+					},
+				},
+			}
+
+			setDummyData := func(pkey string, keys []string, o *corev1.ConfigMap) {
+				dummyValue := "dummy"
+				for _, k := range keys {
+					if k == pkey {
+						delete(o.Data, k)
+						continue
+					}
+					o.Data[k] = dummyValue
+				}
+			}
+
+			for _, test := range updateOnNotSetKeys {
+				observed := getObserved()
+				generated := &corev1.ConfigMap{}
+				err := generateAuthIdpConfigMap(ctx, r.Client, authCR, ibmcloudClusterInfo, generated)
+				Expect(err).NotTo(HaveOccurred())
+				updated, err = updatePlatformAuthIDP(observed, generated)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(updated).To(BeFalse())
+				setDummyData(test.primaryKey, test.keys, observed)
+				updated, err = updatePlatformAuthIDP(observed, generated)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(updated).To(BeTrue())
+				for _, k := range test.keys {
+					Expect(observed.Data[k]).To(Equal(generated.Data[k]))
+				}
+			}
+		})
+
+		It("replaces fields using 127.0.0.1 with the Service domain", func() {
+			updateWhenLocalhostUsed := []string{
+				"IDENTITY_MGMT_URL",
+				"BASE_OIDC_URL",
+				"IDENTITY_AUTH_DIRECTORY_URL",
+				"IDENTITY_PROVIDER_URL",
+			}
+
+			for _, k := range updateWhenLocalhostUsed {
+				observed := getObserved()
+				// Set the keys in observed to contain localhost IP
+				observed.Data[k] = "https://127.0.0.1:12345"
+				generated := &corev1.ConfigMap{}
+				Expect(generateAuthIdpConfigMap(ctx, r.Client, authCR, ibmcloudClusterInfo, generated)).
+					To(Succeed())
+				updated, err := updatePlatformAuthIDP(observed, generated)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(updated).To(BeTrue())
+				Expect(observed.Data[k]).To(Equal(generated.Data[k]))
+			}
+		})
+
+		It("replaces value in OS_TOKEN_LENGTH only when it is set to 45", func() {
+			observed := getObserved()
+			// Set the keys in observed to contain localhost IP
+			k := "OS_TOKEN_LENGTH"
+			observed.Data[k] = "24"
+			generated := &corev1.ConfigMap{}
+			Expect(generateAuthIdpConfigMap(ctx, r.Client, authCR, ibmcloudClusterInfo, generated)).
+				To(Succeed())
+			updated, err := updatePlatformAuthIDP(observed, generated)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(updated).To(BeFalse())
+			Expect(observed.Data[k]).NotTo(Equal(generated.Data[k]))
+			observed.Data[k] = "45"
+			updated, err = updatePlatformAuthIDP(observed, generated)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(updated).To(BeTrue())
+			Expect(observed.Data[k]).To(Equal(generated.Data[k]))
+		})
+	})
+
+	Describe("oauth-client-map handling", func() {
+		var r *AuthenticationReconciler
+		var authCR *operatorv1alpha1.Authentication
+		var cb fakeclient.ClientBuilder
+		var cl client.WithWatch
+		var scheme *runtime.Scheme
+		var ctx context.Context
+		var globalConfigMap *corev1.ConfigMap
+		var ibmcloudClusterInfo *corev1.ConfigMap
+		BeforeEach(func() {
+			authCR = &operatorv1alpha1.Authentication{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "operator.ibm.com/v1alpha1",
+					Kind:       "Authentication",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "example-authentication",
+					Namespace:       "data-ns",
+					ResourceVersion: trackerAddResourceVersion,
+				},
+				Spec: operatorv1alpha1.AuthenticationSpec{
+					Config: operatorv1alpha1.ConfigSpec{
+						ClusterName:           "mycluster",
+						ClusterCADomain:       "domain.example.com",
+						DefaultAdminUser:      "myadmin",
+						ZenFrontDoor:          true,
+						PreferredLogin:        "ldap",
+						ProviderIssuerURL:     "example.com",
+						ROKSURL:               "",
+						ROKSEnabled:           false,
+						FIPSEnabled:           true,
+						NONCEEnabled:          true,
+						OIDCIssuerURL:         "oidc.example.com",
+						SaasClientRedirectUrl: "saasclient.example.com",
+						ClaimsMap:             "someclaims",
+						ScopeClaim:            "scopeclaimexample",
+						IsOpenshiftEnv:        false,
+					},
+				},
+			}
+			globalConfigMap = &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ibm-cpp-config",
+					Namespace: "data-ns",
+				},
+				Data: map[string]string{
+					"kubernetes_cluster_type": "cncf",
+					"domain_name":             "example.ibm.com",
+				},
+			}
+			ibmcloudClusterInfo = &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ibmcloud-cluster-info",
+					Namespace: "data-ns",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion:         "operator.ibm.com/v1alpha1",
+							Kind:               "Authentication",
+							Name:               "example-authentication",
+							Controller:         ptr.To[bool](true),
+							BlockOwnerDeletion: ptr.To[bool](true),
+						},
+					},
+					Labels: map[string]string{
+						"app": "auth-idp",
+					},
+				},
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "ConfigMap",
+					APIVersion: "v1",
+				},
+				Data: map[string]string{
+					"im_idprovider_endpoint":    "https://platform-identity-provider.data-ns.svc:4300",
+					"proxy_address":             "cp-console-data-ns.example.ibm.com",
+					"cluster_address":           "cp-console-data-ns.example.ibm.com",
+					"cluster_endpoint":          "https://cp-console-data-ns.example.ibm.com",
+					"cluster_name":              "mycluster",
+					"cluster_router_http_port":  "80",
+					"cluster_router_https_port": "443",
+					"im_idmgmt_endpoint":        "https://platform-identity-management.data-ns.svc:4500",
+				},
+			}
+			scheme = runtime.NewScheme()
+			Expect(corev1.AddToScheme(scheme)).To(Succeed())
+			Expect(operatorv1alpha1.AddToScheme(scheme)).To(Succeed())
+			cb = *fakeclient.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(globalConfigMap, ibmcloudClusterInfo, authCR)
+			cl = cb.Build()
+			dc, err := discovery.NewDiscoveryClientForConfig(cfg)
+			Expect(err).NotTo(HaveOccurred())
+
+			r = &AuthenticationReconciler{
+				Client:          cl,
+				DiscoveryClient: *dc,
+			}
+			ctx = context.Background()
+		})
+		It("generates a ConfigMap based upon values in ibmcloud-cluster-info and Authentication CR", func() {
+			generated := &corev1.ConfigMap{}
+			err := generateOAuthClientConfigMap(ctx, r.Client, authCR, ibmcloudClusterInfo, generated)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(generated.Data).ToNot(BeNil())
+			Expect(generated.Data["MASTER_IP"]).To(Equal(ibmcloudClusterInfo.Data["cluster_address"]))
+			Expect(generated.Data["PROXY_IP"]).To(Equal(ibmcloudClusterInfo.Data["proxy_address"]))
+			Expect(generated.Data["CLUSTER_CA_DOMAIN"]).To(Equal(ibmcloudClusterInfo.Data["cluster_address"]))
+			Expect(generated.Data["CLUSTER_NAME"]).To(Equal(authCR.Spec.Config.ClusterName))
+			//var findings []metav1.OwnerReference
+			expected := metav1.OwnerReference{
+				APIVersion:         "operator.ibm.com/v1alpha1",
+				Kind:               "Authentication",
+				Name:               "example-authentication",
+				Controller:         ptr.To[bool](true),
+				UID:                authCR.UID,
+				BlockOwnerDeletion: ptr.To[bool](true),
+			}
+			Expect(generated.OwnerReferences).To(ContainElement(expected))
+		})
+	})
+})


### PR DESCRIPTION
Originating issue: [IBMPrivateCloud/roadmap#65249](https://github.ibm.com/IBMPrivateCloud/roadmap/issues/65249)

* Always determine the correct ROKS_URL value instead of assuming the contents of the ConfigMap are already correct.
* Refactor ConfigMap handling so that it conforms to subreconciler pattern and otherwise tidy the logic of this part of the Authentication controller.