### PR TITLE
operandrequest to support ibm-pg and upgrade to continue with edb for now

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": ".secrets.baseline|requirements.txt|go.mod|go.sum|pom.xml|build.gradle|package-lock.json|yarn.lock|Cargo.lock|deno.lock|composer.lock|Gemfile.lock|Pipfile.lock|npm-shrinkwrap.json|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-04-10T14:02:01Z",
+  "generated_at": "2026-04-14T19:49:23Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -146,7 +146,7 @@
         "hashed_secret": "b2541468dfb0f1f89fdf2215cad17b76f5de42e6",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 658,
+        "line_number": 666,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -908,7 +908,7 @@
         "hashed_secret": "0505ee303edffbbcb314426728ca74ac30ad2e71",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 356,
+        "line_number": 372,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -916,7 +916,7 @@
         "hashed_secret": "00c33fae362f8ba82f3d4ea54b7767ccd8a62ab8",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 549,
+        "line_number": 565,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -976,7 +976,7 @@
         "hashed_secret": "0e86a0a5c6d0f5385c99ff1b8d273e20c0df7563",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 54,
+        "line_number": 78,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/bundle/manifests/ibm-iam-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/ibm-iam-operator.clusterserviceversion.yaml
@@ -624,6 +624,14 @@ spec:
                 - list
                 - watch
             - apiGroups:
+                - pg.ibm.com
+              resources:
+                - clusters
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
                 - secrets-store.csi.x-k8s.io
               resources:
                 - secretproviderclasses

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -270,6 +270,14 @@ rules:
   - list
   - watch
 - apiGroups:
+    - pg.ibm.com
+  resources:
+    - clusters
+  verbs:
+    - get
+    - list
+    - watch
+- apiGroups:
   - secrets-store.csi.x-k8s.io
   resources:
   - secretproviderclasses

--- a/helm/templates/00-rbac.yaml
+++ b/helm/templates/00-rbac.yaml
@@ -299,6 +299,14 @@ rules:
   - list
   - watch
 - apiGroups:
+    - pg.ibm.com
+  resources:
+    - clusters
+  verbs:
+    - get
+    - list
+    - watch
+- apiGroups:
   - secrets-store.csi.x-k8s.io
   resources:
   - secretproviderclasses

