### PR TITLE
Add readiness probes for SC2

### DIFF
--- a/bundle/manifests/ibm-iam-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-iam-operator.clusterserviceversion.yaml
@@ -378,6 +378,7 @@ spec:
                       initialDelaySeconds: 3
                       periodSeconds: 20
                       timeoutSeconds: 3
+                      
                     resources:
                       limits:
                         cpu: 25m

--- a/bundle/manifests/ibm-iam-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-iam-operator.clusterserviceversion.yaml
@@ -362,6 +362,22 @@ spec:
                     image: icr.io/cpopen/ibm-iam-operator:4.5.15
                     imagePullPolicy: IfNotPresent
                     name: ibm-iam-operator
+                    livenessProbe:
+                      failureThreshold: 10
+                      httpGet:
+                        path: /healthz
+                        port: 8081
+                      initialDelaySeconds: 120
+                      periodSeconds: 60
+                      timeoutSeconds: 10
+                    readinessProbe:
+                      failureThreshold: 10
+                      httpGet:
+                        path: /readyz
+                        port: 8081
+                      initialDelaySeconds: 3
+                      periodSeconds: 20
+                      timeoutSeconds: 3
                     resources:
                       limits:
                         cpu: 25m

--- a/bundle/manifests/ibm-iam-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-iam-operator.clusterserviceversion.yaml
@@ -378,7 +378,6 @@ spec:
                       initialDelaySeconds: 3
                       periodSeconds: 20
                       timeoutSeconds: 3
-                      
                     resources:
                       limits:
                         cpu: 25m

--- a/config/manager/bases/manager.yaml
+++ b/config/manager/bases/manager.yaml
@@ -84,6 +84,14 @@ spec:
             initialDelaySeconds: 120
             periodSeconds: 60
             timeoutSeconds: 10
+          readinessProbe:
+            failureThreshold: 10
+            httpGet:
+              path: /readyz
+              port: 8081
+            initialDelaySeconds: 3
+            periodSeconds: 20
+            timeoutSeconds: 3
           resources:
             limits:
               cpu: 25m

--- a/config/manager/bases/manager.yaml
+++ b/config/manager/bases/manager.yaml
@@ -76,6 +76,14 @@ spec:
               value: ""
             - name: cluster_name
               value: ""
+          livenessProbe:
+            failureThreshold: 10
+            httpGet:
+              path: /healthz
+              port: 8081
+            initialDelaySeconds: 120
+            periodSeconds: 60
+            timeoutSeconds: 10
           resources:
             limits:
               cpu: 25m


### PR DESCRIPTION
Adding readiness & liveness probes for IM operator.
test results - https://github.ibm.com/IBMPrivateCloud/roadmap/issues/67205#issuecomment-125254167