### PR TITLE
convert ClientSecret to string to avoid base64 encoding by json.Marshal

### DIFF
--- a/internal/controller/oidc.security/zen_registration.go
+++ b/internal/controller/oidc.security/zen_registration.go
@@ -166,7 +166,7 @@ func (r *ClientReconciler) registerZenInstance(ctx context.Context, clientCR *oi
 	log := logf.FromContext(ctx)
 	payloadJSON := map[string]interface{}{
 		"clientId":       clientCR.Spec.ClientId,
-		"clientSecret":   clientCreds.ClientSecret,
+		"clientSecret":   string(clientCreds.ClientSecret),
 		"instanceId":     clientCR.Spec.ZenInstanceId,
 		"productNameUrl": clientCR.Spec.ZenProductNameUrl,
 		"namespace":      clientCR.Namespace,


### PR DESCRIPTION
FIxes: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/67950

when we have value that of type []byte, json.Marshal is automatically doing a base64 encoding of that value