--- a/internal/controller/operator/authentication_controller.go
+++ b/internal/controller/operator/authentication_controller.go
@@ -334,6 +334,7 @@ func (r *AuthenticationReconciler) runNonStatusSubreconcilers(ctx context.Contex
 		r.ensureOIDCClientRegistrationJobRuns,
 		r.handleZenFrontDoor,
 		r.handleRoutes,
+		r.handleUIOperandRequest,
 		r.handleHPAs,
 		r.syncClientHostnames,
 		r.handleMongoDBCleanup,

--- a/internal/controller/operator/migration.go
+++ b/internal/controller/operator/migration.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package operator
 
 import (
@@ -335,7 +351,7 @@ func (r *AuthenticationReconciler) ensureDatastoreSecretAndCM(ctx context.Contex
 		"ConfigMap.Namespace", authCR.Namespace)
 
 	useVaultForExtEDB := false
-	if isExternal, err := r.isConfiguredForExternalEDB(ctx, authCR); err == nil && isExternal {
+	if isExternal, err := r.isConfiguredForExternalDB(ctx, authCR); err == nil && isExternal {
 		edbSPC := &sscsidriverv1.SecretProviderClass{}
 		if authCR.SecretsStoreCSIEnabled() {
 			if err = getSecretProviderClassForVolume(r.Client, ctx, req.Namespace, "pgsql-certs", edbSPC); IsLabelConflictError(err) {

--- a/internal/controller/operator/operandbindinfo_test.go
+++ b/internal/controller/operator/operandbindinfo_test.go
@@ -49,7 +49,7 @@ var _ = Describe("OperandBindInfo handling", func() {
 			crds, err := envtest.InstallCRDs(cfg, envtest.CRDInstallOptions{
 				Paths: []string{filepath.Join(".", "testdata", "crds", "odlm")},
 			})
-			Expect(crds).To(HaveLen(1))
+			Expect(crds).To(HaveLen(2)) // operandbindinfo and operandrequest
 			Expect(err).ToNot(HaveOccurred())
 
 			authCR = &operatorv1alpha1.Authentication{

--- a/internal/controller/operator/operandrequest.go
+++ b/internal/controller/operator/operandrequest.go
@@ -19,6 +19,7 @@ package operator
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"reflect"
 	"time"
 
@@ -37,13 +38,14 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-// addEmbeddedDBIfNeeded appends the common-service-postgresql Operand to the list of Operands when the IM install is
-// configured to use an embedded EDB. If there is an error while trying to obtain the relevant IM configuration for EDB,
-// it will skip adding the Operand and return the encountered error.
+// addEmbeddedDBIfNeeded appends the common-service-cnpg Operand to the list of
+// Operands when the IM install is configured to use an embedded IBM CNPG. If there
+// is an error while trying to obtain the relevant IM configuration for IBM
+// CNPG, it will skip adding the Operand and return the encountered error.
 func (r *AuthenticationReconciler) addEmbeddedDBIfNeeded(ctx context.Context, authCR *operatorv1alpha1.Authentication,
 	operands *[]operatorv1alpha1.Operand) (err error) {
 	var usingExternal bool
-	if usingExternal, err = r.isConfiguredForExternalEDB(ctx, authCR); err != nil || usingExternal {
+	if usingExternal, err = r.isConfiguredForExternalDB(ctx, authCR); err != nil || usingExternal {
 		return
 	}
 	name := "common-service-cnpg"
@@ -59,17 +61,40 @@ func (r *AuthenticationReconciler) addEmbeddedDBIfNeeded(ctx context.Context, au
 	return
 }
 
-// handleOperandRequest manages the ibm-iam-request OperandRequest and adds or removes Operand entries from it depending
-// upon what the IM install needs. At a minimum, the UI Operator is included.
+// addEmbeddedEDBIfNeeded appends the common-service-postgresql Operand to the list of Operands when the IM install is
+// configured to use an embedded EDB. If there is an error while trying to obtain the relevant IM configuration for EDB,
+// it will skip adding the Operand and return the encountered error.
+func (r *AuthenticationReconciler) addEmbeddedEDBIfNeeded(ctx context.Context, authCR *operatorv1alpha1.Authentication,
+	operands *[]operatorv1alpha1.Operand) (err error) {
+	var usingExternal bool
+	if usingExternal, err = r.isConfiguredForExternalDB(ctx, authCR); err != nil || usingExternal {
+		return
+	}
+	name := "common-service-postgresql"
+	*operands = append(*operands, operatorv1alpha1.Operand{
+		Name: name,
+		Bindings: map[string]operatorv1alpha1.Bindable{
+			"protected-im-db": {
+				Secret:    ctrlcommon.DatastoreEDBSecretName,
+				Configmap: ctrlcommon.DatastoreEDBCMName,
+			},
+		},
+	})
+	return
+}
+
+// handleOperandRequest manages the OperandRequest for database operands. For backward compatibility,
+// it uses "ibm-iam-request" if it already exists, otherwise creates "im-needs-database".
+// The UI Operator is now managed by a separate OperandRequest (im-needs-ui).
 func (r *AuthenticationReconciler) handleOperandRequest(ctx context.Context, req ctrl.Request) (result *ctrl.Result, err error) {
-	opReqName := "ibm-iam-request"
+	legacyOpReqName := "ibm-iam-request"
+	newOpReqName := "im-needs-database"
 	log := logf.FromContext(ctx)
 	debugLog := log.V(1)
 	debugCtx := logf.IntoContext(ctx, debugLog)
 
 	log.Info("Ensure OperandRequest is present when supported by cluster and contains correct Operands")
 
-	log = logf.FromContext(ctx, "OperandRequest.Name", opReqName)
 	if !ctrlcommon.ClusterHasOperandRequestAPIResource(&r.DiscoveryClient) {
 		log.Info("The OperandRequest API resource is not supported by this cluster; assuming EDB connection will be configured manually", "Secret", ctrlcommon.DatastoreEDBSecretName, "ConfigMap", ctrlcommon.DatastoreEDBCMName, "Namespace", req.Namespace)
 		return subreconciler.ContinueReconciling()
@@ -80,14 +105,30 @@ func (r *AuthenticationReconciler) handleOperandRequest(ctx context.Context, req
 		return
 	}
 
-	desiredOperands := []operatorv1alpha1.Operand{
-		{Name: "ibm-idp-config-ui-operator"},
+	// Check if legacy OperandRequest exists and use the legacy name if it does exist
+	var opReqName string
+	legacyOpReq := &operatorv1alpha1.OperandRequest{}
+	desiredOperands := []operatorv1alpha1.Operand{}
+	if err = r.Get(debugCtx, types.NamespacedName{Name: legacyOpReqName, Namespace: authCR.Namespace}, legacyOpReq); k8sErrors.IsNotFound(err) {
+		opReqName = newOpReqName
+		log.Info("Using new OperandRequest name", "OperandRequest.Name", opReqName)
+		if err = r.addEmbeddedDBIfNeeded(debugCtx, authCR, &desiredOperands); err != nil {
+			log.Error(err, "Unexpected error was encountered while attempting to determine whether IBM CNPG needed")
+			return subreconciler.RequeueWithError(err)
+		}
+	} else if err != nil {
+		log.Error(err, "Unexpected error was encountered while trying to retrieve legacy OperandRequest", "OperandRequest.Name", legacyOpReqName)
+		return subreconciler.RequeueWithDelayAndError(defaultLowerWait, err)
+	} else {
+		opReqName = legacyOpReqName
+		log.Info("Using legacy OperandRequest name for backward compatibility", "OperandRequest.Name", opReqName)
+		if err = r.addEmbeddedEDBIfNeeded(debugCtx, authCR, &desiredOperands); err != nil {
+			log.Error(err, "Unexpected error was encountered while attempting to determine whether EDB needed")
+			return subreconciler.RequeueWithError(err)
+		}
 	}
 
-	if err = r.addEmbeddedDBIfNeeded(debugCtx, authCR, &desiredOperands); err != nil {
-		log.Error(err, "Unexpected error was encountered while attempting to determine whether EDB needed")
-		return subreconciler.RequeueWithError(err)
-	}
+	log = log.WithValues("OperandRequest.Name", opReqName)
 
 	observedOpReq := &operatorv1alpha1.OperandRequest{}
 	err = r.Get(debugCtx, types.NamespacedName{Name: opReqName, Namespace: authCR.Namespace}, observedOpReq)
@@ -154,7 +195,8 @@ func (r *AuthenticationReconciler) handleOperandRequest(ctx context.Context, req
 	}
 
 	if needToMigrate && observedMongoDBOperand != nil &&
-		!hasMongoDBOperandFromOperands(desiredOperands) {
+		!hasMongoDBOperandFromOperands(desiredOperands) &&
+		opReqName == legacyOpReqName { // TODO: Potentially remove this if IBM CNPG migration from MongoDB to be supported
 		desiredOperands = append(desiredOperands, *observedMongoDBOperand)
 	}
 
@@ -207,11 +249,11 @@ func operandsAreEqual(operandsA, operandsB []operatorv1alpha1.Operand) bool {
 	return true
 }
 
-// configuredForExternalEDB returns whether an Authentication is configured for connecting to an external EDB.
+// configuredForExternalDB returns whether an Authentication is configured for connecting to an external EDB.
 // This is determined by obtaining the `im-datastore-edb-cm` ConfigMap and reading its `IS_EMBEDDED` field.
 // If this value is set to "false", then the IM instance needs to use the connection details contained within this
 // ConfigMap.
-func (r *AuthenticationReconciler) isConfiguredForExternalEDB(ctx context.Context, authCR *operatorv1alpha1.Authentication) (isConfigured bool, err error) {
+func (r *AuthenticationReconciler) isConfiguredForExternalDB(ctx context.Context, authCR *operatorv1alpha1.Authentication) (isConfigured bool, err error) {
 	// stubbed until external EDB is supported
 	log := logf.FromContext(ctx)
 	cm := &corev1.ConfigMap{}
@@ -232,7 +274,7 @@ func (r *AuthenticationReconciler) needsExternalEDB(ctx context.Context, authCR 
 	if !ctrlcommon.ClusterHasOperandRequestAPIResource(&r.DiscoveryClient) {
 		return true, nil
 	}
-	isConfiguredForExternal, err := r.isConfiguredForExternalEDB(ctx, authCR)
+	isConfiguredForExternal, err := r.isConfiguredForExternalDB(ctx, authCR)
 	return isConfiguredForExternal, err
 }
 
@@ -383,4 +425,65 @@ func (r *AuthenticationReconciler) ensureCommonServiceDBIsReady(ctx context.Cont
 	}
 	log.Info("Cluster is not Ready")
 	return subreconciler.RequeueWithDelay(30 * time.Second)
+}
+
+// handleUIOperandRequest manages the UI OperandRequest using a SecondaryReconciler
+func (r *AuthenticationReconciler) handleUIOperandRequest(ctx context.Context, req ctrl.Request) (result *ctrl.Result, err error) {
+	log := logf.FromContext(ctx)
+	log.Info("Ensure UI OperandRequest is present when supported by cluster")
+
+	if !ctrlcommon.ClusterHasOperandRequestAPIResource(&r.DiscoveryClient) {
+		log.Info("The OperandRequest API resource is not supported by this cluster; skipping UI OperandRequest creation")
+		return subreconciler.ContinueReconciling()
+	}
+
+	authCR := &operatorv1alpha1.Authentication{}
+	if result, err = r.getLatestAuthentication(ctx, req, authCR); subreconciler.ShouldHaltOrRequeue(result, err) {
+		return
+	}
+
+	return r.getUIOperandRequestSubreconciler(authCR).Reconcile(ctx)
+}
+
+// getUIOperandRequestSubreconciler creates a subreconciler for managing the UI OperandRequest
+func (r *AuthenticationReconciler) getUIOperandRequestSubreconciler(authCR *operatorv1alpha1.Authentication) (subRec ctrlcommon.Subreconciler) {
+	return ctrlcommon.NewSecondaryReconcilerBuilder[*operatorv1alpha1.OperandRequest]().
+		WithName("im-needs-ui").
+		WithGenerateFns(generateUIOperandRequest).
+		WithClient(r.Client).
+		WithNamespace(authCR.Namespace).
+		WithPrimary(authCR).MustBuild()
+}
+
+// generateUIOperandRequest creates the OperandRequest for the UI operator
+func generateUIOperandRequest(s ctrlcommon.SecondaryReconciler, ctx context.Context, opReq *operatorv1alpha1.OperandRequest) error {
+	log := logf.FromContext(ctx)
+
+	primary := s.GetPrimary()
+	authCR, ok := primary.(*operatorv1alpha1.Authentication)
+	if !ok {
+		log.Error(nil, "Primary is not an Authentication CR")
+		return fmt.Errorf("primary is not an Authentication CR")
+	}
+
+	opReq.SetName(s.GetName())
+	opReq.SetNamespace(s.GetNamespace())
+
+	desiredOperands := []operatorv1alpha1.Operand{
+		{Name: "ibm-idp-config-ui-operator"},
+	}
+
+	desiredRequests := []operatorv1alpha1.Request{
+		{
+			Registry:          "common-service",
+			RegistryNamespace: authCR.Namespace,
+			Operands:          desiredOperands,
+		},
+	}
+
+	opReq.Spec = operatorv1alpha1.OperandRequestSpec{
+		Requests: desiredRequests,
+	}
+
+	return nil
 }

--- a/internal/controller/operator/operandrequest.go
+++ b/internal/controller/operator/operandrequest.go
@@ -451,6 +451,11 @@ func (r *AuthenticationReconciler) handleUIOperandRequest(ctx context.Context, r
 		return
 	}
 
+	if !authCR.Status.Service.DeploymentsReady() {
+		log.Info("IM Deployments are not Ready yet; requeueing")
+		return subreconciler.RequeueWithDelay(10 * time.Second)
+	}
+
 	return r.getUIOperandRequestSubreconciler(authCR).Reconcile(ctx)
 }
 

--- a/internal/controller/operator/operandrequest.go
+++ b/internal/controller/operator/operandrequest.go
@@ -153,8 +153,8 @@ func (r *AuthenticationReconciler) handleOperandRequest(ctx context.Context, req
 			Spec:       desiredOperandSpec,
 		}
 
-		if err = controllerutil.SetOwnerReference(authCR, desiredOpReq, r.Scheme); err != nil {
-			log.Error(err, "Failed to set owner reference on OperandRequest")
+		if err = controllerutil.SetControllerReference(authCR, desiredOpReq, r.Scheme); err != nil {
+			log.Error(err, "Failed to set controller reference on OperandRequest")
 			return subreconciler.RequeueWithError(err)
 		}
 		if err = r.Create(debugCtx, desiredOpReq); k8sErrors.IsAlreadyExists(err) {
@@ -217,8 +217,8 @@ func (r *AuthenticationReconciler) handleOperandRequest(ctx context.Context, req
 		return subreconciler.ContinueReconciling()
 	}
 
-	if err = controllerutil.SetOwnerReference(authCR, observedOpReq, r.Scheme); err != nil {
-		log.Error(err, "Failed to set owner reference on OperandRequest")
+	if err = controllerutil.SetControllerReference(authCR, observedOpReq, r.Scheme); err != nil {
+		log.Error(err, "Failed to set controller reference on OperandRequest")
 		return subreconciler.RequeueWithError(err)
 	}
 	if err = r.Update(debugCtx, observedOpReq); err != nil {
@@ -483,6 +483,11 @@ func generateUIOperandRequest(s ctrlcommon.SecondaryReconciler, ctx context.Cont
 
 	opReq.Spec = operatorv1alpha1.OperandRequestSpec{
 		Requests: desiredRequests,
+	}
+
+	if err := controllerutil.SetControllerReference(authCR, opReq, s.GetClient().Scheme()); err != nil {
+		log.Error(err, "Failed to set controller reference on OperandRequest")
+		return err
 	}
 
 	return nil

--- a/internal/controller/operator/operandrequest.go
+++ b/internal/controller/operator/operandrequest.go
@@ -385,9 +385,9 @@ func (r *AuthenticationReconciler) ensureCommonServiceDBIsReady(ctx context.Cont
 		return subreconciler.RequeueWithError(err)
 	}
 
-	// clusterAPIVersion := "postgresql.k8s.enterprisedb.io/v1"
-	clusterAPIVersion := "pg.ibm.com/v1"
-	log = log.WithValues("Object.Name", "common-service-db", "Object.Kind", "Cluster", "Object.APIVersion", clusterAPIVersion)
+	legacyClusterAPIVersion := "postgresql.k8s.enterprisedb.io/v1"
+	cnpgClusterAPIVersion := "pg.ibm.com/v1"
+	clusterAPIVersion := cnpgClusterAPIVersion
 
 	u := &unstructured.Unstructured{
 		Object: map[string]any{
@@ -396,12 +396,21 @@ func (r *AuthenticationReconciler) ensureCommonServiceDBIsReady(ctx context.Cont
 		},
 	}
 	if err = r.Get(ctx, types.NamespacedName{Name: "common-service-db", Namespace: req.Namespace}, u); k8sErrors.IsNotFound(err) {
-		log.Info("Cluster not found")
+		log.Info("CNPG Cluster not found, try getting legacy EDB Cluster")
+		clusterAPIVersion = legacyClusterAPIVersion
+		u.Object["apiVersion"] = clusterAPIVersion
+		if err = r.Get(ctx, types.NamespacedName{Name: "common-service-db", Namespace: req.Namespace}, u); err != nil && !k8sErrors.IsNotFound(err) {
+			log.Error(err, "Legacy EDB Cluster could not be retrieved")
+			return subreconciler.RequeueWithError(err)
+		}
+		log.Info("Legacy EDB Cluster not found, requeueing")
 		return subreconciler.RequeueWithDelay(30 * time.Second)
 	} else if err != nil {
-		log.Error(err, "Cluster could not be retrieved")
+		log.Error(err, "CNPG Cluster could not be retrieved")
 		return subreconciler.RequeueWithError(err)
 	}
+
+	log = log.WithValues("Object.Name", "common-service-db", "Object.Kind", "Cluster", "Object.APIVersion", clusterAPIVersion)
 	type cluster struct {
 		metav1.ObjectMeta
 		metav1.TypeMeta

--- a/internal/controller/operator/operandrequest.go
+++ b/internal/controller/operator/operandrequest.go
@@ -46,7 +46,7 @@ func (r *AuthenticationReconciler) addEmbeddedDBIfNeeded(ctx context.Context, au
 	if usingExternal, err = r.isConfiguredForExternalEDB(ctx, authCR); err != nil || usingExternal {
 		return
 	}
-	name := "common-service-postgresql"
+	name := "common-service-cnpg"
 	*operands = append(*operands, operatorv1alpha1.Operand{
 		Name: name,
 		Bindings: map[string]operatorv1alpha1.Bindable{
@@ -343,7 +343,8 @@ func (r *AuthenticationReconciler) ensureCommonServiceDBIsReady(ctx context.Cont
 		return subreconciler.RequeueWithError(err)
 	}
 
-	clusterAPIVersion := "postgresql.k8s.enterprisedb.io/v1"
+	// clusterAPIVersion := "postgresql.k8s.enterprisedb.io/v1"
+	clusterAPIVersion := "pg.ibm.com/v1"
 	log = log.WithValues("Object.Name", "common-service-db", "Object.Kind", "Cluster", "Object.APIVersion", clusterAPIVersion)
 
 	u := &unstructured.Unstructured{

--- a/internal/controller/operator/operandrequest_test.go
+++ b/internal/controller/operator/operandrequest_test.go
@@ -1,20 +1,41 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package operator
 
 import (
 	"context"
+	"path/filepath"
 	"testing"
 
 	operatorv1alpha1 "github.com/IBM/ibm-iam-operator/api/operator/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/discovery"
 
 	ctrlcommon "github.com/IBM/ibm-iam-operator/internal/controller/common"
 	testutil "github.com/IBM/ibm-iam-operator/test/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	//"testing"
 )
 
@@ -107,7 +128,7 @@ var _ = Describe("OperandRequest handling", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(len(*operands)).To(Equal(1))
 				Expect((*operands)[0]).ToNot(BeNil())
-				Expect((*operands)[0].Name).To(Equal("common-service-postgresql"))
+				Expect((*operands)[0].Name).To(Equal("common-service-cnpg"))
 			})
 
 			It("should add the embedded EDB entry to the list of Operands", func() {
@@ -133,7 +154,7 @@ var _ = Describe("OperandRequest handling", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(len(*operands)).To(Equal(1))
 				Expect((*operands)[0]).ToNot(BeNil())
-				Expect((*operands)[0].Name).To(Equal("common-service-postgresql"))
+				Expect((*operands)[0].Name).To(Equal("common-service-cnpg"))
 			})
 
 			It("should add the embedded EDB entry to the list of Operands", func() {
@@ -142,7 +163,7 @@ var _ = Describe("OperandRequest handling", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(len(*operands)).To(Equal(1))
 				Expect((*operands)[0]).ToNot(BeNil())
-				Expect((*operands)[0].Name).To(Equal("common-service-postgresql"))
+				Expect((*operands)[0].Name).To(Equal("common-service-cnpg"))
 			})
 
 			It("should NOT add the embedded EDB entry to the list of Operands", func() {
@@ -290,7 +311,7 @@ var _ = Describe("OperandRequest handling", func() {
 		})
 	})
 
-	Describe("isConfiguredForExternalEDB", func() {
+	Describe("isConfiguredForExternalDB", func() {
 		var cm *corev1.ConfigMap
 		BeforeEach(func() {
 			authCR = &operatorv1alpha1.Authentication{
@@ -330,7 +351,7 @@ var _ = Describe("OperandRequest handling", func() {
 			}
 		})
 		It("returns false when IS_EMBEDDED is not set", func() {
-			isExternal, err := r.isConfiguredForExternalEDB(context.Background(), authCR)
+			isExternal, err := r.isConfiguredForExternalDB(context.Background(), authCR)
 			Expect(isExternal).To(BeFalse())
 			Expect(err).ToNot(HaveOccurred())
 		})
@@ -338,7 +359,7 @@ var _ = Describe("OperandRequest handling", func() {
 			cm.Data["IS_EMBEDDED"] = ""
 			err := r.Update(context.Background(), cm)
 			Expect(err).ToNot(HaveOccurred())
-			isExternal, err := r.isConfiguredForExternalEDB(context.Background(), authCR)
+			isExternal, err := r.isConfiguredForExternalDB(context.Background(), authCR)
 			Expect(isExternal).To(BeFalse())
 			Expect(err).ToNot(HaveOccurred())
 		})
@@ -346,7 +367,7 @@ var _ = Describe("OperandRequest handling", func() {
 			cm.Data["IS_EMBEDDED"] = "true"
 			err := r.Update(context.Background(), cm)
 			Expect(err).ToNot(HaveOccurred())
-			isExternal, err := r.isConfiguredForExternalEDB(context.Background(), authCR)
+			isExternal, err := r.isConfiguredForExternalDB(context.Background(), authCR)
 			Expect(isExternal).To(BeFalse())
 			Expect(err).ToNot(HaveOccurred())
 		})
@@ -354,14 +375,14 @@ var _ = Describe("OperandRequest handling", func() {
 			cm.Data["IS_EMBEDDED"] = "false"
 			err := r.Update(context.Background(), cm)
 			Expect(err).ToNot(HaveOccurred())
-			isExternal, err := r.isConfiguredForExternalEDB(context.Background(), authCR)
+			isExternal, err := r.isConfiguredForExternalDB(context.Background(), authCR)
 			Expect(isExternal).To(BeTrue())
 			Expect(err).ToNot(HaveOccurred())
 		})
 		It("returns false when the ConfigMap can't be found", func() {
 			err := r.Delete(context.Background(), cm)
 			Expect(err).ToNot(HaveOccurred())
-			isExternal, err := r.isConfiguredForExternalEDB(context.Background(), authCR)
+			isExternal, err := r.isConfiguredForExternalDB(context.Background(), authCR)
 			Expect(isExternal).To(BeFalse())
 			Expect(err).ToNot(HaveOccurred())
 		})
@@ -376,7 +397,7 @@ var _ = Describe("OperandRequest handling", func() {
 					},
 				},
 			}
-			isExternal, err := rFailing.isConfiguredForExternalEDB(context.Background(), authCR)
+			isExternal, err := rFailing.isConfiguredForExternalDB(context.Background(), authCR)
 			Expect(isExternal).To(BeFalse())
 			Expect(err).To(HaveOccurred())
 		})
@@ -462,4 +483,165 @@ var _ = Describe("getMongoDBOperatorOperand", func() {
 		Entry("When empty Requests are set", []operatorv1alpha1.Request{}, nil),
 	)
 
+	var _ = Describe("handleOperandRequest backward compatibility", Ordered, func() {
+		var r *AuthenticationReconciler
+		var authCR *operatorv1alpha1.Authentication
+		var cb fakeclient.ClientBuilder
+		var cl client.WithWatch
+		var scheme *runtime.Scheme
+		var ctx context.Context
+		var nsName string
+
+		BeforeAll(func() {
+			By("bootstrapping test environment with OperandRequest CRD")
+			crds, err := envtest.InstallCRDs(cfg, envtest.CRDInstallOptions{
+				Paths: []string{filepath.Join(".", "testdata", "crds", "odlm")},
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(crds).To(HaveLen(2)) // operandbindinfo and operandrequest
+
+			nsName = "operandrequest-bc-test"
+			ns := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: nsName,
+				},
+			}
+			err = k8sClient.Create(context.Background(), ns)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		BeforeEach(func() {
+			ctx = context.Background()
+			authCR = &operatorv1alpha1.Authentication{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "operator.ibm.com/v1alpha1",
+					Kind:       "Authentication",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "example-authentication",
+					Namespace: nsName,
+				},
+			}
+			scheme = runtime.NewScheme()
+			Expect(corev1.AddToScheme(scheme)).To(Succeed())
+			Expect(operatorv1alpha1.AddODLMEnabledToScheme(scheme)).To(Succeed())
+		})
+
+		Context("When ibm-iam-request does NOT exist", func() {
+			BeforeEach(func() {
+				cb = *fakeclient.NewClientBuilder().
+					WithScheme(scheme).
+					WithRuntimeObjects(authCR)
+				cl = cb.Build()
+				dc, err := discovery.NewDiscoveryClientForConfig(cfg)
+				Expect(err).NotTo(HaveOccurred())
+				r = &AuthenticationReconciler{
+					Client: &ctrlcommon.FallbackClient{
+						Client: cl,
+						Reader: cl,
+					},
+					Scheme:          scheme,
+					DiscoveryClient: *dc,
+				}
+			})
+
+			It("should create im-needs-database with common-service-cnpg operand and NOT create ibm-iam-request", func() {
+				By("calling handleOperandRequest")
+				result, err := r.handleOperandRequest(ctx, ctrl.Request{
+					NamespacedName: client.ObjectKeyFromObject(authCR),
+				})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).ToNot(BeNil())
+
+				By("verifying im-needs-database was created")
+				newOpReq := &operatorv1alpha1.OperandRequest{}
+				err = r.Get(ctx, client.ObjectKey{Name: "im-needs-database", Namespace: authCR.Namespace}, newOpReq)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(newOpReq.Name).To(Equal("im-needs-database"))
+				Expect(len(newOpReq.Spec.Requests)).To(Equal(1))
+				Expect(len(newOpReq.Spec.Requests[0].Operands)).To(Equal(1))
+				Expect(newOpReq.Spec.Requests[0].Operands[0].Name).To(Equal("common-service-cnpg"))
+
+				By("verifying ibm-iam-request was NOT created")
+				legacyOpReq := &operatorv1alpha1.OperandRequest{}
+				err = r.Get(ctx, client.ObjectKey{Name: "ibm-iam-request", Namespace: authCR.Namespace}, legacyOpReq)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("not found"))
+			})
+		})
+
+		Context("When ibm-iam-request DOES exist", func() {
+			var legacyOpReq *operatorv1alpha1.OperandRequest
+
+			BeforeEach(func() {
+				legacyOpReq = &operatorv1alpha1.OperandRequest{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "operator.ibm.com/v1alpha1",
+						Kind:       "OperandRequest",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "ibm-iam-request",
+						Namespace: nsName,
+					},
+					Spec: operatorv1alpha1.OperandRequestSpec{
+						Requests: []operatorv1alpha1.Request{
+							{
+								Registry:          "common-service",
+								RegistryNamespace: nsName,
+								Operands: []operatorv1alpha1.Operand{
+									{Name: "common-service-cnpg"},
+								},
+							},
+						},
+					},
+				}
+				cb = *fakeclient.NewClientBuilder().
+					WithScheme(scheme).
+					WithRuntimeObjects(authCR, legacyOpReq)
+				cl = cb.Build()
+				dc, err := discovery.NewDiscoveryClientForConfig(cfg)
+				Expect(err).NotTo(HaveOccurred())
+				r = &AuthenticationReconciler{
+					Client: &ctrlcommon.FallbackClient{
+						Client: cl,
+						Reader: cl,
+					},
+					Scheme:          scheme,
+					DiscoveryClient: *dc,
+				}
+			})
+
+			It("should NOT create im-needs-database and continue using ibm-iam-request", func() {
+				By("calling handleOperandRequest")
+				result, err := r.handleOperandRequest(ctx, ctrl.Request{
+					NamespacedName: client.ObjectKeyFromObject(authCR),
+				})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).ToNot(BeNil())
+
+				By("verifying ibm-iam-request still exists and is being used")
+				existingOpReq := &operatorv1alpha1.OperandRequest{}
+				err = r.Get(ctx, client.ObjectKey{Name: "ibm-iam-request", Namespace: authCR.Namespace}, existingOpReq)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(existingOpReq.Name).To(Equal("ibm-iam-request"))
+
+				By("verifying im-needs-database was NOT created")
+				newOpReq := &operatorv1alpha1.OperandRequest{}
+				err = r.Get(ctx, client.ObjectKey{Name: "im-needs-database", Namespace: authCR.Namespace}, newOpReq)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("not found"))
+			})
+		})
+
+		AfterAll(func() {
+			By("cleaning up test namespace")
+			ns := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: nsName,
+				},
+			}
+			err := k8sClient.Delete(context.Background(), ns)
+			Expect(err).To(Or(BeNil(), Satisfy(k8sErrors.IsNotFound)))
+		})
+	})
 })

--- a/internal/controller/operator/testdata/crds/odlm/operandrequest_crd.yaml
+++ b/internal/controller/operator/testdata/crds/odlm/operandrequest_crd.yaml
@@ -1,0 +1,354 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.14.0
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: operand-deployment-lifecycle-manager
+    app.kubernetes.io/managed-by: operand-deployment-lifecycle-manager
+    app.kubernetes.io/name: operand-deployment-lifecycle-manager
+  name: operandrequests.operator.ibm.com
+spec:
+  group: operator.ibm.com
+  names:
+    kind: OperandRequest
+    listKind: OperandRequestList
+    plural: operandrequests
+    shortNames:
+    - opreq
+    singular: operandrequest
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Current Phase
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Created At
+      type: string
+    - jsonPath: .status.services[*].operatorName
+      name: Service
+      priority: 1
+      type: string
+    - jsonPath: .status.services[*].status
+      name: S_Status
+      priority: 1
+      type: string
+    - jsonPath: .status.services[*].resources[-1].objectName
+      name: Obj_Name
+      priority: 1
+      type: string
+    - jsonPath: .status.services[*].resources[-1].status
+      name: Obj_Status
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[-1].lastTransitionTime
+      name: Last_Transition
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[-1].status
+      name: L_Status
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[-1].reason
+      name: Reason
+      priority: 1
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: OperandRequest is the Schema for the operandrequests API. Documentation
+          For additional details regarding install parameters check https://ibm.biz/icpfs39install.
+          License By installing this product you accept the license terms https://ibm.biz/icpfs39license
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: The OperandRequestSpec identifies one or more specific operands
+              (from a specific Registry) that should actually be installed.
+            properties:
+              requests:
+                description: Requests defines a list of operands installation.
+                items:
+                  description: Request identifies a operand detail.
+                  properties:
+                    description:
+                      description: Description is an optional description for the
+                        request.
+                      type: string
+                    operands:
+                      description: Operands defines a list of the OperandRegistry
+                        entry for the operand to be deployed.
+                      items:
+                        description: Operand defines the name and binding information
+                          for one operator.
+                        properties:
+                          apiVersion:
+                            description: APIVersion defines the versioned schema of
+                              this representation of an object.
+                            type: string
+                          bindings:
+                            additionalProperties:
+                              description: |-
+                                Bindable is a Kubernetes resources to be shared from one namespace to another.
+                                List of supported resources are Secrets, Configmaps, Services, and Routes.
+                                Secrets and Configmaps will be copied such that a new Secret/Configmap with
+                                exactly the same data will be created in the target namespace.
+                                Services and Routes data will be copied into a configmap in the target
+                                namespace.
+                              properties:
+                                configmap:
+                                  description: The configmap identifies an existing
+                                    configmap object. if it exists, the ODLM will
+                                    share to the namespace of the OperandRequest.
+                                  type: string
+                                route:
+                                  description: |-
+                                    Route data will be shared by copying it into a configmap which is then
+                                    created in the target namespace
+                                  properties:
+                                    data:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        Data is a key-value pair where the value is a YAML path to a value in the
+                                        OpenShift Route, e.g. .spec.host or .spec.tls.termination
+                                      type: object
+                                    name:
+                                      description: Name is the name of the OpenShift
+                                        Route resource
+                                      type: string
+                                  type: object
+                                secret:
+                                  description: The secret identifies an existing secret.
+                                    if it exists, the ODLM will share to the namespace
+                                    of the OperandRequest.
+                                  type: string
+                                service:
+                                  description: |-
+                                    Service data will be shared by copying it into a configmap which is then
+                                    created in the target namespace
+                                  properties:
+                                    data:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        Data is a key-value pair where the value is a YAML path to a value in the
+                                        Kubernetes Service, e.g. .spec.ports[0]port
+                                      type: object
+                                    name:
+                                      description: Name is the name of the Kubernetes
+                                        Service resource
+                                      type: string
+                                  type: object
+                              type: object
+                            description: The bindings section is used to specify names
+                              of secret and/or configmap.
+                            type: object
+                          instanceName:
+                            description: |-
+                              InstanceName is used when users want to deploy multiple custom resources.
+                              It is the name of the custom resource.
+                            type: string
+                          kind:
+                            description: |-
+                              Kind is used when users want to deploy multiple custom resources.
+                              Kind identifies the kind of the custom resource.
+                            type: string
+                          name:
+                            description: Name of the operand to be deployed.
+                            type: string
+                          spec:
+                            description: |-
+                              Spec is used when users want to deploy multiple custom resources.
+                              It is the configuration map of custom resource.
+                            nullable: true
+                            type: object
+                            x-kubernetes-preserve-unknown-fields: true
+                        required:
+                        - name
+                        type: object
+                      type: array
+                    registry:
+                      description: Specifies the name in which the OperandRegistry
+                        reside.
+                      type: string
+                    registryNamespace:
+                      description: |-
+                        Specifies the namespace in which the OperandRegistry reside.
+                        The default is the current namespace in which the request is defined.
+                      type: string
+                  required:
+                  - operands
+                  - registry
+                  type: object
+                type: array
+            required:
+            - requests
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            description: OperandRequestStatus defines the observed state of OperandRequest.
+            properties:
+              conditions:
+                description: Conditions represents the current state of the Request
+                  Service.
+                items:
+                  description: |-
+                    Condition represents the current state of the Request Service.
+                    A condition might not show up if it is not happening.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      type: string
+                    lastUpdateTime:
+                      description: The last time this condition was updated.
+                      type: string
+                    message:
+                      description: A human readable message indicating details about
+                        the transition.
+                      type: string
+                    reason:
+                      description: The reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: Status of the condition, one of True, False, Unknown.
+                      type: string
+                    type:
+                      description: Type of condition.
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              members:
+                description: Members represnets the current operand status of the
+                  set.
+                items:
+                  description: MemberStatus shows if the Operator is ready.
+                  properties:
+                    name:
+                      description: The member name are the same as the subscription
+                        name.
+                      type: string
+                    operandCRList:
+                      description: OperandCRList shows the list of custom resource
+                        created by OperandRequest.
+                      items:
+                        description: OperandCRMember defines a custom resource created
+                          by OperandRequest.
+                        properties:
+                          apiVersion:
+                            description: APIVersion is the APIVersion of the custom
+                              resource.
+                            type: string
+                          kind:
+                            description: Kind is the kind of the custom resource.
+                            type: string
+                          name:
+                            description: Name is the name of the custom resource.
+                            type: string
+                        type: object
+                      type: array
+                    phase:
+                      description: The operand phase include None, Creating, Running,
+                        Failed.
+                      properties:
+                        operandPhase:
+                          description: OperandPhase shows the deploy phase of the
+                            operator instance.
+                          type: string
+                        operatorPhase:
+                          description: OperatorPhase shows the deploy phase of the
+                            operator.
+                          type: string
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
+              phase:
+                description: Phase is the cluster running phase.
+                type: string
+              services:
+                description: Services reflect the status of operands beyond whether
+                  they have been created
+                items:
+                  properties:
+                    namespace:
+                      type: string
+                    operatorName:
+                      type: string
+                    resources:
+                      description: LastUpdateTime string `json:"lastTransitionTime,omitempty"`
+                      items:
+                        properties:
+                          apiVersion:
+                            type: string
+                          kind:
+                            type: string
+                          managedResources:
+                            description: Message string `json:"message,omitempty"`
+                            items:
+                              properties:
+                                apiVersion:
+                                  type: string
+                                kind:
+                                  type: string
+                                namespace:
+                                  type: string
+                                objectName:
+                                  type: string
+                                status:
+                                  description: Type string `json:"type,omitempty"`
+                                  type: string
+                              type: object
+                            type: array
+                          namespace:
+                            type: string
+                          objectName:
+                            type: string
+                          status:
+                            type: string
+                        type: object
+                      type: array
+                    status:
+                      description: Type string `json:"type,omitempty"`
+                      type: string
+                  type: object
+                type: array
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null


### PR DESCRIPTION
From @rwhundley 
- For fresh install, there is a new OpReq, `im-needs-database`, and this contains the IBM PG request
- For upgrade, `ibm-iam-request` is kept, and it should allow MongoDB upgrades to work still with EDB
- In all cases, another new OpReq, `im-needs-ui`, is created, and it requests the UI separately. It is installed redundantly for now on upgrade.
Main reason for splitting off the OperandRequests was because of a CPD performance ticket re: UI startup time, so we want to start UI later in reconciliation on fresh install.