### PR TITLE
[SC2] Upgrade go version to 1.23.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,7 +168,7 @@ KUSTOMIZE_VERSION ?= v5.4.3
 CONTROLLER_TOOLS_VERSION ?= v0.16.3
 OPERATOR_SDK_VERSION ?= v1.37.0
 YQ_VERSION ?= v4.44.3
-GO_VERSION ?= 1.23.1
+GO_VERSION ?= 1.23.5
 
 # This pinned version of go has its version pinned to its name, so order of operations is inverted here.
 GO ?= $(LOCALBIN)/go$(GO_VERSION)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/IBM/ibm-iam-operator
 
-go 1.21
+go 1.23.5
 
 require (
 	github.com/google/uuid v1.6.0


### PR DESCRIPTION
Addresses [GO-2025-3420](https://pkg.go.dev/vuln/GO-2025-3420) and [GO-2025-3373](https://pkg.go.dev/vuln/GO-2025-3373)