### PR TITLE
Update go version to 1.26.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,7 +175,7 @@ KUSTOMIZE_VERSION ?= v5.6.0
 CONTROLLER_TOOLS_VERSION ?= v0.17.2
 OPERATOR_SDK_VERSION ?= v1.37.0
 YQ_VERSION ?= v4.44.3
-GO_VERSION ?= 1.26.3
+GO_VERSION ?= 1.26.4
 
 # ENVTEST_VERSION is the version of controller-runtime release branch to fetch the envtest setup script (i.e. release-0.20)
 ENVTEST_VERSION ?= $(shell go list -m -f "{{ .Version }}" sigs.k8s.io/controller-runtime | awk -F'[v.]' '{printf "release-%d.%d", $$2, $$3}')

--- a/build_scripts/build_image.sh
+++ b/build_scripts/build_image.sh
@@ -19,7 +19,7 @@ export BUILD_LOCALLY=0
 
 echo "***************** Install go *****************"
 
-GO_VERSION="1.26.3"
+GO_VERSION="1.26.4"
 curl -sLO "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz"
 sudo rm -rf /usr/local/go
 sudo tar -C /usr/local -xzf "go${GO_VERSION}.linux-amd64.tar.gz"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/IBM/ibm-iam-operator
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/google/uuid v1.6.0


### PR DESCRIPTION
https://github.ibm.com/IBMPrivateCloud/roadmap/issues/69061