### PR TITLE
update liveness probe from authsvc

### DIFF
--- a/controllers/operator/containers.go
+++ b/controllers/operator/containers.go
@@ -376,7 +376,7 @@ func buildAuthServiceContainer(instance *operatorv1alpha1.Authentication, authSe
 		LivenessProbe: &corev1.Probe{
 			ProbeHandler: corev1.ProbeHandler{
 				HTTPGet: &corev1.HTTPGetAction{
-					Path: "/oidc/endpoint/OP/.well-known/openid-configuration",
+					Path: "/oidc/endpoint/OP/jwk",
 					Port: intstr.IntOrString{
 						IntVal: authServicePort,
 					},


### PR DESCRIPTION
This is to have separate probes for auth-svc.

```
sh-4.4$ curl -kL https://platform-auth-service.common-services.svc.cluster.local:9443/oidc/endpoint/OP/jwk
{"keys":[{"kty":"RSA","e":"AQAB","use":"sig","kid":"xxxxx"}]}
```