### PR TITLE
Multi-tenancy with cluster charts

### DIFF
--- a/helm-cluster-scoped/templates/10_clusterrole.yaml
+++ b/helm-cluster-scoped/templates/10_clusterrole.yaml
@@ -1,8 +1,8 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: ibm-iam-operator
-  namespace: {{.Values.global.operatorNamespace}}
+  name: ibm-iam-operator-{{ .Values.global.operatorNamespace }}
+  namespace: {{ .Values.global.operatorNamespace }}
   labels:
     app.kubernetes.io/instance: ibm-iam-operator
     app.kubernetes.io/managed-by: ibm-iam-operator

--- a/helm-cluster-scoped/templates/11_clusterrolebinding.yaml
+++ b/helm-cluster-scoped/templates/11_clusterrolebinding.yaml
@@ -1,14 +1,14 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: ibm-iam-operator
+  name: ibm-iam-operator-{{ .Values.global.operatorNamespace }}
   labels:
     component-id: {{ .Chart.Name }}
 subjects:
 - kind: ServiceAccount
   name: ibm-iam-operator
-  namespace: {{.Values.global.operatorNamespace}}
+  namespace: {{ .Values.global.operatorNamespace }}
 roleRef:
     kind: ClusterRole
-    name: ibm-iam-operator
+    name: ibm-iam-operator-{{ .Values.global.operatorNamespace }}
     apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
Originating issue: [IBMPrivateCloud/roadmap#65980](https://github.ibm.com/IBMPrivateCloud/roadmap/issues/65980)

Append namespace to ClusterRole and ClusterRoleBinding names to make them unique in multi-tenant use cases.