### PR TITLE
Removed custom hostname image

### DIFF
--- a/bundle/manifests/ibm-iam-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-iam-operator.clusterserviceversion.yaml
@@ -637,5 +637,3 @@ spec:
       name: ICP_IDENTITY_MANAGER_IMAGE
     - image: icr.io/cpopen/cpfs/im-initcontainer:4.13.0
       name: IM_INITCONTAINER_IMAGE
-    - image: icr.io/cpopen/cpfs/iam-custom-hostname:4.13.0
-      name: IAM_CUSTOM_HOSTNAME_IMAGE

--- a/hack/relatedimages.yaml
+++ b/hack/relatedimages.yaml
@@ -8,5 +8,3 @@
   name: ICP_IDENTITY_MANAGER_IMAGE
 - image: icr.io/cpopen/cpfs/im-initcontainer:4.13.0
   name: IM_INITCONTAINER_IMAGE
-- image: icr.io/cpopen/cpfs/iam-custom-hostname:4.13.0
-  name: IAM_CUSTOM_HOSTNAME_IMAGE


### PR DESCRIPTION
Issue : https://github.ibm.com/IBMPrivateCloud/roadmap/issues/66916#issuecomment-122392194
As outlined in this issue : https://github.ibm.com/IBMPrivateCloud/roadmap/issues/66809
Also removed from CD release pipeline - https://github.ibm.com/IBMPrivateCloud/release/pull/2221