### PR TITLE
Add flag to enable extra attribute for JIT

### DIFF
--- a/internal/controller/operator/configmap.go
+++ b/internal/controller/operator/configmap.go
@@ -448,6 +448,7 @@ func generateAuthIdpConfigMap(clusterInfo *corev1.ConfigMap) ctrlcommon.Generate
 				"IDENTITY_MGMT_URL":                  "https://platform-identity-management:4500",
 				"MASTER_HOST":                        clusterInfo.Data["cluster_address"],
 				"NODE_ENV":                           "production",
+				"ENABLE_JIT_EXTRA_ATTR":              "false",
 				"AUDIT_ENABLED_IDPROVIDER":           "false",
 				"AUDIT_ENABLED_IDMGMT":               "false",
 				"AUDIT_DETAIL":                       "false",

--- a/internal/controller/operator/configmap_test.go
+++ b/internal/controller/operator/configmap_test.go
@@ -529,6 +529,7 @@ var _ = Describe("ConfigMap handling", func() {
 					"IDENTITY_MGMT_URL":                  "https://platform-identity-management:4500",
 					"MASTER_HOST":                        ibmcloudClusterInfo.Data["cluster_address"],
 					"NODE_ENV":                           "production",
+					"ENABLE_JIT_EXTRA_ATTR":              "false",
 					"AUDIT_ENABLED_IDPROVIDER":           "false",
 					"AUDIT_ENABLED_IDMGMT":               "false",
 					"AUDIT_DETAIL":                       "false",

--- a/internal/controller/operator/containers.go
+++ b/internal/controller/operator/containers.go
@@ -437,17 +437,6 @@ func buildIdentityProviderContainer(instance *operatorv1alpha1.Authentication, i
 			Value: "platform-identity-provider",
 		},
 		{
-			Name: "ENABLE_JIT_EXTRA_ATTR",
-			ValueFrom: &corev1.EnvVarSource{
-				ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: "platform-auth-idp",
-					},
-					Key: "ENABLE_JIT_EXTRA_ATTR",
-				},
-			},
-		},
-		{
 			Name: "AUDIT_ENABLED",
 			ValueFrom: &corev1.EnvVarSource{
 				ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
@@ -794,6 +783,17 @@ func buildIdentityManagerContainer(instance *operatorv1alpha1.Authentication, id
 		{
 			Name:  "SERVICE_NAME",
 			Value: "platform-identity-management",
+		},
+		{
+			Name: "ENABLE_JIT_EXTRA_ATTR",
+			ValueFrom: &corev1.EnvVarSource{
+				ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: "platform-auth-idp",
+					},
+					Key: "ENABLE_JIT_EXTRA_ATTR",
+				},
+			},
 		},
 		{
 			Name: "AUDIT_ENABLED",

--- a/internal/controller/operator/containers.go
+++ b/internal/controller/operator/containers.go
@@ -437,6 +437,17 @@ func buildIdentityProviderContainer(instance *operatorv1alpha1.Authentication, i
 			Value: "platform-identity-provider",
 		},
 		{
+			Name: "ENABLE_JIT_EXTRA_ATTR",
+			ValueFrom: &corev1.EnvVarSource{
+				ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: "platform-auth-idp",
+					},
+					Key: "ENABLE_JIT_EXTRA_ATTR",
+				},
+			},
+		},
+		{
 			Name: "AUDIT_ENABLED",
 			ValueFrom: &corev1.EnvVarSource{
 				ConfigMapKeyRef: &corev1.ConfigMapKeySelector{


### PR DESCRIPTION
Issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/66941
Requirement : Additional attribute like "email" , "username" should be propagated to the JIT group members section for the CPD to display this .

Design discussion:
Use a similar approach of having a flag like the ATTR_MAPPING_FROM_CONFIG in platform-auth-idp cm which when enabled would send the additional attributes - email and username fro JIT Groups. This would ensure that the standards for JIT is maintained and would not cause any backward compatibility issues.

Therefore, in order to have these attributes --> the customer would need to enable the flag in the cm. Once enabled, the additional fields would be sent in the GET SCIM Group response allowing the fields to be populated in the UI.