### PR TITLE
CPD-Quality 57014, add default labels to cluster scoped resources

### DIFF
--- a/helm-cluster-scoped/templates/00_operator.ibm.com_authentications.yaml
+++ b/helm-cluster-scoped/templates/00_operator.ibm.com_authentications.yaml
@@ -7,6 +7,12 @@ metadata:
     app.kubernetes.io/managed-by: ibm-iam-operator
     app.kubernetes.io/name: ibm-iam-operator
     component-id: {{ .Chart.Name }}
+    {{- with .Values.cpfs.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.cpfs.clusterLabels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
   name: authentications.operator.ibm.com
 spec:
   group: operator.ibm.com

--- a/helm-cluster-scoped/templates/01_oidc.security.ibm.com_clients.yaml
+++ b/helm-cluster-scoped/templates/01_oidc.security.ibm.com_clients.yaml
@@ -7,6 +7,12 @@ metadata:
     app.kubernetes.io/managed-by: ibm-iam-operator
     app.kubernetes.io/name: ibm-iam-operator
     component-id: {{ .Chart.Name }}
+    {{- with .Values.cpfs.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.cpfs.clusterLabels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
   name: clients.oidc.security.ibm.com
 spec:
   conversion:

--- a/helm-cluster-scoped/templates/10_clusterrole.yaml
+++ b/helm-cluster-scoped/templates/10_clusterrole.yaml
@@ -8,6 +8,12 @@ metadata:
     app.kubernetes.io/managed-by: ibm-iam-operator
     app.kubernetes.io/name: ibm-iam-operator
     component-id: {{ .Chart.Name }}
+    {{- with .Values.cpfs.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.cpfs.clusterLabels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 rules:
 - apiGroups:
   - rbac.authorization.k8s.io

--- a/helm-cluster-scoped/templates/11_clusterrolebinding.yaml
+++ b/helm-cluster-scoped/templates/11_clusterrolebinding.yaml
@@ -4,6 +4,12 @@ metadata:
   name: ibm-iam-operator-{{ .Values.global.operatorNamespace }}
   labels:
     component-id: {{ .Chart.Name }}
+    {{- with .Values.cpfs.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.cpfs.clusterLabels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 subjects:
 - kind: ServiceAccount
   name: ibm-iam-operator


### PR DESCRIPTION
What this PR does / why we need it: CPD BR team requires cluster scoped resources to have both addOnID and tenant operator namespace defined in all cluster resources so they can be appropriately tracked and backed up. Enabling these values allows for flexibly setting both common labels for namespace scoped and cluster scoped resources and cluster specific labels.

Which issue(s) this PR fixes:
Fixes # https://github.ibm.com/PrivateCloud-analytics/CPD-Quality/issues/57014