### PR TITLE
Logging overhaul, part 2

### DIFF
--- a/internal/controller/operator/authentication_controller.go
+++ b/internal/controller/operator/authentication_controller.go
@@ -245,7 +245,7 @@ func (r *AuthenticationReconciler) handleAuthenticationFinalizer(ctx context.Con
 func (r *AuthenticationReconciler) Reconcile(rootCtx context.Context, req ctrl.Request) (result ctrl.Result, err error) {
 	log := logf.FromContext(rootCtx).WithName("controller_authentication")
 	ctx := logf.IntoContext(rootCtx, log)
-	log.Info("Reconciling Authentication")
+	log.Info("Reconciling Authentication CR")
 
 	// Fetch the Authentication instance
 	authCR := &operatorv1alpha1.Authentication{}
@@ -305,6 +305,8 @@ func (r *AuthenticationReconciler) Reconcile(rootCtx context.Context, req ctrl.R
 		log.Info("Reconciliation for spec incomplete; requeueing")
 	} else if subreconciler.ShouldContinue(subResult, err) {
 		log.Info("Reconciliation for spec complete")
+	} else {
+		log.Info("Reconciling Authentication CR complete")
 	}
 
 	result, err = subreconciler.Evaluate(subResult, err)

--- a/internal/controller/operator/ingress.go
+++ b/internal/controller/operator/ingress.go
@@ -32,6 +32,9 @@ import (
 
 func (r *AuthenticationReconciler) removeIngresses(ctx context.Context, req ctrl.Request) (result *ctrl.Result, err error) {
 	log := logf.FromContext(ctx)
+	debugLog := log.V(1)
+	debugCtx := logf.IntoContext(ctx, debugLog)
+
 	log.Info("Ensure all Ingresses are deleted when Routes are supported")
 	authCR := &operatorv1alpha1.Authentication{}
 	if result, err = r.getLatestAuthentication(ctx, req, authCR); subreconciler.ShouldHaltOrRequeue(result, err) {
@@ -57,7 +60,7 @@ func (r *AuthenticationReconciler) removeIngresses(ctx context.Context, req ctrl
 		r.removeIngress("social-login-callback", req.Namespace),
 	)
 
-	return subRec.Reconcile(ctx)
+	return subRec.Reconcile(debugCtx)
 }
 
 func (r *AuthenticationReconciler) removeIngress(name string, namespace string) common.SecondaryReconcilerFn {

--- a/internal/controller/operator/resourcestatus.go
+++ b/internal/controller/operator/resourcestatus.go
@@ -45,10 +45,14 @@ const (
 
 func (r *AuthenticationReconciler) setAuthenticationStatus(ctx context.Context, authCR *operatorv1alpha1.Authentication) (modified bool, err error) {
 	log := logf.FromContext(ctx)
+	debugLog := log.V(1)
+	debugCtx := logf.IntoContext(ctx, debugLog)
+
+	log.Info("Set Authentication status")
 	authCRCopy := authCR.DeepCopy()
 	var nodes []string
-	log.Info("Set nodes status")
-	nodes, err = r.getNodesStatus(ctx, authCR)
+	debugLog.Info("Set nodes status")
+	nodes, err = r.getNodesStatus(debugCtx, authCR)
 	if err != nil {
 		return
 	}
@@ -56,17 +60,17 @@ func (r *AuthenticationReconciler) setAuthenticationStatus(ctx context.Context, 
 		authCR.Status.Nodes = nodes
 	}
 
-	log.Info("Set migration status")
-	err = r.setMigrationStatusConditions(ctx, authCR)
+	debugLog.Info("Set migration status")
+	err = r.setMigrationStatusConditions(debugCtx, authCR)
 	if err != nil {
 		return
 	}
 
-	log.Info("Set service status")
-	authCR.Status.Service = r.getCurrentServiceStatus(ctx, r.Client, authCR)
+	debugLog.Info("Set service status")
+	authCR.Status.Service = r.getCurrentServiceStatus(debugCtx, r.Client, authCR)
 	expectedPodCount := int(authCR.Spec.Replicas) * 3
 	if len(nodes) != expectedPodCount {
-		log.Info("Number of nodes did not match expected count", "expected", expectedPodCount)
+		debugLog.Info("Number of nodes did not match expected count", "expected", expectedPodCount)
 		authCR.Status.Service.Status = ResourceNotReadyState
 	}
 	if !reflect.DeepEqual(authCR.Status, authCRCopy.Status) {

--- a/internal/controller/operator/resourcestatus_test.go
+++ b/internal/controller/operator/resourcestatus_test.go
@@ -150,6 +150,7 @@ var _ = Describe("AuthenticationReconciler", func() {
 	Context("setAuthenticationStatus", func() {
 		It("should update the status when nodes change", func() {
 			r := getReconciler()
+			ctx = context.Background()
 			addNodePods(r.Client, ctx, "data-ns")
 			addJob(r.Client, ctx, "data-ns", false)
 			authCR := &operatorv1alpha1.Authentication{}
@@ -172,6 +173,7 @@ var _ = Describe("AuthenticationReconciler", func() {
 
 		It("should not update the status when nodes do not change", func() {
 			r := getReconciler()
+			ctx = context.Background()
 			authCR := &operatorv1alpha1.Authentication{}
 			Expect(r.Get(ctx, types.NamespacedName{Name: "example-authentication", Namespace: "data-ns"}, authCR)).To(Succeed())
 			modified, err := r.setAuthenticationStatus(ctx, authCR)
@@ -184,6 +186,7 @@ var _ = Describe("AuthenticationReconciler", func() {
 	Context("setMigrationStatusConditions", func() {
 		It("should set conditions when job is completed", func() {
 			r := getReconciler()
+			ctx = context.Background()
 			addCompletedJob(r.Client, ctx, "data-ns")
 			authCR := &operatorv1alpha1.Authentication{}
 			Expect(r.Get(ctx, types.NamespacedName{Name: "example-authentication", Namespace: "data-ns"}, authCR)).To(Succeed())
@@ -203,6 +206,7 @@ var _ = Describe("AuthenticationReconciler", func() {
 
 		It("should set conditions when job is running and conditions are not set", func() {
 			r := getReconciler()
+			ctx = context.Background()
 			addJob(r.Client, ctx, "data-ns", false)
 			authCR := &operatorv1alpha1.Authentication{}
 			Expect(r.Get(ctx, types.NamespacedName{Name: "example-authentication", Namespace: "data-ns"}, authCR)).To(Succeed())
@@ -222,6 +226,7 @@ var _ = Describe("AuthenticationReconciler", func() {
 
 		It("should set conditions when job is running again after a previous success", func() {
 			r := getReconciler()
+			ctx = context.Background()
 			addCompletedJob(r.Client, ctx, "data-ns")
 			authCR := &operatorv1alpha1.Authentication{}
 			Expect(r.Get(ctx, types.NamespacedName{Name: "example-authentication", Namespace: "data-ns"}, authCR)).To(Succeed())
@@ -255,6 +260,7 @@ var _ = Describe("AuthenticationReconciler", func() {
 
 		It("should preserve conditions when job is running again after a previous, incomplete failure", func() {
 			r := getReconciler()
+			ctx = context.Background()
 			addFailedJob(r.Client, ctx, "data-ns", false, nil)
 			authCR := &operatorv1alpha1.Authentication{}
 			Expect(r.Get(ctx, types.NamespacedName{Name: "example-authentication", Namespace: "data-ns"}, authCR)).To(Succeed())
@@ -288,6 +294,7 @@ var _ = Describe("AuthenticationReconciler", func() {
 
 		It("should preserve ReasonMigrationFailure reason when job is running again after a previous, complete failure", func() {
 			r := getReconciler()
+			ctx = context.Background()
 			addFailedJob(r.Client, ctx, "data-ns", true, nil)
 			authCR := &operatorv1alpha1.Authentication{}
 			Expect(r.Get(ctx, types.NamespacedName{Name: "example-authentication", Namespace: "data-ns"}, authCR)).To(Succeed())

--- a/internal/controller/operator/role.go
+++ b/internal/controller/operator/role.go
@@ -30,14 +30,18 @@ import (
 
 func (r *AuthenticationReconciler) createRole(ctx context.Context, req ctrl.Request) (result *ctrl.Result, err error) {
 	log := logf.FromContext(ctx, "Role.Name", "ibm-iam-operand-restricted")
-	log.Info("Ensure Role is created")
+	debugLog := log.V(1)
+	debugCtx := logf.IntoContext(ctx, debugLog)
+
+	log.Info("Ensure Role is present")
+
 	authCR := &operatorv1alpha1.Authentication{}
-	if result, err = r.getLatestAuthentication(ctx, req, authCR); subreconciler.ShouldHaltOrRequeue(result, err) {
+	if result, err = r.getLatestAuthentication(debugCtx, req, authCR); subreconciler.ShouldHaltOrRequeue(result, err) {
 		return
 	}
 	// Define a new Role
 	operandRole := r.iamOperandRole(authCR)
-	err = r.Client.Create(ctx, operandRole)
+	err = r.Client.Create(debugCtx, operandRole)
 	if k8sErrors.IsAlreadyExists(err) {
 		log.Info("Role is already present")
 		return subreconciler.ContinueReconciling()

--- a/internal/controller/operator/rolebinding.go
+++ b/internal/controller/operator/rolebinding.go
@@ -30,13 +30,17 @@ import (
 
 func (r *AuthenticationReconciler) createRoleBinding(ctx context.Context, req ctrl.Request) (result *ctrl.Result, err error) {
 	log := logf.FromContext(ctx, "RoleBinding.Name", "ibm-iam-operand-restricted")
+	debugLog := log.V(1)
+	debugCtx := logf.IntoContext(ctx, debugLog)
+
+	log.Info("Ensure RoleBinding is present")
 	authCR := &operatorv1alpha1.Authentication{}
-	if result, err = r.getLatestAuthentication(ctx, req, authCR); subreconciler.ShouldHaltOrRequeue(result, err) {
+	if result, err = r.getLatestAuthentication(debugCtx, req, authCR); subreconciler.ShouldHaltOrRequeue(result, err) {
 		return
 	}
 	// Define a new RoleBinding
 	operandRB := r.iamOperandRB(authCR)
-	log.Info("Creating RoleBinding")
+	debugLog.Info("Creating RoleBinding")
 	err = r.Client.Create(ctx, operandRB)
 	if k8sErrors.IsAlreadyExists(err) {
 		log.Info("RoleBinding is already present")

--- a/internal/controller/operator/secret.go
+++ b/internal/controller/operator/secret.go
@@ -40,14 +40,16 @@ import (
 
 func (r *AuthenticationReconciler) handleSecrets(ctx context.Context, req ctrl.Request) (result *ctrl.Result, err error) {
 	log := logf.FromContext(ctx)
-	sCtx := logf.IntoContext(ctx, log)
+	debugLog := log.V(1)
+	debugCtx := logf.IntoContext(ctx, debugLog)
 
+	log.Info("Ensure Secrets are present and updated")
 	authCR := &operatorv1alpha1.Authentication{}
-	if result, err = r.getLatestAuthentication(sCtx, req, authCR); subreconciler.ShouldHaltOrRequeue(result, err) {
+	if result, err = r.getLatestAuthentication(debugCtx, req, authCR); subreconciler.ShouldHaltOrRequeue(result, err) {
 		return
 	}
 
-	secretSubreconcilers, err := r.getSecretSubreconcilers(sCtx, authCR)
+	secretSubreconcilers, err := r.getSecretSubreconcilers(debugCtx, authCR)
 	if err != nil {
 		log.Error(err, "Failed to generate updaters for Secrets")
 		return subreconciler.RequeueWithError(err)
@@ -56,7 +58,7 @@ func (r *AuthenticationReconciler) handleSecrets(ctx context.Context, req ctrl.R
 	results := []*ctrl.Result{}
 	errs := []error{}
 	for _, secretSubreconciler := range secretSubreconcilers {
-		result, err = secretSubreconciler.Reconcile(sCtx)
+		result, err = secretSubreconciler.Reconcile(debugCtx)
 		results = append(results, result)
 		errs = append(errs, err)
 	}

--- a/internal/controller/operator/service.go
+++ b/internal/controller/operator/service.go
@@ -32,9 +32,12 @@ import (
 
 func (r *AuthenticationReconciler) handleServices(ctx context.Context, req ctrl.Request) (result *ctrl.Result, err error) {
 	log := logf.FromContext(ctx)
+	debugLog := log.V(1)
+	debugCtx := logf.IntoContext(ctx, debugLog)
+
 	log.Info("Ensure Services are created")
 	authCR := &operatorv1alpha1.Authentication{}
-	if result, err = r.getLatestAuthentication(ctx, req, authCR); subreconciler.ShouldHaltOrRequeue(result, err) {
+	if result, err = r.getLatestAuthentication(debugCtx, req, authCR); subreconciler.ShouldHaltOrRequeue(result, err) {
 		return
 	}
 
@@ -95,7 +98,7 @@ func (r *AuthenticationReconciler) handleServices(ctx context.Context, req ctrl.
 	results := []*ctrl.Result{}
 	errs := []error{}
 	for _, reconciler := range subRecs {
-		result, err = reconciler.Reconcile(ctx)
+		result, err = reconciler.Reconcile(debugCtx)
 		results = append(results, result)
 		errs = append(errs, err)
 	}


### PR DESCRIPTION
* Further divided logging to be more terse by default
* Fixed an issue where wait for Cluster CR would block when configured to use external EDB