### PR TITLE
Get from API server when cache fails

### DIFF
--- a/controllers/oidc.security/client_controller_config.go
+++ b/controllers/oidc.security/client_controller_config.go
@@ -24,7 +24,6 @@ import (
 	ctrlCommon "github.com/IBM/ibm-iam-operator/controllers/common"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // AuthenticationConfig collects relevant Authentication configuration from Secrets and ConfigMaps and provides that
@@ -280,15 +279,15 @@ func (c AuthenticationConfig) GetCSCATLSKey() (value []byte, err error) {
 	return c.getConfigValue(key)
 }
 
-func GetConfig(ctx context.Context, k8sClient *client.Client, config *AuthenticationConfig) (err error) {
-	servicesNamespace, err := ctrlCommon.GetServicesNamespace(ctx, k8sClient)
+func GetConfig(ctx context.Context, r *ClientReconciler, config *AuthenticationConfig) (err error) {
+	servicesNamespace, err := ctrlCommon.GetServicesNamespace(ctx, &r.Client)
 	if err != nil {
 		return fmt.Errorf("failed to get ConfigMap: %w", err)
 	}
 	config.ApplyAuthenticationNamespace(servicesNamespace)
 
 	configMap := &corev1.ConfigMap{}
-	err = (*k8sClient).Get(ctx, types.NamespacedName{Name: PlatformAuthIDPConfigMapName, Namespace: servicesNamespace}, configMap)
+	err = r.Get(ctx, types.NamespacedName{Name: PlatformAuthIDPConfigMapName, Namespace: servicesNamespace}, configMap)
 	if err != nil {
 		return fmt.Errorf("client failed to GET ConfigMap: %w", err)
 	}
@@ -298,7 +297,7 @@ func GetConfig(ctx context.Context, k8sClient *client.Client, config *Authentica
 	}
 
 	platformAuthIDPCredentialsSecret := &corev1.Secret{}
-	err = (*k8sClient).Get(ctx, types.NamespacedName{Name: PlatformAuthIDPCredentialsSecretName, Namespace: servicesNamespace}, platformAuthIDPCredentialsSecret)
+	err = r.Get(ctx, types.NamespacedName{Name: PlatformAuthIDPCredentialsSecretName, Namespace: servicesNamespace}, platformAuthIDPCredentialsSecret)
 	if err != nil {
 		return
 	}
@@ -308,7 +307,7 @@ func GetConfig(ctx context.Context, k8sClient *client.Client, config *Authentica
 	}
 
 	platformOIDCCredentialsSecret := &corev1.Secret{}
-	err = (*k8sClient).Get(ctx, types.NamespacedName{Name: PlatformOIDCCredentialsSecretName, Namespace: servicesNamespace}, platformOIDCCredentialsSecret)
+	err = r.Get(ctx, types.NamespacedName{Name: PlatformOIDCCredentialsSecretName, Namespace: servicesNamespace}, platformOIDCCredentialsSecret)
 	if err != nil {
 		return
 	}
@@ -318,7 +317,7 @@ func GetConfig(ctx context.Context, k8sClient *client.Client, config *Authentica
 	}
 
 	csCACertificateSecret := &corev1.Secret{}
-	err = (*k8sClient).Get(ctx, types.NamespacedName{Name: CSCACertificateSecretName, Namespace: servicesNamespace}, csCACertificateSecret)
+	err = r.Get(ctx, types.NamespacedName{Name: CSCACertificateSecretName, Namespace: servicesNamespace}, csCACertificateSecret)
 	if err != nil {
 		return
 	}

--- a/controllers/operator/authentication_controller.go
+++ b/controllers/operator/authentication_controller.go
@@ -186,11 +186,21 @@ func needsAuditServiceDummyDataReset(a *operatorv1alpha1.Authentication) bool {
 // AuthenticationReconciler reconciles a Authentication object
 type AuthenticationReconciler struct {
 	client.Client
+	Reader          client.Reader
 	Scheme          *runtime.Scheme
 	DiscoveryClient discovery.DiscoveryClient
 	Mutex           sync.Mutex
 	clusterType     ctrlcommon.ClusterType
 	dbSetupChan     chan *migration.Result
+}
+
+// GetFromCacheOrAPI first tries to GET the object from the cache; if this
+// fails, it attempts a GET from the API server directly.
+func (r *AuthenticationReconciler) Get(ctx context.Context, objkey client.ObjectKey, obj client.Object) (err error) {
+	if err = r.Client.Get(ctx, objkey, obj); k8sErrors.IsNotFound(err) {
+		return r.Reader.Get(ctx, objkey, obj)
+	}
+	return
 }
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to

--- a/controllers/operator/certificate_test.go
+++ b/controllers/operator/certificate_test.go
@@ -77,6 +77,7 @@ var _ = Describe("Certificate handling", Ordered, func() {
 
 		r = &AuthenticationReconciler{
 			Client:          cl,
+			Reader:          cl,
 			DiscoveryClient: *dc,
 		}
 		ctx = context.Background()
@@ -211,6 +212,7 @@ var _ = Describe("Certificate handling", Ordered, func() {
 		It("will produce a function that signals to requeue with an error when an unexpected error occurs", func() {
 			rFailing := &AuthenticationReconciler{
 				Client:          testutil.NewFakeTimeoutClient(cl),
+				Reader:          testutil.NewFakeTimeoutClient(cl),
 				DiscoveryClient: *dc,
 			}
 			fieldsList := generateCertificateFieldsList(authCR)
@@ -374,6 +376,9 @@ var _ = Describe("Certificate handling", Ordered, func() {
 				Client: &testutil.FakeTimeoutClient{
 					Client: cl,
 				},
+				Reader: &testutil.FakeTimeoutClient{
+					Client: cl,
+				},
 				DiscoveryClient: *dc,
 			}
 			remainingCertsCount := 4
@@ -529,6 +534,7 @@ var _ = Describe("Certificate handling", Ordered, func() {
 			timeoutClient.GetAllowed = true
 			rFailing := &AuthenticationReconciler{
 				Client:          timeoutClient,
+				Reader:          timeoutClient,
 				DiscoveryClient: *dc,
 			}
 			for _, fields := range fieldsList {
@@ -703,6 +709,7 @@ var _ = Describe("Certificate handling", Ordered, func() {
 			timeoutClient.GetAllowed = true
 			rFailing := &AuthenticationReconciler{
 				Client:          timeoutClient,
+				Reader:          timeoutClient,
 				DiscoveryClient: *dc,
 			}
 			fn := rFailing.createV1CertificatesIfNotPresent(authCR, fieldsList)

--- a/controllers/operator/configmap.go
+++ b/controllers/operator/configmap.go
@@ -766,21 +766,19 @@ func getHostFromDummyRoute(ctx context.Context, cl client.Client, authCR *operat
 	if err = controllerutil.SetControllerReference(authCR, dummyRoute, cl.Scheme()); err != nil {
 		return
 	}
-	dummyKey := types.NamespacedName{Name: "domain-test", Namespace: authCR.Namespace}
 	if err = cl.Create(ctx, dummyRoute); err != nil && !k8sErrors.IsAlreadyExists(err) {
 		return
 	}
-	if err = cl.Get(ctx, dummyKey, dummyRoute); err != nil {
-		return
-	}
 	reqLogger.Info("Got dummy route", "spec", dummyRoute.Spec)
+
+	host = dummyRoute.Spec.Host
 
 	if err = cl.Delete(ctx, dummyRoute); err != nil && !k8sErrors.IsNotFound(err) {
 		reqLogger.Error(err, "Failed to delete dummy Route")
 		return "", err
 	}
 
-	return dummyRoute.Spec.Host, nil
+	return
 }
 
 func (r *AuthenticationReconciler) getDomain(ctx context.Context, authCR *operatorv1alpha1.Authentication) (domain string, err error) {

--- a/controllers/operator/configmap_test.go
+++ b/controllers/operator/configmap_test.go
@@ -62,6 +62,7 @@ var _ = Describe("ConfigMap handling", func() {
 
 			r = &AuthenticationReconciler{
 				Client:          cl,
+				Reader:          cl,
 				DiscoveryClient: *dc,
 			}
 			ctx = context.Background()
@@ -137,6 +138,7 @@ var _ = Describe("ConfigMap handling", func() {
 
 			r = &AuthenticationReconciler{
 				Client:          cl,
+				Reader:          cl,
 				DiscoveryClient: *dc,
 			}
 			ctx = context.Background()
@@ -421,6 +423,7 @@ var _ = Describe("ConfigMap handling", func() {
 
 			r = &AuthenticationReconciler{
 				Client:          cl,
+				Reader:          cl,
 				DiscoveryClient: *dc,
 			}
 			ctx = context.Background()
@@ -866,6 +869,7 @@ var _ = Describe("ConfigMap handling", func() {
 
 			r = &AuthenticationReconciler{
 				Client:          cl,
+				Reader:          cl,
 				DiscoveryClient: *dc,
 			}
 			ctx = context.Background()
@@ -1015,6 +1019,7 @@ var _ = Describe("ConfigMap handling", func() {
 
 			r = &AuthenticationReconciler{
 				Client:          cl,
+				Reader:          cl,
 				DiscoveryClient: *dc,
 			}
 			ctx = context.Background()

--- a/controllers/operator/operandbindinfo_test.go
+++ b/controllers/operator/operandbindinfo_test.go
@@ -76,6 +76,7 @@ var _ = Describe("OperandBindInfo handling", func() {
 
 			r = &AuthenticationReconciler{
 				Client:          cl,
+				Reader:          cl,
 				DiscoveryClient: *dc,
 			}
 			ctx = context.Background()

--- a/controllers/operator/operandrequest_test.go
+++ b/controllers/operator/operandrequest_test.go
@@ -78,6 +78,7 @@ var _ = Describe("OperandRequest handling", func() {
 				cl = cb.Build()
 				r = &AuthenticationReconciler{
 					Client: cl,
+					Reader: cl,
 				}
 			})
 			It("should add the embedded EDB entry to the list of Operands", func() {
@@ -168,6 +169,9 @@ var _ = Describe("OperandRequest handling", func() {
 			It("should NOT add the embedded EDB entry to the list of Operands", func() {
 				rFailing := &AuthenticationReconciler{
 					Client: &testutil.FakeTimeoutClient{
+						Client: cl,
+					},
+					Reader: &testutil.FakeTimeoutClient{
 						Client: cl,
 					},
 				}
@@ -315,6 +319,7 @@ var _ = Describe("OperandRequest handling", func() {
 			cl = cb.Build()
 			r = &AuthenticationReconciler{
 				Client: cl,
+				Reader: cl,
 			}
 		})
 		It("returns false when IS_EMBEDDED is not set", func() {
@@ -356,6 +361,9 @@ var _ = Describe("OperandRequest handling", func() {
 		It("returns an error when an unexpected error is encountered", func() {
 			rFailing := &AuthenticationReconciler{
 				Client: &testutil.FakeTimeoutClient{
+					Client: cl,
+				},
+				Reader: &testutil.FakeTimeoutClient{
 					Client: cl,
 				},
 			}

--- a/controllers/operator/routes_test.go
+++ b/controllers/operator/routes_test.go
@@ -79,6 +79,7 @@ var _ = Describe("Route handling", func() {
 
 			r = &AuthenticationReconciler{
 				Client:          cl,
+				Reader:          cl,
 				DiscoveryClient: *dc,
 			}
 			ctx = context.Background()
@@ -99,6 +100,9 @@ var _ = Describe("Route handling", func() {
 		It("will produce a function that signals to requeue with an error when an unexpected error occurs", func() {
 			rFailing := &AuthenticationReconciler{
 				Client: &testutil.FakeTimeoutClient{
+					Client: cl,
+				},
+				Reader: &testutil.FakeTimeoutClient{
 					Client: cl,
 				},
 			}
@@ -140,6 +144,7 @@ var _ = Describe("Route handling", func() {
 			cl = cb.Build()
 			r = &AuthenticationReconciler{
 				Client: cl,
+				Reader: cl,
 			}
 			ctx = context.Background()
 		})
@@ -194,6 +199,7 @@ var _ = Describe("Route handling", func() {
 			cl = cb.Build()
 			r = &AuthenticationReconciler{
 				Client: cl,
+				Reader: cl,
 			}
 			ctx = context.Background()
 		})
@@ -253,6 +259,7 @@ var _ = Describe("Route handling", func() {
 			cl = cb.Build()
 			r = &AuthenticationReconciler{
 				Client: cl,
+				Reader: cl,
 			}
 			ctx = context.Background()
 		})
@@ -293,6 +300,9 @@ var _ = Describe("Route handling", func() {
 			}
 			rFailing := &AuthenticationReconciler{
 				Client: &testutil.FakeTimeoutClient{
+					Client: cl,
+				},
+				Reader: &testutil.FakeTimeoutClient{
 					Client: cl,
 				},
 			}
@@ -338,6 +348,7 @@ var _ = Describe("Route handling", func() {
 			cl = cb.Build()
 			r = &AuthenticationReconciler{
 				Client: cl,
+				Reader: cl,
 			}
 			ctx = context.Background()
 			wlpClientID = ""
@@ -359,6 +370,9 @@ var _ = Describe("Route handling", func() {
 		It("will produce a function that signals to requeue with an error when the ConfigMap is not changed successfully", func() {
 			rFailing := &AuthenticationReconciler{
 				Client: &testutil.FakeTimeoutClient{
+					Client: cl,
+				},
+				Reader: &testutil.FakeTimeoutClient{
 					Client: cl,
 				},
 			}
@@ -428,6 +442,7 @@ var _ = Describe("Route handling", func() {
 			cl = cb.Build()
 			r = &AuthenticationReconciler{
 				Client: cl,
+				Reader: cl,
 			}
 			ctx = context.Background()
 
@@ -453,6 +468,9 @@ var _ = Describe("Route handling", func() {
 			certificate := []byte{}
 			rFailing := &AuthenticationReconciler{
 				Client: &testutil.FakeTimeoutClient{
+					Client: cl,
+				},
+				Reader: &testutil.FakeTimeoutClient{
 					Client: cl,
 				},
 			}
@@ -538,6 +556,7 @@ var _ = Describe("Route handling", func() {
 			cl = cb.Build()
 			r = &AuthenticationReconciler{
 				Client: cl,
+				Reader: cl,
 			}
 			clusterAddress = ""
 		})
@@ -563,6 +582,9 @@ var _ = Describe("Route handling", func() {
 			Expect(err).ToNot(HaveOccurred())
 			rFailing := &AuthenticationReconciler{
 				Client: &testutil.FakeTimeoutClient{
+					Client: cl,
+				},
+				Reader: &testutil.FakeTimeoutClient{
 					Client: cl,
 				},
 			}
@@ -697,6 +719,7 @@ var _ = Describe("Route handling", func() {
 
 			r = &AuthenticationReconciler{
 				Client:          cl,
+				Reader:          cl,
 				DiscoveryClient: *dc,
 			}
 		})
@@ -1012,6 +1035,7 @@ var _ = Describe("Route handling", func() {
 			Expect(resources).To(BeNil())
 			r = &AuthenticationReconciler{
 				Client:          cl,
+				Reader:          cl,
 				DiscoveryClient: *dc,
 			}
 			result, err := r.handleRoutes(ctx,

--- a/controllers/operator/secret.go
+++ b/controllers/operator/secret.go
@@ -94,7 +94,7 @@ func (r *AuthenticationReconciler) handleSecret(instance *operatorv1alpha1.Authe
 	var err error
 
 	for secret := range secretData {
-		err = r.Client.Get(context.TODO(), types.NamespacedName{Name: secret, Namespace: instance.Namespace}, currentSecret)
+		err = r.Get(context.TODO(), types.NamespacedName{Name: secret, Namespace: instance.Namespace}, currentSecret)
 		if err != nil {
 			if errors.IsNotFound(err) {
 				// Define a new Secret
@@ -189,7 +189,7 @@ func (r *AuthenticationReconciler) waitForSecret(instance *operatorv1alpha1.Auth
 	s := &corev1.Secret{}
 
 	err := wait.PollImmediateUntil(2*time.Second, func() (done bool, err error) {
-		if err := r.Client.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: instance.Namespace}, s); err != nil {
+		if err := r.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: instance.Namespace}, s); err != nil {
 			return false, nil
 		}
 		return true, nil
@@ -243,7 +243,7 @@ func (r *AuthenticationReconciler) createClusterCACert(i *operatorv1alpha1.Authe
 
 	// Confirm that the secret, ibmcloud-cluster-ca-cert, is created by IM-Operator before further usage
 	current := &corev1.Secret{}
-	err = r.Client.Get(context.TODO(), types.NamespacedName{Name: secretName, Namespace: i.Namespace}, current)
+	err = r.Get(context.TODO(), types.NamespacedName{Name: secretName, Namespace: i.Namespace}, current)
 	if err != nil {
 		reqLogger.Error(err, "Failed to get existing secret")
 		return

--- a/main.go
+++ b/main.go
@@ -164,6 +164,7 @@ func main() {
 
 	clientReconciler := &oidcsecuritycontrollers.ClientReconciler{
 		Client:   mgr.GetClient(),
+		Reader:   mgr.GetAPIReader(),
 		Scheme:   mgr.GetScheme(),
 		Recorder: mgr.GetEventRecorderFor(clientControllerName),
 	}
@@ -180,6 +181,7 @@ func main() {
 
 	if err = (&operatorcontrollers.AuthenticationReconciler{
 		Client:          mgr.GetClient(),
+		Reader:          mgr.GetAPIReader(),
 		DiscoveryClient: *dc,
 		Scheme:          mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {


### PR DESCRIPTION
Originating issue: [IBMPrivateCloud/roadmap#66250](https://github.ibm.com/IBMPrivateCloud/roadmap/issues/66250)

Fall back to querying the API server directly when an object isn't found just in case the cache filtering is leading to missing existing objects.