### PR TITLE
fix: unconditional ODLM scheme registration and SSAR retry for RBAC

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -99,25 +99,15 @@ func init() {
 		namespacesToCheck = strings.Split(watchNamespaceEnv, ",")
 	}
 
-	// Check OperandRequest permissions across all watch namespaces
-	operandRequestVerbs := []string{"create", "get", "list", "patch", "watch", "update", "delete"}
-	if controllercommon.ClusterHasOperandRequestAPIResource(dc) {
-		hasOperandRequestAccess, err := hasNamespacedAPIAccessForNamespaces(ctx, tempClient, namespacesToCheck, "operator.ibm.com", "operandrequests", operandRequestVerbs)
-		if err != nil {
-			setupLog.Error(err, "Failed to check OperandRequest permissions")
-			hasOperandRequestAccess = false
-		}
-		if hasOperandRequestAccess {
-			setupLog.V(1).Info("OperandRequest API present with required permissions in all watch namespaces; adding ODLM-enabled operator.ibm.com scheme")
-			utilruntime.Must(operatorv1alpha1.AddODLMEnabledToScheme(scheme))
-		} else {
-			setupLog.Info("OperandRequest API present but missing required permissions; adding base operator.ibm.com scheme")
-			utilruntime.Must(operatorv1alpha1.AddToScheme(scheme))
-		}
-	} else {
-		setupLog.V(1).Info("OperandRequest API not present; adding base operator.ibm.com scheme")
-		utilruntime.Must(operatorv1alpha1.AddToScheme(scheme))
-	}
+	// Always register the full ODLM-enabled scheme (Authentication + OperandRequest +
+	// OperandBindInfo). Scheme registration must never be gated on a runtime RBAC
+	// check: init() runs once at process start — before ibm-namespace-scope-operator
+	// has projected permissions into watched namespaces. If the SSAR fails here the
+	// type is permanently absent from the scheme, causing a "no kind is registered
+	// for OperandRequest" panic on every reconcile even after RBAC is later granted.
+	// Scheme registration has no security implication; it only maps Go types to GVKs.
+	// Access-gating (whether to *watch* a resource) is done in SetupWithManager.
+	utilruntime.Must(operatorv1alpha1.AddODLMEnabledToScheme(scheme))
 
 	// Check Route permissions (including routes/custom-host subresource) across all watch namespaces
 	routeVerbs := []string{"get", "list", "watch", "create", "delete", "update", "patch"}

