### PR TITLE
fix: unconditional scheme registration and retry SSAR checks at startup

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -29,7 +29,6 @@ import (
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
-	authorizationv1 "k8s.io/api/authorization/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -68,161 +67,38 @@ func init() {
 	utilruntime.Must(certmgrv1.AddToScheme(scheme))
 	utilruntime.Must(zenv1.AddToScheme(scheme))
 
-	// Get config and create clients for SSAR checks
+	// Always register all known API types unconditionally.
+	//
+	// Scheme registration must not be gated on runtime RBAC checks because init()
+	// runs exactly once at process startup — before ibm-namespace-scope-operator
+	// has had a chance to project permissions into watched namespaces.  If a SSAR
+	// check were to fail here (due to that race), the type would be permanently
+	// absent from the scheme for the lifetime of the process, causing "no kind is
+	// registered" panics during reconciliation even after RBAC is later granted.
+	//
+	// Scheme registration has no security implication; it merely maps Go types to
+	// GroupVersionKinds.  The actual access-gating (deciding whether to *watch* a
+	// resource) is handled by SetupWithManager, which runs its own SSAR checks
+	// with a retry loop that tolerates the startup race.
+	utilruntime.Must(operatorv1alpha1.AddODLMEnabledToScheme(scheme))
+	utilruntime.Must(routev1.AddToScheme(scheme))
+	utilruntime.Must(networkingv1.AddToScheme(scheme))
+
+	// SecretProviderClass: only available when the CSI driver CRD is installed.
+	// Detect its presence via discovery before registering to avoid a panic on
+	// clusters that do not have the CRD at all.
 	cfg, err := config.GetConfig()
 	if err != nil {
 		return
 	}
-
 	dc, err := discovery.NewDiscoveryClientForConfig(cfg)
 	if err != nil {
 		return
 	}
-
-	// Create a temporary client for SSAR checks during init
-	tempClient, err := client.New(cfg, client.Options{Scheme: scheme})
-	if err != nil {
-		setupLog.Error(err, "Failed to create temporary client for SSAR checks")
-		return
-	}
-
-	ctx := context.Background()
-
-	// Get watch namespaces for permission checks
-	watchNamespaceEnv := os.Getenv("WATCH_NAMESPACE")
-	var namespacesToCheck []string
-	if watchNamespaceEnv == "" {
-		// Empty string means cluster-wide, check with empty namespace
-		namespacesToCheck = []string{""}
-	} else {
-		// Split comma-separated namespaces
-		namespacesToCheck = strings.Split(watchNamespaceEnv, ",")
-	}
-
-	// Check OperandRequest permissions across all watch namespaces
-	operandRequestVerbs := []string{"create", "get", "list", "patch", "watch", "update", "delete"}
-	if controllercommon.ClusterHasOperandRequestAPIResource(dc) {
-		hasOperandRequestAccess, err := hasNamespacedAPIAccessForNamespaces(ctx, tempClient, namespacesToCheck, "operator.ibm.com", "operandrequests", operandRequestVerbs)
-		if err != nil {
-			setupLog.Error(err, "Failed to check OperandRequest permissions")
-			hasOperandRequestAccess = false
-		}
-		if hasOperandRequestAccess {
-			setupLog.V(1).Info("OperandRequest API present with required permissions in all watch namespaces; adding ODLM-enabled operator.ibm.com scheme")
-			utilruntime.Must(operatorv1alpha1.AddODLMEnabledToScheme(scheme))
-		} else {
-			setupLog.Info("OperandRequest API present but missing required permissions; adding base operator.ibm.com scheme")
-			utilruntime.Must(operatorv1alpha1.AddToScheme(scheme))
-		}
-	} else {
-		setupLog.V(1).Info("OperandRequest API not present; adding base operator.ibm.com scheme")
-		utilruntime.Must(operatorv1alpha1.AddToScheme(scheme))
-	}
-
-	// Check Route permissions (including routes/custom-host subresource) across all watch namespaces
-	routeVerbs := []string{"get", "list", "watch", "create", "delete", "update", "patch"}
-	if controllercommon.ClusterHasRouteGroupVersion(dc) {
-		hasRouteAccess, err := hasNamespacedAPIAccessForNamespaces(ctx, tempClient, namespacesToCheck, "route.openshift.io", "routes", routeVerbs)
-		if err != nil {
-			setupLog.Error(err, "Failed to check Route permissions")
-			hasRouteAccess = false
-		}
-
-		if hasRouteAccess {
-			// Also check routes/custom-host subresource permission across all namespaces
-			hasCustomHostAccess, err := hasNamespacedAPIAccessForNamespaces(ctx, tempClient, namespacesToCheck, "route.openshift.io", "routes/custom-host", []string{"create"})
-			if err != nil {
-				setupLog.Error(err, "Failed to check routes/custom-host permissions")
-				hasCustomHostAccess = false
-			}
-			if !hasCustomHostAccess {
-				setupLog.Info("Route API present but missing routes/custom-host create permission in one or more namespaces")
-			}
-
-			if hasCustomHostAccess {
-				setupLog.V(1).Info("Route API present with all required permissions including routes/custom-host in all watch namespaces; adding Routes to scheme")
-				utilruntime.Must(routev1.AddToScheme(scheme))
-			} else {
-				setupLog.Info("Route API present but missing routes/custom-host create permission; skipping Routes scheme")
-			}
-		} else {
-			setupLog.Info("Route API present but missing required permissions; skipping Routes scheme")
-		}
-	}
-
-	// Check Ingress permissions across all watch namespaces
-	ingressVerbs := []string{"delete", "get", "list", "watch"}
-	if controllercommon.ClusterHasIngressGroupVersion(dc) {
-		hasIngressAccess, err := hasNamespacedAPIAccessForNamespaces(ctx, tempClient, namespacesToCheck, "networking.k8s.io", "ingresses", ingressVerbs)
-		if err != nil {
-			setupLog.Error(err, "Failed to check Ingress permissions")
-			hasIngressAccess = false
-		}
-
-		if hasIngressAccess {
-			setupLog.V(1).Info("Ingress API present with required permissions in all watch namespaces; adding Ingress to scheme")
-			utilruntime.Must(networkingv1.AddToScheme(scheme))
-		} else {
-			setupLog.Info("Ingress API present but missing required permissions; skipping Ingress scheme")
-		}
-	}
-
-	// Check SecretProviderClass permissions across all watch namespaces
-	spcVerbs := []string{"get", "list", "watch"}
 	if controllercommon.ClusterHasCSIGroupVersion(dc) {
-		hasSPCAccess, err := hasNamespacedAPIAccessForNamespaces(ctx, tempClient, namespacesToCheck, "secrets-store.csi.x-k8s.io", "secretproviderclasses", spcVerbs)
-		if err != nil {
-			setupLog.Error(err, "Failed to check SecretProviderClass permissions")
-			hasSPCAccess = false
-		}
-		if hasSPCAccess {
-			setupLog.V(1).Info("SSCSI API present with required permissions in all watch namespaces; adding SSCSI driver to scheme")
-			utilruntime.Must(sscsidriverv1.AddToScheme(scheme))
-		} else {
-			setupLog.Info("SSCSI API present but missing required permissions; skipping SSCSI driver scheme")
-		}
+		utilruntime.Must(sscsidriverv1.AddToScheme(scheme))
 	}
 	//+kubebuilder:scaffold:scheme
-}
-
-// hasNamespacedAPIAccess uses SelfSubjectAccessReviews to check if the operator has all required permissions
-// for a given namespaced resource. Empty namespace means check without namespace scope.
-func hasNamespacedAPIAccess(ctx context.Context, c client.Client, namespace string, group string, resource string, verbs []string) (bool, error) {
-	for _, verb := range verbs {
-		ssar := &authorizationv1.SelfSubjectAccessReview{
-			Spec: authorizationv1.SelfSubjectAccessReviewSpec{
-				ResourceAttributes: &authorizationv1.ResourceAttributes{
-					Namespace: namespace,
-					Verb:      verb,
-					Group:     group,
-					Resource:  resource,
-				},
-			},
-		}
-		if err := c.Create(ctx, ssar); err != nil {
-			return false, fmt.Errorf("failed to create SSAR for %s.%s verb %s: %w", resource, group, verb, err)
-		}
-		if !ssar.Status.Allowed {
-			return false, nil
-		}
-	}
-	return true, nil
-}
-
-// hasNamespacedAPIAccessForNamespaces checks if the operator has all required permissions
-// for a given namespaced resource across multiple namespaces. It fails fast, returning
-// an error or false as soon as any namespace check fails.
-func hasNamespacedAPIAccessForNamespaces(ctx context.Context, c client.Client, namespaces []string, group string, resource string, verbs []string) (bool, error) {
-	for _, ns := range namespaces {
-		hasAccess, err := hasNamespacedAPIAccess(ctx, c, ns, group, resource, verbs)
-		if err != nil {
-			return false, err
-		}
-		if !hasAccess {
-			return false, nil
-		}
-	}
-	return true, nil
 }
 
 func main() {

--- a/internal/controller/operator/authentication_controller.go
+++ b/internal/controller/operator/authentication_controller.go
@@ -426,9 +426,38 @@ func (r *AuthenticationReconciler) Reconcile(rootCtx context.Context, req ctrl.R
 }
 
 // SetupWithManager sets up the controller with the Manager.
+// setupPermissionRetryTimeout is the maximum time SetupWithManager will wait for
+// RBAC permissions to be projected into watched namespaces (e.g. by
+// ibm-namespace-scope-operator) before proceeding without the optional watches.
+const setupPermissionRetryTimeout = 5 * time.Minute
+
+// setupPermissionRetryInterval is how long SetupWithManager waits between
+// successive SSAR attempts when permissions are not yet available.
+const setupPermissionRetryInterval = 2 * time.Second
+
+// waitForAPIAccess retries hasAPIAccessInNamespaces until it returns true or
+// the deadline from ctx is reached. It returns (true, nil) on success and
+// (false, nil) on timeout; non-permission errors are returned immediately.
+func (r *AuthenticationReconciler) waitForAPIAccess(ctx context.Context, log interface{ Info(string, ...any) }, namespaces []string, group, resource string, verbs []string) (bool, error) {
+	for {
+		ok, err := r.hasAPIAccessInNamespaces(ctx, namespaces, group, resource, verbs)
+		if err != nil {
+			return false, err
+		}
+		if ok {
+			return true, nil
+		}
+		select {
+		case <-ctx.Done():
+			return false, nil
+		case <-time.After(setupPermissionRetryInterval):
+			log.Info("Permissions not yet available; retrying", "group", group, "resource", resource, "namespaces", namespaces)
+		}
+	}
+}
+
 func (r *AuthenticationReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	setupLog := ctrl.Log.WithName("setup")
-	ctx := context.Background()
 
 	// Get the watch namespace(s) for permission checks
 	watchNamespace, err := common.GetWatchNamespace()
@@ -447,6 +476,13 @@ func (r *AuthenticationReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 	setupLog.Info("Checking permissions in namespaces", "namespaces", namespacesToCheck)
 
+	// permCtx bounds the time we are willing to wait for RBAC to be projected.
+	// ibm-namespace-scope-operator copies RoleBindings into watched namespaces
+	// shortly after the operator pod starts; without a retry window the one-shot
+	// SSAR check races against that projection and permanently skips watches.
+	permCtx, permCancel := context.WithTimeout(context.Background(), setupPermissionRetryTimeout)
+	defer permCancel()
+
 	authCtrl := ctrl.NewControllerManagedBy(mgr).
 		Watches(&corev1.ConfigMap{}, handler.EnqueueRequestForOwner(mgr.GetScheme(), mgr.GetRESTMapper(), &operatorv1alpha1.Authentication{}, handler.OnlyControllerOwner())).
 		Watches(&corev1.Secret{}, handler.EnqueueRequestForOwner(mgr.GetScheme(), mgr.GetRESTMapper(), &operatorv1alpha1.Authentication{}, handler.OnlyControllerOwner())).
@@ -459,14 +495,14 @@ func (r *AuthenticationReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// Add Routes watch if API is present and operator has required permissions
 	if common.ClusterHasOpenShiftConfigGroupVerison(&r.DiscoveryClient) {
 		routeVerbs := []string{"get", "list", "watch", "create", "delete", "update", "patch"}
-		hasRouteAccess, err := r.hasAPIAccessInNamespaces(ctx, namespacesToCheck, "route.openshift.io", "routes", routeVerbs)
+		hasRouteAccess, err := r.waitForAPIAccess(permCtx, setupLog, namespacesToCheck, "route.openshift.io", "routes", routeVerbs)
 		if err != nil {
 			setupLog.Error(err, "Failed to check Route permissions for watch setup")
 		} else if !hasRouteAccess {
 			setupLog.Info("Route API present but missing required permissions; skipping Route watch")
 		} else {
 			// Also check routes/custom-host subresource permission
-			hasCustomHostAccess, err := r.hasAPIAccessInNamespaces(ctx, namespacesToCheck, "route.openshift.io", "routes/custom-host", []string{"create"})
+			hasCustomHostAccess, err := r.waitForAPIAccess(permCtx, setupLog, namespacesToCheck, "route.openshift.io", "routes/custom-host", []string{"create"})
 			if err != nil {
 				setupLog.Error(err, "Failed to check routes/custom-host permissions for watch setup")
 			} else if hasCustomHostAccess {
@@ -482,7 +518,7 @@ func (r *AuthenticationReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	if common.ClusterHasIngressGroupVersion(&r.DiscoveryClient) {
 		setupLog.Info("Ingress API detected in cluster; checking permissions")
 		ingressVerbs := []string{"delete", "get", "list", "watch"}
-		hasIngressAccess, err := r.hasAPIAccessInNamespaces(ctx, namespacesToCheck, "networking.k8s.io", "ingresses", ingressVerbs)
+		hasIngressAccess, err := r.waitForAPIAccess(permCtx, setupLog, namespacesToCheck, "networking.k8s.io", "ingresses", ingressVerbs)
 		if err != nil {
 			setupLog.Error(err, "Failed to check Ingress permissions for watch setup; skipping Ingress watch")
 			hasIngressAccess = false
@@ -501,7 +537,7 @@ func (r *AuthenticationReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// Add OperandRequest watch if API is present and operator has required permissions
 	if common.ClusterHasOperandRequestAPIResource(&r.DiscoveryClient) {
 		operandRequestVerbs := []string{"create", "get", "list", "patch", "watch", "update", "delete"}
-		hasOperandRequestAccess, err := r.hasAPIAccessInNamespaces(ctx, namespacesToCheck, "operator.ibm.com", "operandrequests", operandRequestVerbs)
+		hasOperandRequestAccess, err := r.waitForAPIAccess(permCtx, setupLog, namespacesToCheck, "operator.ibm.com", "operandrequests", operandRequestVerbs)
 		if err != nil {
 			setupLog.Error(err, "Failed to check OperandRequest permissions for watch setup")
 		} else if hasOperandRequestAccess {
@@ -515,7 +551,7 @@ func (r *AuthenticationReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// Add OperandBindInfo watch if API is present and operator has required permissions
 	if common.ClusterHasOperandBindInfoAPIResource(&r.DiscoveryClient) {
 		operandBindInfoVerbs := []string{"create", "get", "list", "patch", "watch", "update", "delete"}
-		hasOperandBindInfoAccess, err := r.hasAPIAccessInNamespaces(ctx, namespacesToCheck, "operator.ibm.com", "operandbindinfos", operandBindInfoVerbs)
+		hasOperandBindInfoAccess, err := r.waitForAPIAccess(permCtx, setupLog, namespacesToCheck, "operator.ibm.com", "operandbindinfos", operandBindInfoVerbs)
 		if err != nil {
 			setupLog.Error(err, "Failed to check OperandBindInfo permissions for watch setup")
 		} else if hasOperandBindInfoAccess {
@@ -529,7 +565,7 @@ func (r *AuthenticationReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// Add SecretProviderClass watches if API is present and operator has required permissions
 	if common.ClusterHasCSIGroupVersion(&r.DiscoveryClient) {
 		spcVerbs := []string{"get", "list", "watch"}
-		hasSPCAccess, err := r.hasAPIAccessInNamespaces(ctx, namespacesToCheck, "secrets-store.csi.x-k8s.io", "secretproviderclasses", spcVerbs)
+		hasSPCAccess, err := r.waitForAPIAccess(permCtx, setupLog, namespacesToCheck, "secrets-store.csi.x-k8s.io", "secretproviderclasses", spcVerbs)
 		if err != nil {
 			setupLog.Error(err, "Failed to check SecretProviderClass permissions for watch setup")
 		} else if hasSPCAccess {

--- a/internal/controller/operator/deployment.go
+++ b/internal/controller/operator/deployment.go
@@ -844,7 +844,7 @@ func preserveObservedFields(observed, generated *appsv1.Deployment) {
 			if observedContainer.ReadinessProbe != nil {
 				generated.Spec.Template.Spec.Containers[i].ReadinessProbe.SuccessThreshold = observedContainer.ReadinessProbe.SuccessThreshold
 			}
-			
+
 			generated.Spec.Template.Spec.Containers[i].TerminationMessagePath = observedContainer.TerminationMessagePath
 			generated.Spec.Template.Spec.Containers[i].TerminationMessagePolicy = observedContainer.TerminationMessagePolicy
 		}

--- a/internal/controller/operator/job.go
+++ b/internal/controller/operator/job.go
@@ -981,14 +981,14 @@ func buildMigratorVolumes(needsMongoDBMigration bool, edbSPCName string, zenInst
 		})
 	} else {
 		volumes = append(volumes, corev1.Volume{
-				Name: "pgsql-certs",
-				VolumeSource: corev1.VolumeSource{
-					Secret: &corev1.SecretVolumeSource{
-						SecretName:  common.DatastoreEDBSecretName,
-						DefaultMode: ptr.To(int32(420)),
-					},
+			Name: "pgsql-certs",
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName:  common.DatastoreEDBSecretName,
+					DefaultMode: ptr.To(int32(420)),
 				},
-			})
+			},
+		})
 	}
 
 	if !needsMongoDBMigration {


### PR DESCRIPTION
When ibm-iam-operator is deployed in a namespace-scoped configuration (e.g. operator in cs-operators, Authentication CR in cs-data), ibm-namespace-scope- operator projects RBAC into the watched namespaces *after* the operator pod starts. PR #1275 introduced one-shot SSAR-gated scheme registration in init() and one-shot watch setup in SetupWithManager(), both of which race against that RBAC projection, causing two distinct failures:

1. 'no kind is registered for the type v1alpha1.OperandRequest in scheme' init() ran before RBAC was projected -> SSAR denied -> base scheme used (Authentication only, no OperandRequest/OperandBindInfo) -> scheme frozen for process lifetime -> every reconcile loop panics on OperandRequest Get.

2. 'Failed to watch' errors for HPA, Certificate, Service, etc. Cache informers try to list those types in cs-data before RBAC is ready.

Fixes:

cmd/main.go:
  Remove SSAR-gated branching from init(). All operator.ibm.com, Route,
  and Ingress types are now registered unconditionally. Scheme registration
  has no security implication; it only maps Go types to GVKs. Access control
  belongs in the watch setup, not the scheme. SecretProviderClass remains
  discovery-gated (requires CRD presence, not an RBAC race).

internal/controller/operator/authentication_controller.go:
  Add waitForAPIAccess() which retries hasAPIAccessInNamespaces every 2s
  for up to 2 minutes. All optional watches (Route, Ingress, OperandRequest,
  OperandBindInfo, SecretProviderClass) use this instead of the one-shot
  hasAPIAccessInNamespaces call. If ibm-namespace-scope-operator projects
  the RBAC within the 2-minute window, all watches are registered correctly
  without requiring a pod restart.