### PR TITLE
add key value pairs to log statements

### DIFF
--- a/controllers/operator/configmap.go
+++ b/controllers/operator/configmap.go
@@ -942,7 +942,7 @@ func getClusterAddress(client client.Client, namespace string, configMap string)
 		log.Info("Error getting configmap", "ConfigMap.Name", configMap, "ConfigMap.Namespace", namespace)
 	} else {
 		host := currentConfigMap.Data["cluster_address"]
-		log.Info("Fetched cluster address from configmap", "found host value ", host)
+		log.Info("Fetched cluster address from configmap", " with cluster_address value ", host)
 		return host, nil
 	}
 	return "", errors.New(fmt.Sprint("failed to fetch the cluster address"))

--- a/controllers/operator/configmap.go
+++ b/controllers/operator/configmap.go
@@ -925,7 +925,7 @@ func isPublicCloud(client client.Client, namespace string, configMap string) boo
 	currentConfigMap := &corev1.ConfigMap{}
 	err := client.Get(context.TODO(), types.NamespacedName{Name: configMap, Namespace: namespace}, currentConfigMap)
 	if err != nil {
-		log.Info("Error getting configmap", configMap)
+		log.Info("Error getting configmap", " Name ", configMap)
 		return false
 	} else if err == nil {
 		host := currentConfigMap.Data["cluster_kube_apiserver_host"]
@@ -939,10 +939,10 @@ func getClusterAddress(client client.Client, namespace string, configMap string)
 	currentConfigMap := &corev1.ConfigMap{}
 	err := client.Get(context.TODO(), types.NamespacedName{Name: configMap, Namespace: namespace}, currentConfigMap)
 	if err != nil {
-		log.Info("Error getting configmap", configMap)
+		log.Info("Error getting configmap", " Name ", configMap)
 	} else {
 		host := currentConfigMap.Data["cluster_address"]
-		log.Info("Fetched cluster address from configmap", host)
+		log.Info("Fetched cluster address from configmap", "found host value ", host)
 		return host, nil
 	}
 	return "", errors.New(fmt.Sprint("failed to fetch the cluster address"))

--- a/controllers/operator/configmap.go
+++ b/controllers/operator/configmap.go
@@ -942,7 +942,7 @@ func getClusterAddress(client client.Client, namespace string, configMap string)
 		log.Info("Error getting configmap", "ConfigMap.Name", configMap, "ConfigMap.Namespace", namespace)
 	} else {
 		host := currentConfigMap.Data["cluster_address"]
-		log.Info("Fetched cluster address from configmap", " with cluster_address value ", host)
+		log.Info("Fetched cluster address from configmap", "cluster_address", host)
 		return host, nil
 	}
 	return "", errors.New(fmt.Sprint("failed to fetch the cluster address"))

--- a/controllers/operator/configmap.go
+++ b/controllers/operator/configmap.go
@@ -925,7 +925,7 @@ func isPublicCloud(client client.Client, namespace string, configMap string) boo
 	currentConfigMap := &corev1.ConfigMap{}
 	err := client.Get(context.TODO(), types.NamespacedName{Name: configMap, Namespace: namespace}, currentConfigMap)
 	if err != nil {
-		log.Info("Error getting configmap", " Name ", configMap)
+		log.Info("Error getting configmap", "ConfigMap.Name", configMap, "ConfigMap.Namespace", namespace)
 		return false
 	} else if err == nil {
 		host := currentConfigMap.Data["cluster_kube_apiserver_host"]
@@ -939,7 +939,7 @@ func getClusterAddress(client client.Client, namespace string, configMap string)
 	currentConfigMap := &corev1.ConfigMap{}
 	err := client.Get(context.TODO(), types.NamespacedName{Name: configMap, Namespace: namespace}, currentConfigMap)
 	if err != nil {
-		log.Info("Error getting configmap", " Name ", configMap)
+		log.Info("Error getting configmap", "ConfigMap.Name", configMap, "ConfigMap.Namespace", namespace)
 	} else {
 		host := currentConfigMap.Data["cluster_address"]
 		log.Info("Fetched cluster address from configmap", "found host value ", host)


### PR DESCRIPTION
Log.Info expects key value pairs, else throws errors. We don't want these errors in our logs that deviate us from the real issue.