### PR TITLE
[DONOTMERGE]im-certauth-passthrough route addition

### DIFF
--- a/controllers/operator/configmap.go
+++ b/controllers/operator/configmap.go
@@ -854,14 +854,17 @@ func (r *AuthenticationReconciler) generateOCPClusterInfo(ctx context.Context, a
 		return
 	}
 
-	var domainName, proxyDomainName string
+	var domainName, certAuthDomainName, proxyDomainName string
 	multipleauthCRRouteName := strings.Join([]string{"cp-console", authCR.Namespace}, "-")
+	multipleCertAuthRouteName := strings.Join([]string{IMCrtAuthRouteName, authCR.Namespace}, "-")
 	multipleauthCRProxyRouteName := strings.Join([]string{"cp-proxy", authCR.Namespace}, "-")
 	if authCR.Spec.Config.OnPremMultipleDeploy {
 		domainName = strings.Join([]string{multipleauthCRRouteName, baseDomain}, ".")
+		certAuthDomainName = strings.Join([]string{multipleCertAuthRouteName, baseDomain}, ".")
 		proxyDomainName = strings.Join([]string{multipleauthCRProxyRouteName, baseDomain}, ".")
 	} else {
 		domainName = strings.Join([]string{"cp-console", baseDomain}, ".")
+		certAuthDomainName = strings.Join([]string{IMCrtAuthRouteName, baseDomain}, ".")
 		proxyDomainName = strings.Join([]string{"cp-proxy", baseDomain}, ".")
 	}
 

--- a/controllers/operator/configmap.go
+++ b/controllers/operator/configmap.go
@@ -798,8 +798,9 @@ func (r *AuthenticationReconciler) generateCNCFClusterInfo(ctx context.Context, 
 
 	zenHost := ""
 	clusterAddress := strings.Join([]string{strings.Join([]string{"cp-console", authCR.Namespace}, "-"), domainName}, ".")
-	imCertAuthEP := strings.Join([]string{strings.Join([]string{IMCrtAuthRouteName, authCR.Namespace}, "-"), domainName}, ".")
+	imCertAuthAddress := strings.Join([]string{strings.Join([]string{IMCrtAuthRouteName, authCR.Namespace}, "-"), domainName}, ".")
 	clusterEndpoint := "https://" + clusterAddress
+	imCertAuthEP := "https://" + imCertAuthAddress
 	clusterAddressAuth := clusterAddress
 	if authCR.Spec.Config.ZenFrontDoor && ctrlcommon.ClusterHasZenExtensionGroupVersion(&r.DiscoveryClient) {
 		zenHost, err = r.getZenHost(ctx, authCR)
@@ -872,6 +873,7 @@ func (r *AuthenticationReconciler) generateOCPClusterInfo(ctx context.Context, a
 	zenHost := ""
 	clusterAddress := domainName
 	clusterEndpoint := "https://" + clusterAddress
+	imCertAuthEndpoint := "https://" + certAuthDomainName
 	clusterAddressAuth := clusterAddress
 	if authCR.Spec.Config.ZenFrontDoor && ctrlcommon.ClusterHasZenExtensionGroupVersion(&r.DiscoveryClient) {
 		zenHost, err = r.getZenHost(ctx, authCR)
@@ -895,7 +897,7 @@ func (r *AuthenticationReconciler) generateOCPClusterInfo(ctx context.Context, a
 		},
 		Data: map[string]string{
 			ClusterAddr:            clusterAddress,
-			IMCrtAuthEP:            certAuthDomainName,
+			IMCrtAuthEP:            imCertAuthEndpoint,
 			"cluster_address_auth": clusterAddressAuth,
 			ClusterEP:              clusterEndpoint,
 			RouteHTTPPort:          rhttpPort,

--- a/controllers/operator/constants.go
+++ b/controllers/operator/constants.go
@@ -20,6 +20,8 @@ const (
 	// ClusterConfigName ... ibmcloud-cluster-info
 	ClusterAddr          string = "cluster_address"
 	ClusterEP            string = "cluster_endpoint"
+	IMCrtAuthEP          string = "im_certauth_endpoint"
+	IMCrtAuthRouteName   string = "im-certauth-passthrough"
 	RouteHTTPPort        string = "cluster_router_http_port"
 	RouteHTTPSPort       string = "cluster_router_https_port"
 	RouteHTTPPortValue   string = "80"

--- a/controllers/operator/routes_test.go
+++ b/controllers/operator/routes_test.go
@@ -496,8 +496,9 @@ var _ = Describe("Route handling", func() {
 		})
 	})
 
-	Describe("getClusterAddress", func() {
+	Describe("getClusterAddressAndCertAuthEP", func() {
 		var clusterAddress string
+		var imCertAuthEP string
 		BeforeEach(func() {
 			crds, err := envtest.InstallCRDs(cfg, envtest.CRDInstallOptions{
 				Paths: []string{filepath.Join(".", "testdata", "crds", "routes")},
@@ -528,6 +529,7 @@ var _ = Describe("Route handling", func() {
 				Data: map[string]string{
 					"cluster_address":      "cp-console-example.apps.cluster.ibm.com",
 					"cluster_address_auth": "cp-console-example.apps.cluster.ibm.com",
+					"im_certauth_endpoint": "im-certauth-passthrough-exampleapps.cluster.ibm.com",
 				},
 			}
 			controllerutil.SetOwnerReference(authCR, clusterInfoConfigMap, scheme)
@@ -540,21 +542,24 @@ var _ = Describe("Route handling", func() {
 				Client: cl,
 			}
 			clusterAddress = ""
+			imCertAuthEP = ""
 		})
 
 		It("returns a function that signals to continue reconciling when cluster address is retrieved successfully", func() {
-			fn := r.getClusterAddress(authCR, &clusterAddress)
+			fn := r.getClusterAddressAndCertAuthEP(authCR, &clusterAddress, &imCertAuthEP)
 			result, err := fn(ctx)
 			Expect(clusterAddress).To(Equal(clusterInfoConfigMap.Data["cluster_address"]))
+			Expect(imCertAuthEP).To(Equal(clusterInfoConfigMap.Data[IMCrtAuthEP]))
 			testutil.ConfirmThatItContinuesReconciling(result, err)
 		})
 
 		It("returns a function that signals to requeue with a delay when ConfigMap is not present", func() {
 			err := r.Delete(ctx, clusterInfoConfigMap)
 			Expect(err).ToNot(HaveOccurred())
-			fn := r.getClusterAddress(authCR, &clusterAddress)
+			fn := r.getClusterAddressAndCertAuthEP(authCR, &clusterAddress, &imCertAuthEP)
 			result, err := fn(ctx)
 			Expect(clusterAddress).To(BeZero())
+			Expect(imCertAuthEP).To(BeZero())
 			testutil.ConfirmThatItRequeuesWithDelay(result, err, defaultLowerWait)
 		})
 
@@ -566,9 +571,10 @@ var _ = Describe("Route handling", func() {
 					Client: cl,
 				},
 			}
-			fn := rFailing.getClusterAddress(authCR, &clusterAddress)
+			fn := rFailing.getClusterAddressAndCertAuthEP(authCR, &clusterAddress, &imCertAuthEP)
 			result, err := fn(ctx)
 			Expect(clusterAddress).To(BeZero())
+			Expect(imCertAuthEP).To(BeZero())
 			testutil.ConfirmThatItRequeuesWithError(result, err)
 		})
 	})


### PR DESCRIPTION
What this PR contains
- Creates a new passthrough route `im-certauth-passthrough`
- updates this route url into `ibmcloud-cluster-info` configmap for common-ui consumption