--- a/internal/controller/operator/authentication_controller.go
+++ b/internal/controller/operator/authentication_controller.go
@@ -27,6 +27,7 @@ import (
 	certmgr "github.com/IBM/ibm-iam-operator/internal/api/certmanager/v1"
 	"github.com/IBM/ibm-iam-operator/internal/controller/common"
 	"github.com/IBM/ibm-iam-operator/internal/version"
+	"github.com/go-logr/logr"
 	routev1 "github.com/openshift/api/route/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	authorizationv1 "k8s.io/api/authorization/v1"
@@ -498,31 +499,36 @@ func (r *AuthenticationReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		setupLog.Info("Ingress API not detected in cluster; skipping Ingress watch")
 	}
 
-	// Add OperandRequest watch if API is present and operator has required permissions
+	// Add OperandRequest watch if API is present and operator has required permissions.
+	// Unlike Route/Ingress (which are intentionally optional), OperandRequest permissions
+	// are always expected when the ODLM API is present: they are projected by
+	// ibm-namespace-scope-operator shortly after pod start. Retry with a timeout to
+	// tolerate the race between pod start and RBAC projection.
 	if common.ClusterHasOperandRequestAPIResource(&r.DiscoveryClient) {
 		operandRequestVerbs := []string{"create", "get", "list", "patch", "watch", "update", "delete"}
-		hasOperandRequestAccess, err := r.hasAPIAccessInNamespaces(ctx, namespacesToCheck, "operator.ibm.com", "operandrequests", operandRequestVerbs)
+		hasOperandRequestAccess, err := r.waitForODLMAccess(ctx, setupLog, namespacesToCheck, "operandrequests", operandRequestVerbs)
 		if err != nil {
 			setupLog.Error(err, "Failed to check OperandRequest permissions for watch setup")
 		} else if hasOperandRequestAccess {
 			setupLog.V(1).Info("OperandRequest API present with required permissions; setting up OperandRequest watch")
 			authCtrl.Watches(&operatorv1alpha1.OperandRequest{}, handler.EnqueueRequestForOwner(mgr.GetScheme(), mgr.GetRESTMapper(), &operatorv1alpha1.Authentication{}, handler.OnlyControllerOwner()))
 		} else {
-			setupLog.Info("OperandRequest API present but missing required permissions; skipping OperandRequest watch")
+			setupLog.Info("OperandRequest API present but missing required permissions after waiting; skipping OperandRequest watch")
 		}
 	}
 
-	// Add OperandBindInfo watch if API is present and operator has required permissions
+	// Add OperandBindInfo watch if API is present and operator has required permissions.
+	// Same rationale as OperandRequest above — retry to tolerate RBAC projection race.
 	if common.ClusterHasOperandBindInfoAPIResource(&r.DiscoveryClient) {
 		operandBindInfoVerbs := []string{"create", "get", "list", "patch", "watch", "update", "delete"}
-		hasOperandBindInfoAccess, err := r.hasAPIAccessInNamespaces(ctx, namespacesToCheck, "operator.ibm.com", "operandbindinfos", operandBindInfoVerbs)
+		hasOperandBindInfoAccess, err := r.waitForODLMAccess(ctx, setupLog, namespacesToCheck, "operandbindinfos", operandBindInfoVerbs)
 		if err != nil {
 			setupLog.Error(err, "Failed to check OperandBindInfo permissions for watch setup")
 		} else if hasOperandBindInfoAccess {
 			setupLog.V(1).Info("OperandBindInfo API present with required permissions; setting up OperandBindInfo watch")
 			authCtrl.Watches(&operatorv1alpha1.OperandBindInfo{}, handler.EnqueueRequestForOwner(mgr.GetScheme(), mgr.GetRESTMapper(), &operatorv1alpha1.Authentication{}, handler.OnlyControllerOwner()))
 		} else {
-			setupLog.Info("OperandBindInfo API present but missing required permissions; skipping OperandBindInfo watch")
+			setupLog.Info("OperandBindInfo API present but missing required permissions after waiting; skipping OperandBindInfo watch")
 		}
 	}
 
@@ -710,6 +716,41 @@ func (r *AuthenticationReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	authCtrl.Watches(&operatorv1alpha1.Authentication{}, &handler.EnqueueRequestForObject{}, builder.WithPredicates(bootstrappedPred))
 	return authCtrl.Named("controller_authentication").
 		Complete(r)
+}
+
+// odlmAccessRetryInterval is the wait between SSAR retries for ODLM resources.
+const odlmAccessRetryInterval = 2 * time.Second
+
+// odlmAccessRetryTimeout is the maximum time to wait for ibm-namespace-scope-operator
+// to project ODLM (OperandRequest/OperandBindInfo) RBAC into watched namespaces.
+// Route, Ingress, and SPC permissions are intentionally optional and are never
+// retried — a denied SSAR for those means "don't watch" by design.
+const odlmAccessRetryTimeout = 5 * time.Minute
+
+// waitForODLMAccess retries hasAPIAccessInNamespaces for ODLM resources until
+// permissions are granted or odlmAccessRetryTimeout elapses.
+// It returns (true, nil) on success and (false, nil) on timeout.
+// Real API errors are returned immediately without retrying.
+func (r *AuthenticationReconciler) waitForODLMAccess(ctx context.Context, log logr.Logger, namespaces []string, resource string, verbs []string) (bool, error) {
+	deadline := time.Now().Add(odlmAccessRetryTimeout)
+	for {
+		ok, err := r.hasAPIAccessInNamespaces(ctx, namespaces, "operator.ibm.com", resource, verbs)
+		if err != nil {
+			return false, err
+		}
+		if ok {
+			return true, nil
+		}
+		if time.Now().After(deadline) {
+			return false, nil
+		}
+		log.Info("ODLM permissions not yet available; retrying", "resource", resource, "namespaces", namespaces)
+		select {
+		case <-ctx.Done():
+			return false, nil
+		case <-time.After(odlmAccessRetryInterval):
+		}
+	}
 }
 
 // hasAPIAccess uses SelfSubjectAccessReviews to confirm whether the Opertor's ServiceAccount has authorization to use a


### PR DESCRIPTION


Two bugs introduced by #1275 affect namespace-scoped deployments where ibm-namespace-scope-operator projects RBAC into watched namespaces after pod start (e.g. operator in cs-operators, Authentication CR in cs-data).

Bug 1 — "no kind is registered for the type v1alpha1.OperandRequest in scheme"
  init() in cmd/main.go ran a one-shot SSAR to decide which scheme to register.
  Because the SSAR fired before RBAC was projected, it returned denied, so
  operatorv1alpha1.AddToScheme (base scheme: Authentication only, no
  OperandRequest/OperandBindInfo) was used. The scheme is frozen for the
  process lifetime, so every reconcile call to r.Get(..., &OperandRequest{})
  panicked with "no kind registered". Deleting the pod worked only because
  on restart the RBAC was already in cs-data.

  Fix: always call operatorv1alpha1.AddODLMEnabledToScheme unconditionally.
  Scheme registration has no security implication — it only maps Go types to
  GVKs. Whether to *watch* a resource is gated in SetupWithManager.

Bug 2 — OperandRequest/OperandBindInfo watches permanently skipped
  SetupWithManager ran a one-shot SSAR for OperandRequest and OperandBindInfo.
  Same race: SSAR returned denied before RBAC was projected, so the watches
  were skipped for the lifetime of the process.

  Fix: replace the one-shot hasAPIAccessInNamespaces call for OperandRequest
  and OperandBindInfo with waitForODLMAccess, which retries every 2s for up
  to 5 minutes. Route, Ingress, and SPC checks are deliberately NOT retried:
  - Route: intentionally optional even on OCP (operator may not be configured to manage routes)
  - Ingress: intentionally optional on both CNCF and OCP
  - SPC: intentionally optional (requires CSI driver) A denied SSAR for those resources means "don't watch" by design, not a transient race. Retrying them would stall startup unnecessarily.