### PR TITLE
Rework ibmcloud-cluster-info reconcile

### DIFF
--- a/controllers/operator/configmap.go
+++ b/controllers/operator/configmap.go
@@ -117,9 +117,10 @@ func (r *AuthenticationReconciler) handleIBMCloudClusterInfo(ctx context.Context
 	}
 
 	updateFns := []func(*corev1.ConfigMap, *corev1.ConfigMap) bool{
-		updatesValuesWhen(not(observedKeyValueSetTo("cluster_address", generated.Data["cluster_address"])),
+		updatesValuesWhen(and(zenFrontDoorEnabled(authCR), not(observedKeyValueSetTo("cluster_address", generated.Data["cluster_address"]))),
 			"cluster_address",
 			"cluster_address_auth",
+			"proxy_address",
 			"cluster_endpoint"),
 		updatesValuesWhen(not(observedKeySet("cluster_address_auth")), "cluster_address_auth"),
 	}
@@ -781,7 +782,6 @@ func (r *AuthenticationReconciler) getDomain(ctx context.Context, authCR *operat
 	}
 
 	splitHost := strings.SplitN(host, ".", 2)
-	reqLogger.Info("split host", "value", splitHost)
 	if len(splitHost) < 2 {
 		return
 	}
@@ -873,6 +873,7 @@ func (r *AuthenticationReconciler) generateOCPClusterInfo(ctx context.Context, a
 			clusterAddressAuth = zenHost
 			clusterAddress = zenHost
 			clusterEndpoint = "https://" + zenHost
+			proxyDomainName = zenHost
 		} else {
 			reqLogger.Info("Zen host could not be retrieved; using defaults")
 		}

--- a/controllers/operator/configmap_test.go
+++ b/controllers/operator/configmap_test.go
@@ -318,7 +318,7 @@ var _ = Describe("ConfigMap handling", func() {
 			err = r.Get(ctx, cmKey, observed)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(observed.Data).ToNot(BeNil())
-			Expect(observed.Data["cluster_address_auth"]).To(Equal(observed.Data["cluster_address"]))
+			Expect(observed.Data["cluster_address_auth"]).To(Equal("cp-console-data-ns.example1.ibm.com"))
 			Expect(observed.Labels).ToNot(BeNil())
 			Expect(observed.Labels["app"]).To(Equal("auth-idp"))
 			Expect(observed.OwnerReferences).ToNot(BeEmpty())


### PR DESCRIPTION
The `ibmcloud-cluster-info` ConfigMap is now reconciled as follows:

* If the `cluster_address_auth` field is not present in either case (e.g. upgrade from IM version without this field), it is set to match the `cluster_address` field's value.
* If the Zen front door is disabled, the ConfigMap is initially created with the default cp-console values and is left unmanaged after that point.
* If the Zen front door is enabled, all hostname values for `cluster_address`, `cluster_address_auth`, `cluster_endpoint`, and `proxy_address` are aligned to match the hostname provided by Zen.