### PR TITLE
Fix miscellaneous bugs

### DIFF
--- a/api/operator/v1alpha1/authentication_types.go
+++ b/api/operator/v1alpha1/authentication_types.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"sync"
 
@@ -257,8 +258,8 @@ func NewMigrationCompleteCondition() *metav1.Condition {
 // Creates a new ConditionMigrated condition for when the migration Job has yet
 // to run at all; should not be set unless the previous status is
 // `metav1.ConditionTrue`.
-func NewMigrationYetToBeCompleteCondition() *metav1.Condition {
-	message := "The \"ibm-im-db-migration\" Job is not yet complete"
+func NewMigrationYetToBeCompleteCondition(name string) *metav1.Condition {
+	message := fmt.Sprintf("The %q Job is not yet complete", name)
 	return &metav1.Condition{
 		Type:    ConditionMigrated,
 		Status:  metav1.ConditionFalse,
@@ -268,8 +269,8 @@ func NewMigrationYetToBeCompleteCondition() *metav1.Condition {
 }
 
 // Creates a new ConditionMigrated condition for when the migration Job fails.
-func NewMigrationFailureCondition() *metav1.Condition {
-	message := "Migration failed; review the \"ibm-im-db-migrator\" Job logs for more information"
+func NewMigrationFailureCondition(name string) *metav1.Condition {
+	message := fmt.Sprintf("Migration failed; review the %q Job logs for more information", name)
 	return &metav1.Condition{
 		Type:    ConditionMigrated,
 		Status:  metav1.ConditionFalse,

--- a/bundle/manifests/ibm-iam-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-iam-operator.clusterserviceversion.yaml
@@ -154,7 +154,7 @@ metadata:
     categories: Security
     certified: "false"
     containerImage: icr.io/cpopen/ibm-iam-operator:4.14.0
-    createdAt: "2025-08-28T15:02:42Z"
+    createdAt: "2025-09-12T19:56:51Z"
     description: The IAM operator provides a simple Kubernetes CRD-Based API to manage the lifecycle of IAM services. With this operator, you can simply deploy and upgrade the IAM services
     features.operators.openshift.io/disconnected: "true"
     features.operators.openshift.io/fips-compliant: "true"
@@ -246,6 +246,15 @@ spec:
               verbs:
                 - get
                 - list
+            - apiGroups:
+                - postgresql.k8s.enterprisedb.io
+              resources:
+                - clusters
+                - clusters/status
+              verbs:
+                - get
+                - list
+                - watch
           serviceAccountName: ibm-iam-operator
       deployments:
         - label:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -258,6 +258,15 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - postgresql.k8s.enterprisedb.io
+  resources:
+  - clusters
+  - clusters/status
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/helm/templates/00-rbac.yaml
+++ b/helm/templates/00-rbac.yaml
@@ -284,6 +284,15 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - postgresql.k8s.enterprisedb.io
+  resources:
+  - clusters
+  - clusters/status
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/helm/templates/10-deployment.yaml
+++ b/helm/templates/10-deployment.yaml
@@ -258,6 +258,8 @@ spec:
           value: {{ .Values.cpfs.imagePullPrefix | default .Values.global.imagePullPrefix }}/{{ .Values.cpfs.imageRegistryNamespaceOperand }}/icp-identity-manager:{{ .Values.operands.platformIdentityManagement.imageTag }}
         - name: IM_INITCONTAINER_IMAGE
           value: {{ .Values.cpfs.imagePullPrefix | default .Values.global.imagePullPrefix }}/{{ .Values.cpfs.imageRegistryNamespaceOperand }}/im-initcontainer:{{ .Values.operands.imInitContainer.imageTag }}
+        - name: IM_DB_MIGRATOR_IMAGE
+          value: {{ .Values.cpfs.imagePullPrefix | default .Values.global.imagePullPrefix }}/{{ .Values.cpfs.imageRegistryNamespaceOperand }}/ibm-im-db-migrator:{{ .Values.operands.imDBMigrator.imageTag }}
         - name: IMAGE_PULL_SECRET
           value: {{ .Values.global.imagePullSecret }}
         {{- $watchNamespaces := .Values.global.tetheredNamespaces | default list -}}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -22,3 +22,5 @@ operands:
     imageTag: "4.14.0"
   imInitContainer:
     imageTag: "4.14.0"
+  imDBMigrator:
+    imageTag: "0.0.1"

--- a/internal/controller/operator/configmap.go
+++ b/internal/controller/operator/configmap.go
@@ -40,6 +40,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -222,15 +223,25 @@ func (r *AuthenticationReconciler) handleIBMCloudClusterInfo(ctx context.Context
 }
 
 func replaceOIDCClientRegistrationJob(s common.SecondaryReconciler, ctx context.Context) (err error) {
+	log := logf.FromContext(ctx, "Job.Name", "oidc-client-registration")
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "oidc-client-registration",
 			Namespace: s.GetNamespace(),
 		},
 	}
-	if err = s.GetClient().Delete(ctx, job); k8sErrors.IsNotFound(err) {
-		return nil
+	deleteOpts := []client.DeleteOption{
+		client.PropagationPolicy(metav1.DeletePropagationForeground),
 	}
+	log.Info("Object reconciliation has triggered replacement of Job so it will run again")
+	if err = s.GetClient().Delete(ctx, job, deleteOpts...); k8sErrors.IsNotFound(err) {
+		log.Info("Job did not exist; skipping")
+		return nil
+	} else if err != nil {
+		log.Error(err, "Failed to delete Job")
+		return
+	}
+	log.Info("Removed Job successfully")
 	return
 }
 
@@ -460,9 +471,12 @@ func (r *AuthenticationReconciler) generateAuthIdpConfigMap(clusterInfo *corev1.
 
 		// Set the path for SAML connections
 		var masterPath string
-		if masterPath, err = r.getMasterPath(ctx, s.GetNamespace()); err != nil {
+		if masterPath, err = r.getMasterPath(ctx, s.GetNamespace()); IsJobMissingResultError(err) {
+			reqLogger.Error(err, "Could not retrieve return codes from Job")
+			return fmt.Errorf("could not set MASTER_PATH: %w", err)
+		} else if err != nil {
 			reqLogger.Error(err, "Failed to determine whether a preexisting SAML exists")
-			err = fmt.Errorf("could not set MASTER_PATH")
+			err = fmt.Errorf("could not set MASTER_PATH: %w", err)
 			return
 		}
 
@@ -813,6 +827,7 @@ func (r *AuthenticationReconciler) generateCNCFClusterInfo(ctx context.Context, 
 			proxyDomainName = zenHost
 		} else {
 			reqLogger.Info("Zen host could not be retrieved; using defaults")
+			err = nil
 		}
 	}
 
@@ -872,8 +887,11 @@ func (r *AuthenticationReconciler) generateOCPClusterInfo(ctx context.Context, a
 			clusterAddress = zenHost
 			clusterEndpoint = "https://" + zenHost
 			proxyDomainName = zenHost
-		} else {
+		} else if m, ok := err.(*missingKeyError); ok && m.GetKey() == URL_PREFIX {
 			reqLogger.Info("Zen host could not be retrieved; using defaults")
+			err = nil
+		} else {
+			return
 		}
 	}
 
@@ -920,11 +938,49 @@ func getClusterInfoFromEnv() (rhttpPort, rhttpsPort, cname string) {
 	return
 }
 
+type missingKeyError struct {
+	key  string
+	kind string
+	client.ObjectKey
+}
+
+func (e *missingKeyError) GetName() string {
+	return e.ObjectKey.Name
+}
+
+func (e *missingKeyError) GetNamespace() string {
+	return e.ObjectKey.Namespace
+}
+
+type Keyed interface {
+	GetKey() string
+}
+
+func (e *missingKeyError) GetKey() string {
+	return e.key
+}
+
+func (e *missingKeyError) GetKind() string {
+	return e.kind
+}
+
+func (e *missingKeyError) Error() string {
+	return fmt.Sprintf("%s %s in namespace %s was missing expected key %q", e.kind, e.Name, e.Namespace, e.key)
+}
+
+func IsMissingKeyError(err error) bool {
+	if k, ok := err.(Keyed); ok || errors.As(err, &k) {
+		return k.GetKey() != ""
+	}
+	return false
+}
+
 func (r *AuthenticationReconciler) getZenHost(ctx context.Context, authCR *operatorv1alpha1.Authentication) (zenHost string, err error) {
 	reqLogger := logf.FromContext(ctx)
 	//Get the routehost from the ibmcloud-cluster-info configmap
 	productConfigMap := &corev1.ConfigMap{}
-	err = r.Client.Get(ctx, types.NamespacedName{Name: ZenProductConfigmapName, Namespace: authCR.Namespace}, productConfigMap)
+	cmKey := types.NamespacedName{Name: ZenProductConfigmapName, Namespace: authCR.Namespace}
+	err = r.Client.Get(ctx, cmKey, productConfigMap)
 	if k8sErrors.IsNotFound(err) {
 		reqLogger.Info("Zen product configmap does not exist")
 		return
@@ -934,8 +990,11 @@ func (r *AuthenticationReconciler) getZenHost(ctx context.Context, authCR *opera
 	}
 
 	if productConfigMap.Data == nil || len(productConfigMap.Data[URL_PREFIX]) == 0 {
-		err = fmt.Errorf("hostname for Zen is not set in ConfigMap %q using key %q", ZenProductConfigmapName, URL_PREFIX)
-		return
+		return "", &missingKeyError{
+			key:       URL_PREFIX,
+			kind:      "ConfigMap",
+			ObjectKey: cmKey,
+		}
 	}
 
 	zenHost = productConfigMap.Data[URL_PREFIX]
@@ -1036,6 +1095,129 @@ func readROKSURL(ctx context.Context) (issuer string, err error) {
 	return issuer, nil
 }
 
+type ReturnCoded interface {
+	GetRC() int32
+}
+
+type failedJobError struct {
+	rc int32 // the code returned by the failing container
+	client.ObjectKey
+	msg string
+}
+
+func (e *failedJobError) GetRC() int32 {
+	return e.rc
+}
+
+func (e *failedJobError) GetName() string {
+	return e.Name
+}
+
+func (e *failedJobError) GetNamespace() string {
+	return e.Namespace
+}
+
+func ReturnCodeForError(err error) int32 {
+	if rc, ok := err.(ReturnCoded); ok || errors.As(err, &rc) {
+		return rc.GetRC()
+	}
+	return -1
+}
+
+func ReturnNameForError(err error) string {
+	if n, ok := err.(common.Named); ok || errors.As(err, &n) {
+		return n.GetName()
+	}
+	return ""
+}
+
+func ReturnNamespaceForError(err error) string {
+	if ns, ok := err.(common.Namespaced); ok || errors.As(err, &ns) {
+		return ns.GetNamespace()
+	}
+	return ""
+}
+
+func IsFailingIMHasSAMLError(err error) bool {
+	return ReturnNameForError(err) == "im-has-saml" && ReturnCodeForError(err) > 1
+}
+
+func (e *failedJobError) Error() string {
+	return e.msg
+}
+
+func NewIMHasSAMLError(rc int32, objKey client.ObjectKey) *failedJobError {
+	if rc == 2 {
+		return &failedJobError{
+			rc:        rc,
+			ObjectKey: objKey,
+			msg:       fmt.Sprintf("failed to query for SAML connection; check Job %s in namespace %s for details, or delete the Job to rerun", objKey.Name, objKey.Namespace),
+		}
+	} else if rc > 2 {
+		return &failedJobError{
+			rc:        rc,
+			ObjectKey: objKey,
+			msg:       fmt.Sprintf("received unexpected error code while running SAML; check Job %s in namespace %s for details, or delete the Job to rerun", objKey.Name, objKey.Namespace),
+		}
+	}
+	return nil
+}
+
+type invalidMatchListError struct {
+	length int
+	gvk    *schema.GroupVersionKind
+}
+
+type Lengthed interface {
+	Length() int
+	IsEmpty() bool
+}
+
+func (e *invalidMatchListError) Length() int {
+	return e.length
+}
+
+func (e *invalidMatchListError) IsEmpty() bool {
+	return e.length == 0
+}
+
+func (e *invalidMatchListError) Error() string {
+	return fmt.Sprintf("received invalid number of matching %s (%d)", e.gvk.Kind, e.length)
+}
+
+func IsEmptyMatchListError(err error) bool {
+	if l, ok := err.(Lengthed); ok || errors.As(err, &l) {
+		return l.IsEmpty()
+	}
+	return false
+}
+
+func NewInvalidMatchListError(length int, gvk schema.GroupVersionKind) *invalidMatchListError {
+	return &invalidMatchListError{
+		length: length,
+		gvk:    &gvk,
+	}
+}
+
+type jobMissingResultError struct {
+	client.ObjectKey
+}
+
+func (e *jobMissingResultError) GetObjectKey() client.ObjectKey {
+	return e.ObjectKey
+}
+
+func (e *jobMissingResultError) Error() string {
+	return fmt.Sprintf("Pods for Job %s in namespace %s could not be found to determine result", e.Name, e.Namespace)
+}
+
+func IsJobMissingResultError(err error) bool {
+	if j, ok := err.(*jobMissingResultError); ok || errors.As(err, &j) {
+		return true
+	}
+	return false
+}
+
 func (r *AuthenticationReconciler) getMasterPath(ctx context.Context, namespace string) (path string, err error) {
 	cmKey := types.NamespacedName{Name: "platform-auth-idp", Namespace: namespace}
 	cm := &corev1.ConfigMap{}
@@ -1064,34 +1246,40 @@ func (r *AuthenticationReconciler) getMasterPath(ctx context.Context, namespace 
 		}),
 	}
 
+	var exitCode int32 = -1
 	if err = r.List(ctx, podList, opts...); err != nil {
 		return
-	} else if len(podList.Items) != 1 {
-		return "", fmt.Errorf("received invalid number of matching Pods (%d)", len(podList.Items))
+	} else if len(podList.Items) > 1 {
+		return "", NewInvalidMatchListError(len(podList.Items), podList.GetObjectKind().GroupVersionKind())
+	} else if len(podList.Items) == 1 {
+		po := podList.Items[0]
+		if len(po.Status.ContainerStatuses) != 1 {
+			return "", fmt.Errorf("received invalid number of containerStatuses (%d)", len(po.Status.ContainerStatuses))
+		}
+
+		containerState := podList.Items[0].Status.ContainerStatuses[0].State
+		if containerState.Terminated == nil {
+			return "", fmt.Errorf("container does not appear to have terminated yet")
+		}
+
+		exitCode = containerState.Terminated.ExitCode
 	}
 
-	po := podList.Items[0]
-	if len(po.Status.ContainerStatuses) != 1 {
-		return "", fmt.Errorf("received invalid number of containerStatuses (%d)", len(po.Status.ContainerStatuses))
-	}
-
-	containerState := podList.Items[0].Status.ContainerStatuses[0].State
-	if containerState.Terminated == nil {
-		return "", fmt.Errorf("container does not appear to have terminated yet")
-	}
-
-	exitCode := containerState.Terminated.ExitCode
 	var deleteJob bool
 	switch exitCode {
-	case 2:
-		err = fmt.Errorf("failed to query for SAML connection; check Job %s in namespace %s for details, or delete the Job to rerun", "im-has-saml", namespace)
 	case 1:
 		path = "/idauth"
 		deleteJob = true
 	case 0:
 		deleteJob = true
+	case -1:
+		err = &jobMissingResultError{jobKey}
+		deleteJob = true
 	default:
-		err = fmt.Errorf("received unexpected error code while running SAML; check Job %s in namespace %s for details, or delete the Job to rerun", "im-has-saml", namespace)
+		if job.Status.Failed == 1 {
+			deleteJob = true
+		}
+		err = NewIMHasSAMLError(exitCode, jobKey)
 	}
 
 	if !deleteJob {
@@ -1102,8 +1290,8 @@ func (r *AuthenticationReconciler) getMasterPath(ctx context.Context, namespace 
 		client.PropagationPolicy(metav1.DeletePropagationForeground),
 	}
 
-	if err = r.Delete(ctx, job, deleteOpts...); err != nil && !k8sErrors.IsNotFound(err) {
-		return "", fmt.Errorf("failed to delete Job %s in namespace %s after getting MASTER_PATH: %w", "im-has-saml", namespace, err)
+	if delErr := r.Delete(ctx, job, deleteOpts...); delErr != nil && !k8sErrors.IsNotFound(delErr) {
+		return "", fmt.Errorf("failed to delete Job %s in namespace %s after getting MASTER_PATH: %w", "im-has-saml", namespace, delErr)
 	}
 
 	return

--- a/internal/controller/operator/migration.go
+++ b/internal/controller/operator/migration.go
@@ -150,8 +150,8 @@ func (r *AuthenticationReconciler) handleMongoDBCleanup(ctx context.Context, req
 
 	// if retain annotation is unset or set to true - continue reconciling
 	if authCR.HasNotBeenMigrated() {
-		reqLogger.Info("Migrations have not completed yet; skipping")
-		return subreconciler.ContinueReconciling()
+		reqLogger.Info("Migrations have not completed yet; requeueing")
+		return subreconciler.Requeue()
 	}
 	reqLogger.Info("Condition indicates migrations have completed")
 

--- a/internal/controller/operator/resourcestatus_test.go
+++ b/internal/controller/operator/resourcestatus_test.go
@@ -93,7 +93,7 @@ var _ = Describe("AuthenticationReconciler", func() {
 				APIVersion: "batch/v1",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "ibm-im-db-migrator",
+				Name:      MigrationJobName,
 				Namespace: ns,
 			},
 		}
@@ -111,7 +111,7 @@ var _ = Describe("AuthenticationReconciler", func() {
 				APIVersion: "batch/v1",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "ibm-im-db-migrator",
+				Name:      MigrationJobName,
 				Namespace: ns,
 			},
 			Status: batchv1.JobStatus{
@@ -128,7 +128,7 @@ var _ = Describe("AuthenticationReconciler", func() {
 				APIVersion: "batch/v1",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "ibm-im-db-migrator",
+				Name:      MigrationJobName,
 				Namespace: ns,
 			},
 			Spec:   batchv1.JobSpec{},


### PR DESCRIPTION
* Some Job name checks were using the wrong name or gates; now using a single constant to ensure the same value is used or otherwise corrected those gates
* Introduce a requeue if the Cluster CR is not ready to prevent the database-related Jobs from running to failure
* Permissions were too stringent on mounted volumes in Jobs; added group write