### PR TITLE
[CD] Update image builds for RH Certification

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,8 @@ FROM docker-na-public.artifactory.swg-devops.com/hyc-cloud-private-edge-docker-l
 
 ARG VCS_REF
 ARG VCS_URL
+ARG IMG_VERSION
+ARG IMG_RELEASE
 
 LABEL org.label-schema.vendor="IBM" \
     org.label-schema.name="ibm-iam-operator" \
@@ -27,7 +29,10 @@ LABEL org.label-schema.vendor="IBM" \
     name="ibm-iam-operator" \
     vendor="IBM" \
     description="IBM IM Operator" \
-    summary="IBM IM Operator"
+    summary="IBM IM Operator" \
+    maintainer="IBM IM Squad" \
+    version=$IMG_VERSION \
+    release=$IMG_RELEASE
 
 ENV OPERATOR=/usr/local/bin/ibm-iam-operator \
     USER_UID=1001 \
@@ -37,7 +42,7 @@ WORKDIR /
 
 COPY build/_output/bin/manager ${OPERATOR}
 
-COPY licenses /
+COPY licenses /licenses
 
 USER ${USER_UID}
 

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ BUILD_LOCALLY ?= 1
 NAMESPACE=ibm-common-services
 GIT_COMMIT_ID=$(shell git rev-parse --short HEAD)
 GIT_REMOTE_URL=$(shell git config --get remote.origin.url)
-IMAGE_BUILD_OPTS=--build-arg "VCS_REF=$(GIT_COMMIT_ID)" --build-arg "VCS_URL=$(GIT_REMOTE_URL)"
+IMAGE_BUILD_OPTS=--build-arg "VCS_REF=$(GIT_COMMIT_ID)" --build-arg "VCS_URL=$(GIT_REMOTE_URL)" --build-arg "IMG_VERSION=$(VERSION)" --build-arg "IMG_RELEASE=$(shell date +%s)"
 
 # Image URL to use all building/pushing image targets;
 # Use your own docker registry and image name for dev/test by overridding the IMG and REGISTRY environment variable.


### PR DESCRIPTION
Originating issue: [IBMPrivateCloud/roadmap#65705](https://github.ibm.com/IBMPrivateCloud/roadmap/issues/65705)

* Place LICENSE in /licenses
* Add RH image labels