### PR TITLE
update image pull prefix for operands

### DIFF
--- a/helm/templates/10-deployment.yaml
+++ b/helm/templates/10-deployment.yaml
@@ -251,13 +251,13 @@ spec:
         - name: cluster_name
           value: ""
         - name: ICP_PLATFORM_AUTH_IMAGE
-          value: {{ .Values.global.imagePullPrefix }}/{{ .Values.cpfs.imageRegistryNamespaceOperand }}/icp-platform-auth:{{ .Values.operands.platformAuthService.imageTag }}
+          value: {{ .Values.cpfs.imagePullPrefix | default .Values.global.imagePullPrefix }}/{{ .Values.cpfs.imageRegistryNamespaceOperand }}/icp-platform-auth:{{ .Values.operands.platformAuthService.imageTag }}
         - name: ICP_IDENTITY_PROVIDER_IMAGE
-          value: {{ .Values.global.imagePullPrefix }}/{{ .Values.cpfs.imageRegistryNamespaceOperand }}/icp-identity-provider:{{ .Values.operands.platformIdentityProvider.imageTag }}
+          value: {{ .Values.cpfs.imagePullPrefix | default .Values.global.imagePullPrefix }}/{{ .Values.cpfs.imageRegistryNamespaceOperand }}/icp-identity-provider:{{ .Values.operands.platformIdentityProvider.imageTag }}
         - name: ICP_IDENTITY_MANAGER_IMAGE
-          value: {{ .Values.global.imagePullPrefix }}/{{ .Values.cpfs.imageRegistryNamespaceOperand }}/icp-identity-manager:{{ .Values.operands.platformIdentityManagement.imageTag }}
+          value: {{ .Values.cpfs.imagePullPrefix | default .Values.global.imagePullPrefix }}/{{ .Values.cpfs.imageRegistryNamespaceOperand }}/icp-identity-manager:{{ .Values.operands.platformIdentityManagement.imageTag }}
         - name: IM_INITCONTAINER_IMAGE
-          value: {{ .Values.global.imagePullPrefix }}/{{ .Values.cpfs.imageRegistryNamespaceOperand }}/im-initcontainer:{{ .Values.operands.imInitContainer.imageTag }}
+          value: {{ .Values.cpfs.imagePullPrefix | default .Values.global.imagePullPrefix }}/{{ .Values.cpfs.imageRegistryNamespaceOperand }}/im-initcontainer:{{ .Values.operands.imInitContainer.imageTag }}
         - name: IMAGE_PULL_SECRET
           value: {{ .Values.global.imagePullSecret }}
         {{- $watchNamespaces := .Values.global.tetheredNamespaces | default list -}}


### PR DESCRIPTION
For the same reason we updated the operator imagePullPrefix to take different values, we need to update the operand image locations. This is primarily a factor in test cases where dev images are stored in different repos (like EDB, CPD, and CPFS images all being in different places). This prevents us from needing multiple different top overrides files.