### PR TITLE
extra {{end}} causing problems with deployment of latest iam chart

### DIFF
--- a/helm/templates/10-deployment.yaml
+++ b/helm/templates/10-deployment.yaml
@@ -267,7 +267,6 @@ spec:
         {{- $watchNamespaces = prepend $watchNamespaces .Values.global.operatorNamespace }}
         - name: WATCH_NAMESPACE
           value: {{ uniq $watchNamespaces | join "," | quote }}
-        {{- end }}
         image: {{ .Values.cpfs.imagePullPrefix | default .Values.global.imagePullPrefix }}/{{ .Values.cpfs.imageRegistryNamespaceOperator }}/ibm-iam-operator:{{ .Values.operator.imageTag }}
         imagePullPolicy: {{ .Values.global.imagePullPolicy }}
         name: ibm-iam-operator


### PR DESCRIPTION
 I think this line is causing a problem in the iam helm chart:
> Error: INSTALLATION FAILED: parse error at (ibm-iam-operator/templates/10-deployment.yaml:270): unexpected {{end}}

I don't see an equivalent line in the cs operator https://github.com/IBM/ibm-common-service-operator/blob/master/helm/templates/operator-deployment.yaml#L57 or an unclosed if condition before this {{end}}