### PR TITLE
Fix/odlm scheme rbac race

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -99,25 +99,15 @@ func init() {
 		namespacesToCheck = strings.Split(watchNamespaceEnv, ",")
 	}
 
-	// Check OperandRequest permissions across all watch namespaces
-	operandRequestVerbs := []string{"create", "get", "list", "patch", "watch", "update", "delete"}
-	if controllercommon.ClusterHasOperandRequestAPIResource(dc) {
-		hasOperandRequestAccess, err := hasNamespacedAPIAccessForNamespaces(ctx, tempClient, namespacesToCheck, "operator.ibm.com", "operandrequests", operandRequestVerbs)
-		if err != nil {
-			setupLog.Error(err, "Failed to check OperandRequest permissions")
-			hasOperandRequestAccess = false
-		}
-		if hasOperandRequestAccess {
-			setupLog.V(1).Info("OperandRequest API present with required permissions in all watch namespaces; adding ODLM-enabled operator.ibm.com scheme")
-			utilruntime.Must(operatorv1alpha1.AddODLMEnabledToScheme(scheme))
-		} else {
-			setupLog.Info("OperandRequest API present but missing required permissions; adding base operator.ibm.com scheme")
-			utilruntime.Must(operatorv1alpha1.AddToScheme(scheme))
-		}
-	} else {
-		setupLog.V(1).Info("OperandRequest API not present; adding base operator.ibm.com scheme")
-		utilruntime.Must(operatorv1alpha1.AddToScheme(scheme))
-	}
+	// Always register the full ODLM-enabled scheme (Authentication + OperandRequest +
+	// OperandBindInfo). Scheme registration must never be gated on a runtime RBAC
+	// check: init() runs once at process start — before ibm-namespace-scope-operator
+	// has projected permissions into watched namespaces. If the SSAR fails here the
+	// type is permanently absent from the scheme, causing a "no kind is registered
+	// for OperandRequest" panic on every reconcile even after RBAC is later granted.
+	// Scheme registration has no security implication; it only maps Go types to GVKs.
+	// Access-gating (whether to *watch* a resource) is done in SetupWithManager.
+	utilruntime.Must(operatorv1alpha1.AddODLMEnabledToScheme(scheme))
 
 	// Check Route permissions (including routes/custom-host subresource) across all watch namespaces
 	routeVerbs := []string{"get", "list", "watch", "create", "delete", "update", "patch"}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -109,52 +109,19 @@ func init() {
 	// Access-gating (whether to *watch* a resource) is done in SetupWithManager.
 	utilruntime.Must(operatorv1alpha1.AddODLMEnabledToScheme(scheme))
 
-	// Check Route permissions (including routes/custom-host subresource) across all watch namespaces
-	routeVerbs := []string{"get", "list", "watch", "create", "delete", "update", "patch"}
+	// Route: register whenever the Route API is present on the cluster, regardless of
+	// whether the operator has Route permissions. The reconciler unconditionally builds
+	// SecondaryReconcilerBuilder[*routev1.Route] at runtime (routes.go), so the type
+	// must always be in the scheme on OCP clusters. Whether the operator actually
+	// *watches* or manages routes is gated by RBAC checks in SetupWithManager.
 	if controllercommon.ClusterHasRouteGroupVersion(dc) {
-		hasRouteAccess, err := hasNamespacedAPIAccessForNamespaces(ctx, tempClient, namespacesToCheck, "route.openshift.io", "routes", routeVerbs)
-		if err != nil {
-			setupLog.Error(err, "Failed to check Route permissions")
-			hasRouteAccess = false
-		}
-
-		if hasRouteAccess {
-			// Also check routes/custom-host subresource permission across all namespaces
-			hasCustomHostAccess, err := hasNamespacedAPIAccessForNamespaces(ctx, tempClient, namespacesToCheck, "route.openshift.io", "routes/custom-host", []string{"create"})
-			if err != nil {
-				setupLog.Error(err, "Failed to check routes/custom-host permissions")
-				hasCustomHostAccess = false
-			}
-			if !hasCustomHostAccess {
-				setupLog.Info("Route API present but missing routes/custom-host create permission in one or more namespaces")
-			}
-
-			if hasCustomHostAccess {
-				setupLog.V(1).Info("Route API present with all required permissions including routes/custom-host in all watch namespaces; adding Routes to scheme")
-				utilruntime.Must(routev1.AddToScheme(scheme))
-			} else {
-				setupLog.Info("Route API present but missing routes/custom-host create permission; skipping Routes scheme")
-			}
-		} else {
-			setupLog.Info("Route API present but missing required permissions; skipping Routes scheme")
-		}
+		utilruntime.Must(routev1.AddToScheme(scheme))
 	}
 
-	// Check Ingress permissions across all watch namespaces
-	ingressVerbs := []string{"delete", "get", "list", "watch"}
+	// Ingress: same rationale — register whenever the API is present; watch gating
+	// is handled in SetupWithManager.
 	if controllercommon.ClusterHasIngressGroupVersion(dc) {
-		hasIngressAccess, err := hasNamespacedAPIAccessForNamespaces(ctx, tempClient, namespacesToCheck, "networking.k8s.io", "ingresses", ingressVerbs)
-		if err != nil {
-			setupLog.Error(err, "Failed to check Ingress permissions")
-			hasIngressAccess = false
-		}
-
-		if hasIngressAccess {
-			setupLog.V(1).Info("Ingress API present with required permissions in all watch namespaces; adding Ingress to scheme")
-			utilruntime.Must(networkingv1.AddToScheme(scheme))
-		} else {
-			setupLog.Info("Ingress API present but missing required permissions; skipping Ingress scheme")
-		}
+		utilruntime.Must(networkingv1.AddToScheme(scheme))
 	}
 
 	// Check SecretProviderClass permissions across all watch namespaces

--- a/internal/controller/operator/authentication_controller.go
+++ b/internal/controller/operator/authentication_controller.go
@@ -457,7 +457,40 @@ func (r *AuthenticationReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(&appsv1.Deployment{}, handler.EnqueueRequestForOwner(mgr.GetScheme(), mgr.GetRESTMapper(), &operatorv1alpha1.Authentication{}, handler.OnlyControllerOwner())).
 		Watches(&autoscalingv2.HorizontalPodAutoscaler{}, handler.EnqueueRequestForOwner(mgr.GetScheme(), mgr.GetRESTMapper(), &operatorv1alpha1.Authentication{}, handler.OnlyControllerOwner()))
 
-	// Add Routes watch if API is present and operator has required permissions
+	// Add OperandRequest watch first: permissions are always expected when the ODLM API
+	// is present (projected by ibm-namespace-scope-operator). Retry with a timeout to
+	// tolerate the race between pod start and RBAC projection.
+	// This is checked first so the manager blocks here until ODLM RBAC is ready before
+	// proceeding to the intentionally-optional Route/Ingress checks.
+	if common.ClusterHasOperandRequestAPIResource(&r.DiscoveryClient) {
+		operandRequestVerbs := []string{"create", "get", "list", "patch", "watch", "update", "delete"}
+		hasOperandRequestAccess, err := r.waitForODLMAccess(ctx, setupLog, namespacesToCheck, "operandrequests", operandRequestVerbs)
+		if err != nil {
+			setupLog.Error(err, "Failed to check OperandRequest permissions for watch setup")
+		} else if hasOperandRequestAccess {
+			setupLog.V(1).Info("OperandRequest API present with required permissions; setting up OperandRequest watch")
+			authCtrl.Watches(&operatorv1alpha1.OperandRequest{}, handler.EnqueueRequestForOwner(mgr.GetScheme(), mgr.GetRESTMapper(), &operatorv1alpha1.Authentication{}, handler.OnlyControllerOwner()))
+		} else {
+			setupLog.Info("OperandRequest API present but missing required permissions after waiting; skipping OperandRequest watch")
+		}
+	}
+
+	// Add OperandBindInfo watch — same rationale as OperandRequest above.
+	if common.ClusterHasOperandBindInfoAPIResource(&r.DiscoveryClient) {
+		operandBindInfoVerbs := []string{"create", "get", "list", "patch", "watch", "update", "delete"}
+		hasOperandBindInfoAccess, err := r.waitForODLMAccess(ctx, setupLog, namespacesToCheck, "operandbindinfos", operandBindInfoVerbs)
+		if err != nil {
+			setupLog.Error(err, "Failed to check OperandBindInfo permissions for watch setup")
+		} else if hasOperandBindInfoAccess {
+			setupLog.V(1).Info("OperandBindInfo API present with required permissions; setting up OperandBindInfo watch")
+			authCtrl.Watches(&operatorv1alpha1.OperandBindInfo{}, handler.EnqueueRequestForOwner(mgr.GetScheme(), mgr.GetRESTMapper(), &operatorv1alpha1.Authentication{}, handler.OnlyControllerOwner()))
+		} else {
+			setupLog.Info("OperandBindInfo API present but missing required permissions after waiting; skipping OperandBindInfo watch")
+		}
+	}
+
+	// Add Routes watch if API is present and operator has required permissions.
+	// Route permissions are intentionally optional — no retry.
 	if common.ClusterHasOpenShiftConfigGroupVerison(&r.DiscoveryClient) {
 		routeVerbs := []string{"get", "list", "watch", "create", "delete", "update", "patch"}
 		hasRouteAccess, err := r.hasAPIAccessInNamespaces(ctx, namespacesToCheck, "route.openshift.io", "routes", routeVerbs)
@@ -479,7 +512,8 @@ func (r *AuthenticationReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		}
 	}
 
-	// Add Ingress watch if API is present and operator has required permissions
+	// Add Ingress watch if API is present and operator has required permissions.
+	// Ingress permissions are intentionally optional — no retry.
 	if common.ClusterHasIngressGroupVersion(&r.DiscoveryClient) {
 		setupLog.Info("Ingress API detected in cluster; checking permissions")
 		ingressVerbs := []string{"delete", "get", "list", "watch"}
@@ -497,39 +531,6 @@ func (r *AuthenticationReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		}
 	} else {
 		setupLog.Info("Ingress API not detected in cluster; skipping Ingress watch")
-	}
-
-	// Add OperandRequest watch if API is present and operator has required permissions.
-	// Unlike Route/Ingress (which are intentionally optional), OperandRequest permissions
-	// are always expected when the ODLM API is present: they are projected by
-	// ibm-namespace-scope-operator shortly after pod start. Retry with a timeout to
-	// tolerate the race between pod start and RBAC projection.
-	if common.ClusterHasOperandRequestAPIResource(&r.DiscoveryClient) {
-		operandRequestVerbs := []string{"create", "get", "list", "patch", "watch", "update", "delete"}
-		hasOperandRequestAccess, err := r.waitForODLMAccess(ctx, setupLog, namespacesToCheck, "operandrequests", operandRequestVerbs)
-		if err != nil {
-			setupLog.Error(err, "Failed to check OperandRequest permissions for watch setup")
-		} else if hasOperandRequestAccess {
-			setupLog.V(1).Info("OperandRequest API present with required permissions; setting up OperandRequest watch")
-			authCtrl.Watches(&operatorv1alpha1.OperandRequest{}, handler.EnqueueRequestForOwner(mgr.GetScheme(), mgr.GetRESTMapper(), &operatorv1alpha1.Authentication{}, handler.OnlyControllerOwner()))
-		} else {
-			setupLog.Info("OperandRequest API present but missing required permissions after waiting; skipping OperandRequest watch")
-		}
-	}
-
-	// Add OperandBindInfo watch if API is present and operator has required permissions.
-	// Same rationale as OperandRequest above — retry to tolerate RBAC projection race.
-	if common.ClusterHasOperandBindInfoAPIResource(&r.DiscoveryClient) {
-		operandBindInfoVerbs := []string{"create", "get", "list", "patch", "watch", "update", "delete"}
-		hasOperandBindInfoAccess, err := r.waitForODLMAccess(ctx, setupLog, namespacesToCheck, "operandbindinfos", operandBindInfoVerbs)
-		if err != nil {
-			setupLog.Error(err, "Failed to check OperandBindInfo permissions for watch setup")
-		} else if hasOperandBindInfoAccess {
-			setupLog.V(1).Info("OperandBindInfo API present with required permissions; setting up OperandBindInfo watch")
-			authCtrl.Watches(&operatorv1alpha1.OperandBindInfo{}, handler.EnqueueRequestForOwner(mgr.GetScheme(), mgr.GetRESTMapper(), &operatorv1alpha1.Authentication{}, handler.OnlyControllerOwner()))
-		} else {
-			setupLog.Info("OperandBindInfo API present but missing required permissions after waiting; skipping OperandBindInfo watch")
-		}
 	}
 
 	// Add SecretProviderClass watches if API is present and operator has required permissions

--- a/internal/controller/operator/authentication_controller.go
+++ b/internal/controller/operator/authentication_controller.go
@@ -27,6 +27,7 @@ import (
 	certmgr "github.com/IBM/ibm-iam-operator/internal/api/certmanager/v1"
 	"github.com/IBM/ibm-iam-operator/internal/controller/common"
 	"github.com/IBM/ibm-iam-operator/internal/version"
+	"github.com/go-logr/logr"
 	routev1 "github.com/openshift/api/route/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	authorizationv1 "k8s.io/api/authorization/v1"
@@ -498,31 +499,36 @@ func (r *AuthenticationReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		setupLog.Info("Ingress API not detected in cluster; skipping Ingress watch")
 	}
 
-	// Add OperandRequest watch if API is present and operator has required permissions
+	// Add OperandRequest watch if API is present and operator has required permissions.
+	// Unlike Route/Ingress (which are intentionally optional), OperandRequest permissions
+	// are always expected when the ODLM API is present: they are projected by
+	// ibm-namespace-scope-operator shortly after pod start. Retry with a timeout to
+	// tolerate the race between pod start and RBAC projection.
 	if common.ClusterHasOperandRequestAPIResource(&r.DiscoveryClient) {
 		operandRequestVerbs := []string{"create", "get", "list", "patch", "watch", "update", "delete"}
-		hasOperandRequestAccess, err := r.hasAPIAccessInNamespaces(ctx, namespacesToCheck, "operator.ibm.com", "operandrequests", operandRequestVerbs)
+		hasOperandRequestAccess, err := r.waitForODLMAccess(ctx, setupLog, namespacesToCheck, "operandrequests", operandRequestVerbs)
 		if err != nil {
 			setupLog.Error(err, "Failed to check OperandRequest permissions for watch setup")
 		} else if hasOperandRequestAccess {
 			setupLog.V(1).Info("OperandRequest API present with required permissions; setting up OperandRequest watch")
 			authCtrl.Watches(&operatorv1alpha1.OperandRequest{}, handler.EnqueueRequestForOwner(mgr.GetScheme(), mgr.GetRESTMapper(), &operatorv1alpha1.Authentication{}, handler.OnlyControllerOwner()))
 		} else {
-			setupLog.Info("OperandRequest API present but missing required permissions; skipping OperandRequest watch")
+			setupLog.Info("OperandRequest API present but missing required permissions after waiting; skipping OperandRequest watch")
 		}
 	}
 
-	// Add OperandBindInfo watch if API is present and operator has required permissions
+	// Add OperandBindInfo watch if API is present and operator has required permissions.
+	// Same rationale as OperandRequest above — retry to tolerate RBAC projection race.
 	if common.ClusterHasOperandBindInfoAPIResource(&r.DiscoveryClient) {
 		operandBindInfoVerbs := []string{"create", "get", "list", "patch", "watch", "update", "delete"}
-		hasOperandBindInfoAccess, err := r.hasAPIAccessInNamespaces(ctx, namespacesToCheck, "operator.ibm.com", "operandbindinfos", operandBindInfoVerbs)
+		hasOperandBindInfoAccess, err := r.waitForODLMAccess(ctx, setupLog, namespacesToCheck, "operandbindinfos", operandBindInfoVerbs)
 		if err != nil {
 			setupLog.Error(err, "Failed to check OperandBindInfo permissions for watch setup")
 		} else if hasOperandBindInfoAccess {
 			setupLog.V(1).Info("OperandBindInfo API present with required permissions; setting up OperandBindInfo watch")
 			authCtrl.Watches(&operatorv1alpha1.OperandBindInfo{}, handler.EnqueueRequestForOwner(mgr.GetScheme(), mgr.GetRESTMapper(), &operatorv1alpha1.Authentication{}, handler.OnlyControllerOwner()))
 		} else {
-			setupLog.Info("OperandBindInfo API present but missing required permissions; skipping OperandBindInfo watch")
+			setupLog.Info("OperandBindInfo API present but missing required permissions after waiting; skipping OperandBindInfo watch")
 		}
 	}
 
@@ -710,6 +716,41 @@ func (r *AuthenticationReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	authCtrl.Watches(&operatorv1alpha1.Authentication{}, &handler.EnqueueRequestForObject{}, builder.WithPredicates(bootstrappedPred))
 	return authCtrl.Named("controller_authentication").
 		Complete(r)
+}
+
+// odlmAccessRetryInterval is the wait between SSAR retries for ODLM resources.
+const odlmAccessRetryInterval = 2 * time.Second
+
+// odlmAccessRetryTimeout is the maximum time to wait for ibm-namespace-scope-operator
+// to project ODLM (OperandRequest/OperandBindInfo) RBAC into watched namespaces.
+// Route, Ingress, and SPC permissions are intentionally optional and are never
+// retried — a denied SSAR for those means "don't watch" by design.
+const odlmAccessRetryTimeout = 5 * time.Minute
+
+// waitForODLMAccess retries hasAPIAccessInNamespaces for ODLM resources until
+// permissions are granted or odlmAccessRetryTimeout elapses.
+// It returns (true, nil) on success and (false, nil) on timeout.
+// Real API errors are returned immediately without retrying.
+func (r *AuthenticationReconciler) waitForODLMAccess(ctx context.Context, log logr.Logger, namespaces []string, resource string, verbs []string) (bool, error) {
+	deadline := time.Now().Add(odlmAccessRetryTimeout)
+	for {
+		ok, err := r.hasAPIAccessInNamespaces(ctx, namespaces, "operator.ibm.com", resource, verbs)
+		if err != nil {
+			return false, err
+		}
+		if ok {
+			return true, nil
+		}
+		if time.Now().After(deadline) {
+			return false, nil
+		}
+		log.Info("ODLM permissions not yet available; retrying", "resource", resource, "namespaces", namespaces)
+		select {
+		case <-ctx.Done():
+			return false, nil
+		case <-time.After(odlmAccessRetryInterval):
+		}
+	}
 }
 
 // hasAPIAccess uses SelfSubjectAccessReviews to confirm whether the Opertor's ServiceAccount has authorization to use a

--- a/internal/controller/operator/authentication_controller.go
+++ b/internal/controller/operator/authentication_controller.go
@@ -491,7 +491,7 @@ func (r *AuthenticationReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	// Add Routes watch if API is present and operator has required permissions.
 	// Route permissions are intentionally optional — no retry.
-	if common.ClusterHasOpenShiftConfigGroupVerison(&r.DiscoveryClient) {
+	if common.ClusterHasRouteGroupVersion(&r.DiscoveryClient) {
 		routeVerbs := []string{"get", "list", "watch", "create", "delete", "update", "patch"}
 		hasRouteAccess, err := r.hasAPIAccessInNamespaces(ctx, namespacesToCheck, "route.openshift.io", "routes", routeVerbs)
 		if err != nil {


### PR DESCRIPTION
Here's a summary of everything in this commit:

Root cause of the `v1.Route` panic on power/z
`routes.go:231-245` calls `MustBuild()` on `SecondaryReconcilerBuilder[*routev1.Route]` unconditionally on every reconcile — regardless of whether the operator has Route permissions. But `init()` was only calling `routev1.AddToScheme` when the SSAR returned allowed. On power/z where Route permissions are absent, the type was never registered → `MustBuild` panics. x86 happened to get the permissions in time, so it worked there.

Changes
`cmd/main.go` the entire Route and Ingress SSAR blocks in init() are replaced with simple discovery-gated registration:

```
if controllercommon.ClusterHasRouteGroupVersion(dc) {
    utilruntime.Must(routev1.AddToScheme(scheme))   // always, when API exists
}
if controllercommon.ClusterHasIngressGroupVersion(dc) {
    utilruntime.Must(networkingv1.AddToScheme(scheme)) // always, when API exists
}
```

`authentication_controller.go` — OperandRequest and OperandBindInfo checks (with retry) now run first in `SetupWithManager`, before the Route/Ingress single-shot checks. The manager waits up to 5 minutes for ODLM RBAC to be projected, then immediately proceeds to Route/Ingress (no retry there by design).