### PR TITLE
Always update values in platform-auth-idp when triggered

### DIFF
--- a/controllers/operator/configmap.go
+++ b/controllers/operator/configmap.go
@@ -184,10 +184,12 @@ func (r *AuthenticationReconciler) handleConfigMaps(ctx context.Context, req ctr
 	return ctrlcommon.ReduceSubreconcilerResultsAndErrors(subresults, errs)
 }
 
-func updateFields(observed, updates *corev1.ConfigMap, keys ...string) (updated bool) {
+func updateFields(observed, update *corev1.ConfigMap, keys ...string) (updated bool) {
 	for _, key := range keys {
-		if value, ok := updates.Data[key]; ok && observed.Data[key] != value {
-			observed.Data[key] = value
+		observedVal, ok := observed.Data[key]
+		updateVal := update.Data[key]
+		if !ok || observedVal != updateVal {
+			observed.Data[key] = updateVal
 			updated = true
 		}
 	}
@@ -364,7 +366,7 @@ func updatePlatformAuthIDP(observed, generated *corev1.ConfigMap) (updated bool,
 			"PROVIDER_ISSUER_URL"),
 		updatesValuesWhen(not(observedKeySet("PREFERRED_LOGIN")),
 			"PREFERRED_LOGIN"),
-		updatesValuesWhen(not(observedKeySet("DEFAULT_LOGIN")),
+		updatesValuesWhen(not(observedKeyValueSetTo("DEFAULT_LOGIN", generated.Data["DEFAULT_LOGIN"])),
 			"DEFAULT_LOGIN"),
 		updatesValuesWhen(not(observedKeySet("DB_CONNECT_TIMEOUT")),
 			"DB_CONNECT_TIMEOUT",

--- a/controllers/operator/configmap_test.go
+++ b/controllers/operator/configmap_test.go
@@ -427,6 +427,7 @@ var _ = Describe("ConfigMap handling", func() {
 					"LOG_LEVEL_AUTHSVC":                  "info",
 					"LOG_LEVEL_IDMGMT":                   "info",
 					"LOG_LEVEL_MW":                       "info",
+					"DEFAULT_LOGIN":                      "",
 					"IDTOKEN_LIFETIME":                   "12h",
 					"SESSION_TIMEOUT":                    "43200",
 					"OIDC_ISSUER_URL":                    authCR.Spec.Config.OIDCIssuerURL,
@@ -501,6 +502,10 @@ var _ = Describe("ConfigMap handling", func() {
 						"SCOPE_CLAIM",
 						"BOOTSTRAP_USERID",
 					},
+				},
+				{
+					"DEFAULT_LOGIN",
+					[]string{"DEFAULT_LOGIN"},
 				},
 				{
 					"PROVIDER_ISSUER_URL",


### PR DESCRIPTION
Originating issue: [IBMPrivateCloud/roadmap#65604](https://github.ibm.com/IBMPrivateCloud/roadmap/issues/65604)

* Add a check to be sure that, if a selected key is not present in the observed ConfigMap that is present in the generated one, the selected key is added to the observed ConfigMap.
* Always update DEFAULT_LOGIN to whatever is set in the Authentication CR.
* Update test to account for this change.