### PR TITLE
Add operandbindinfo permissions to chart role

### DIFF
--- a/helm/templates/00-rbac.yaml
+++ b/helm/templates/00-rbac.yaml
@@ -168,6 +168,7 @@ rules:
   - operator.ibm.com
   resources:
   - operandrequests
+  - operandbindinfos
   verbs:
   - create
   - get
@@ -180,6 +181,7 @@ rules:
   - operator.ibm.com
   resources:
   - operandrequests/status
+  - operandbindinfos/status
   verbs:
   - watch
   - get


### PR DESCRIPTION
Adding missing RBAC for Helm chart that was previously added to CSV in order to comply with RH certification guidelines.