### PR TITLE
[CD] Upgrade go version to 1.23.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,7 +168,7 @@ KUSTOMIZE_VERSION ?= v5.4.3
 CONTROLLER_TOOLS_VERSION ?= v0.16.3
 OPERATOR_SDK_VERSION ?= v1.37.0
 YQ_VERSION ?= v4.44.3
-GO_VERSION ?= 1.23.1
+GO_VERSION ?= 1.23.5
 
 # This pinned version of go has its version pinned to its name, so order of operations is inverted here.
 GO ?= $(LOCALBIN)/go$(GO_VERSION)

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,8 @@
 module github.com/IBM/ibm-iam-operator
 
-go 1.23
+go 1.23.5
 
 require (
-	github.com/go-logr/logr v1.2.4
 	github.com/google/uuid v1.6.0
 	github.com/ibm/ibm-cert-manager-operator v0.0.0-20220602233809-3a62073266c7
 	github.com/jackc/pgx/v5 v5.5.4
@@ -29,6 +28,7 @@ require (
 	github.com/evanphx/json-patch v5.6.0+incompatible // indirect
 	github.com/evanphx/json-patch/v5 v5.6.0 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
+	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-logr/zapr v1.2.4 // indirect
 	github.com/go-openapi/jsonpointer v0.19.6 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect


### PR DESCRIPTION
Addresses [GO-2025-3420](https://pkg.go.dev/vuln/GO-2025-3420) and [GO-2025-3373](https://pkg.go.dev/vuln/GO-2025-3373)